### PR TITLE
Fix nirsevimab vignette: remove upper y limits and include time 0

### DIFF
--- a/vignettes/Clegg_2024_nirsevimab.Rmd
+++ b/vignettes/Clegg_2024_nirsevimab.Rmd
@@ -163,7 +163,6 @@ out_f4 <- rxode2::rxSolve(mod, events = sim_f4) |>
 
 ```{r fig4-summarise}
 d_f4 <- out_f4 |>
-  filter(time > 0) |>
   group_by(trial, time) |>
   summarise(
     Q05 = quantile(Cc, 0.05, na.rm = TRUE),
@@ -185,7 +184,7 @@ ggplot(d_f4, aes(x = time, y = Q50)) +
   geom_line(colour = "#4682b4", linewidth = 0.8) +
   facet_wrap(~trial, scales = "free_x", nrow = 2) +
   scale_y_log10(
-    limits = c(0.1, 200),
+    limits = c(0.1, NA),
     labels = scales::label_number(drop0trailing = TRUE)
   ) +
   scale_x_continuous(breaks = seq(0, 500, by = 100)) +
@@ -217,7 +216,6 @@ out_f5 <- rxode2::rxSolve(mod, events = d_f5) |> as.data.frame()
 
 ```{r fig5-summarise}
 d_f5_plot <- out_f5 |>
-  filter(time > 0) |>
   group_by(time) |>
   summarise(
     Q10 = quantile(Cc, 0.10, na.rm = TRUE),
@@ -234,7 +232,7 @@ ggplot(d_f5_plot, aes(x = time, y = Q50)) +
   geom_line(aes(y = Q10), linetype = "dashed", linewidth = 0.5) +
   geom_line(aes(y = Q90), linetype = "dashed", linewidth = 0.5) +
   scale_y_log10(
-    limits = c(0.5, 300),
+    limits = c(0.5, NA),
     labels = scales::label_number(drop0trailing = TRUE)
   ) +
   scale_x_continuous(breaks = seq(0, 360, by = 30)) +
@@ -303,8 +301,7 @@ sim_f6_list <- lapply(ga_groups, function(g) {
            BLACK_OTH, ASIAN_AMIND_MULTI, SEASON2, ADA_POS, WT_0)
 
   out <- rxode2::rxSolve(mod, events = d_events) |>
-    as.data.frame() |>
-    filter(time > 0)
+    as.data.frame()
 
   # NCA by individual
   nca <- out |>


### PR DESCRIPTION
Remove hard-coded upper limits from scale_y_log10 calls (replaced with NA) so peak concentrations are not clipped. Remove filter(time > 0) so time = 0 observations are included in all summary plots.