### PR TITLE
Use addSd and propSd for residual error parameter names

### DIFF
--- a/R/addResErr.R
+++ b/R/addResErr.R
@@ -1,11 +1,11 @@
 #' Add residual error to a model
 #'
 #' @param model The model as a function
-#' @param reserr character with the type of residual error (currently "add",
-#'   "prop" and "add+prop" are accepted)
+#' @param reserr character with the type of residual error (currently "addSd",
+#'   "propSd" and "addSd+propSd" are accepted)
 #' @return The model with residual error modified
 #' @examples
-#' readModelDb("PK_1cmt") %>% addResErr("add")
+#' readModelDb("PK_1cmt") %>% addResErr("addSd")
 #' @export
 addResErr <- function(model, reserr) {
   modelUi <- rxode2::rxode(model)
@@ -16,18 +16,18 @@ addResErr <- function(model, reserr) {
   checkmate::expect_character(paramErr, len = 1, min.chars = 1)
 
   if (is.character(reserr)) {
-    if (reserr == "add") {
-      newErrLine <- sprintf("%s ~ add(add.err)", paramErr)
+    if (reserr == "addSd") {
+      newErrLine <- sprintf("%s ~ add(addSd)", paramErr)
       modelUi <- do.call(rxode2::model, list(modelUi, str2lang(newErrLine)))
-      modelUi <- rxode2::ini(modelUi, add.err=1)
-    } else if (reserr == "prop") {
-      newErrLine <- sprintf("%s ~ prop(prop.err)", paramErr)
+      modelUi <- rxode2::ini(modelUi, addSd=1)
+    } else if (reserr == "propSd") {
+      newErrLine <- sprintf("%s ~ prop(propSd)", paramErr)
       modelUi <- do.call(rxode2::model, list(modelUi, str2lang(newErrLine)))
-      modelUi <- rxode2::ini(modelUi, prop.err=0.5)
-    } else if (reserr == "add+prop") {
-      newErrLine <- sprintf("%s ~ add(add.err) + prop(prop.err)", paramErr)
+      modelUi <- rxode2::ini(modelUi, propSd=0.5)
+    } else if (reserr == "addSd+propSd") {
+      newErrLine <- sprintf("%s ~ add(addSd) + prop(propSd)", paramErr)
       modelUi <- do.call(rxode2::model, list(modelUi, str2lang(newErrLine)))
-      modelUi <- rxode2::ini(modelUi, add.err=1, prop.err=0.5)
+      modelUi <- rxode2::ini(modelUi, addSd=1, propSd=0.5)
     } else {
       cli::cli_abort("unknown residual error")
     }

--- a/R/modellib.r
+++ b/R/modellib.r
@@ -17,8 +17,8 @@
 #'
 #' \dontrun{
 #'   modellib(name="PK_1cmt")
-#'   modellib(name="PK_1cmt", eta = c("ka", "vc"), reserr = "add")
-#'   modellib(name="PK_1cmt", reserr = "add")
+#'   modellib(name="PK_1cmt", eta = c("ka", "vc"), reserr = "addSd")
+#'   modellib(name="PK_1cmt", reserr = "addSd")
 #' }
 modellib <- function(name=NULL, eta=NULL, reserr=NULL) {
   if (is.null(name)) {

--- a/R/searchReplace.R
+++ b/R/searchReplace.R
@@ -1,6 +1,6 @@
 #' Search within a model to replace part of the model
 #'
-#' @inheritParams nlmixr2::nlmixr2
+#' @param object function specifying the nlmixr2 model
 #' @param find,replace Character scalars of parts of the model to replace
 #' @return \code{object} with \code{find} replaced with \code{replace}
 #' @keywords Internal

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ modellib()
 # Load the "PK_1cmt" model
 modellib(name="PK_1cmt")
 # Switch residual error to additive
-modellib(name="PK_1cmt", reserr = "add")
+modellib(name="PK_1cmt", reserr = "addSd")
 # Add inter-individual variability on ka and v and switch residual error to
 # additive and proportional
-modellib(name="PK_1cmt", eta = c("lka", "lv"), reserr = "add+prop")
+modellib(name="PK_1cmt", eta = c("lka", "lv"), reserr = "addSd+propSd")
 ```
 
 # Modifying models by piping
@@ -29,7 +29,7 @@ and then switches residual error to additive and proportional.
 ```r
 modellib(name="PK_1cmt") %>%
   addEta(c("lka", "lv") %>%
-  addResErr("add+prop")
+  addResErr("addSd+propSd")
 ```
 
 # Possible extensions

--- a/inst/modeldb/PK_1cmt.r
+++ b/inst/modeldb/PK_1cmt.r
@@ -4,7 +4,7 @@ PK_1cmt <- function() {
     lka <- 0.45 ; label("Absorption rate (Ka)")
     lcl <- 1 ; label("Clearance (CL)")
     lvc  <- 3.45 ; label("Central volume of distribution (V)")
-    prop.err <- 0.5 ; label("Proportional residual error (fraction)")
+    propSd <- 0.5 ; label("Proportional residual error (fraction)")
   })
   model({
     ka <- exp(lka)
@@ -12,6 +12,6 @@ PK_1cmt <- function() {
     vc  <- exp(lvc)
 
     cp <- linCmt()
-    cp ~ prop(prop.err)
+    cp ~ prop(propSd)
   })
 }

--- a/inst/modeldb/PK_1cmt_des.r
+++ b/inst/modeldb/PK_1cmt_des.r
@@ -4,7 +4,7 @@ PK_1cmt_des <- function() {
     lka <- 0.45 ; label("Absorption rate (Ka)")
     lcl <- 1 ; label("Clearance (CL)")
     lvc  <- 3.45 ; label("Central volume of distribution (V)")
-    prop.err <- 0.5 ; label("Proportional residual error (fraction)")
+    propSd <- 0.5 ; label("Proportional residual error (fraction)")
   })
   model({
     ka <- exp(lka)
@@ -17,6 +17,6 @@ PK_1cmt_des <- function() {
     d/dt(center) <- ka*depot-kel*center
 
     cp <- center / vc
-    cp ~ prop(prop.err)
+    cp ~ prop(propSd)
   })
 }

--- a/inst/modeldb/PK_2cmt.r
+++ b/inst/modeldb/PK_2cmt.r
@@ -6,7 +6,7 @@ PK_2cmt <- function() {
     lvc  <- 3 ; label("Central volume of distribution (V)")
     lvp  <- 5 ; label("Peripheral volume of distribution (Vp)")
     lq  <- 0.1 ; label("Intercompartmental clearance (Q)")
-    prop.err <- 0.5 ; label("Proportional residual error (fraction)")
+    propSd <- 0.5 ; label("Proportional residual error (fraction)")
   })
   model({
     ka <- exp(lka)
@@ -16,6 +16,6 @@ PK_2cmt <- function() {
     q  <- exp(lq)
 
     cp <- linCmt()
-    cp ~ prop(prop.err)
+    cp ~ prop(propSd)
   })
 }

--- a/inst/modeldb/PK_2cmt_des.r
+++ b/inst/modeldb/PK_2cmt_des.r
@@ -6,7 +6,7 @@ PK_2cmt_des <- function() {
     lvc  <- 3 ; label("Central volume of distribution (V)")
     lvp  <- 5 ; label("Peripheral volume of distribution (Vp)")
     lq  <- 0.1 ; label("Intercompartmental clearance (Q)")
-    prop.err <- 0.5 ; label("Proportional residual error (fraction)")
+    propSd <- 0.5 ; label("Proportional residual error (fraction)")
   })
   model({
     ka <- exp(lka)
@@ -24,6 +24,6 @@ PK_2cmt_des <- function() {
     d/dt(peripheral1) <- k12*center - k21*peripheral1
     cp <- center / vc
 
-    cp ~ prop(prop.err)
+    cp ~ prop(propSd)
   })
 }

--- a/inst/modeldb/PK_3cmt.r
+++ b/inst/modeldb/PK_3cmt.r
@@ -8,7 +8,7 @@ PK_3cmt <- function() {
     lvp2  <- 8 ; label("Second peripheral volume of distribution (Vp2)")
     lq  <- 0.1 ; label("Intercompartmental clearance (Q)")
     lq2  <- 0.5 ; label("Second intercompartmental clearance (Q2)")
-    prop.err <- 0.5 ; label("Proportional residual error (fraction)")
+    propSd <- 0.5 ; label("Proportional residual error (fraction)")
   })
   model({
     ka <- exp(lka)
@@ -20,6 +20,6 @@ PK_3cmt <- function() {
     q2  <- exp(lq2)
 
     cp <- linCmt()
-    cp ~ prop(prop.err)
+    cp ~ prop(propSd)
   })
 }

--- a/inst/modeldb/PK_3cmt_des.r
+++ b/inst/modeldb/PK_3cmt_des.r
@@ -8,7 +8,7 @@ PK_3cmt_des <- function() {
     lvp2  <- 8 ; label("Second peripheral volume of distribution (Vp2)")
     lq  <- 0.1 ; label("Intercompartmental clearance (Q)")
     lq2  <- 0.5 ; label("Second intercompartmental clearance (Q2)")
-    prop.err <- 0.5 ; label("Proportional residual error (fraction)")
+    propSd <- 0.5 ; label("Proportional residual error (fraction)")
   })
   model({
     ka <- exp(lka)
@@ -31,6 +31,6 @@ PK_3cmt_des <- function() {
     d/dt(peripheral2) <- k13*center - k31*peripheral2
     cp <- center / vc
 
-    cp ~ prop(prop.err)
+    cp ~ prop(propSd)
   })
 }

--- a/man/addResErr.Rd
+++ b/man/addResErr.Rd
@@ -9,8 +9,8 @@ addResErr(model, reserr)
 \arguments{
 \item{model}{The model as a function}
 
-\item{reserr}{character with the type of residual error (currently "add",
-"prop" and "add+prop" are accepted)}
+\item{reserr}{character with the type of residual error (currently "addSd",
+"propSd" and "addSd+propSd" are accepted)}
 }
 \value{
 The model with residual error modified
@@ -19,5 +19,5 @@ The model with residual error modified
 Add residual error to a model
 }
 \examples{
-readModelDb("PK_1cmt") \%>\% addResErr("add")
+readModelDb("PK_1cmt") \%>\% addResErr("addSd")
 }

--- a/man/modellib.Rd
+++ b/man/modellib.Rd
@@ -13,8 +13,8 @@ lists all available base models)}
 \item{eta}{vector with the parameters to add random effects (sometimes
 referred to as inter-individual variability, IIV) on}
 
-\item{reserr}{character with the type of residual error (currently "add",
-"prop" and "add+prop" are accepted)}
+\item{reserr}{character with the type of residual error (currently "addSd",
+"propSd" and "addSd+propSd" are accepted)}
 }
 \value{
 The function returns a function the model code (or \code{NULL} if the
@@ -30,7 +30,7 @@ This is a very first draft just to look at the proof of concept
 
 \dontrun{
   modellib(name="PK_1cmt")
-  modellib(name="PK_1cmt", eta = c("ka", "vc"), reserr = "add")
-  modellib(name="PK_1cmt", reserr = "add")
+  modellib(name="PK_1cmt", eta = c("ka", "vc"), reserr = "addSd")
+  modellib(name="PK_1cmt", reserr = "addSd")
 }
 }

--- a/man/searchReplace.Rd
+++ b/man/searchReplace.Rd
@@ -10,7 +10,7 @@ searchReplace(object, find, replace)
 searchReplaceHelper(object, find, replace)
 }
 \arguments{
-\item{object}{Fitted object or function specifying the model.}
+\item{object}{function specifying the nlmixr2 model}
 
 \item{find, replace}{Character scalars of parts of the model to replace}
 }

--- a/tests/testthat/test-addResErr.R
+++ b/tests/testthat/test-addResErr.R
@@ -1,63 +1,63 @@
 test_that("addResErr with des model, changing to additive error", {
   model <- readModelDb("PK_1cmt_des")
-  suppressMessages(modelUpdate <- addResErr(model, reserr = "add"))
+  suppressMessages(modelUpdate <- addResErr(model, reserr = "addSd"))
   # initial conditions are added
   expect_equal(
     functionBody(
       modelUpdate
     )[[3]][[2]][[8]],
-    str2lang("add.err <- c(0, 1)")
+    str2lang("addSd <- c(0, 1)")
   )
   # eta is added
   expect_equal(
     functionBody(
       modelUpdate
     )[[4]][[2]][[9]],
-    str2lang("cp ~ add(add.err)")
+    str2lang("cp ~ add(addSd)")
   )
 })
 
 test_that("addResErr with linCmt model, changing to additive error", {
   model <- readModelDb("PK_1cmt")
-  suppressMessages(modelUpdate <- addResErr(model, reserr = "add"))
+  suppressMessages(modelUpdate <- addResErr(model, reserr = "addSd"))
   # initial conditions are added
   expect_equal(
     functionBody(
       modelUpdate
     )[[3]][[2]][[8]],
-    str2lang("add.err <- c(0, 1)")
+    str2lang("addSd <- c(0, 1)")
   )
   # eta is added
   expect_equal(
     functionBody(
       modelUpdate
     )[[4]][[2]][[6]],
-    str2lang("cp ~ add(add.err)")
+    str2lang("cp ~ add(addSd)")
   )
 })
 
 test_that("addResErr with des model, changing to additive and proportinoal error", {
   model <- readModelDb("PK_1cmt_des")
-  suppressMessages(modelUpdate <- addResErr(model, reserr = "add+prop"))
+  suppressMessages(modelUpdate <- addResErr(model, reserr = "addSd+propSd"))
   # initial conditions are added
   expect_equal(
     functionBody(
       modelUpdate
     )[[3]][[2]][[8]],
-    str2lang("prop.err <- c(0, 0.5)")
+    str2lang("propSd <- c(0, 0.5)")
   )
   expect_equal(
     functionBody(
       modelUpdate
     )[[3]][[2]][[10]],
-    str2lang("add.err <- c(0, 1)")
+    str2lang("addSd <- c(0, 1)")
   )
   # eta is added
   expect_equal(
     functionBody(
       modelUpdate
     )[[4]][[2]][[9]],
-    str2lang("cp ~ add(add.err) + prop(prop.err)")
+    str2lang("cp ~ add(addSd) + prop(propSd)")
   )
 })
 


### PR DESCRIPTION
Change for consistency with other nlmixr2-verse packages.