### PR TITLE
Add extract-literature-model skill, covariate register, and CLAUDE.md

### DIFF
--- a/.claude/skills/extract-literature-model/SKILL.md
+++ b/.claude/skills/extract-literature-model/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: extract-literature-model
+description: This skill should be used when the user wants to "add a model from a paper", "extract a pharmacometric model from the literature", "implement a published PK/PD model in nlmixr2lib", or provides a scientific article, conference poster, supplement, or regulatory review document and asks to add the model to nlmixr2lib. Guides source review, standardized model file creation under inst/modeldb/, in-file source-trace verification, and validation vignette with PKNCA NCA checks.
+---
+
+# Extract a pharmacometric model from the literature
+
+Input: a scientific source describing a pharmacometric model (journal article, supplement, conference poster, or regulatory review).
+Output: a packaged nlmixr2lib model file under `inst/modeldb/`, a validation vignette under `vignettes/`, and updated registry artifacts — opened as a pull request against `main`.
+
+Work through the six phases below. Stop and ask the user at any of the decision points called out explicitly; ambiguity is the main failure mode for this workflow, and silent assumptions are what get shipped as bugs.
+
+## References
+
+Read these on demand; don't load them up front.
+
+- `references/naming-conventions.md` — parameter, compartment, IIV, and error-model names.
+- `references/covariate-columns.md` — authoritative register of covariate column names. Consult before introducing any new covariate.
+- `references/model-file-template.md` — skeleton for the `.R` file.
+- `references/vignette-template.md` — skeleton for the validation vignette.
+- `references/pknca-recipes.md` — PKNCA setups for single-dose, steady-state, and multi-dose NCA.
+- `references/verification-checklist.md` — checklist to walk after the first-pass implementation.
+
+## Phase 1 — Source acquisition and scoping
+
+1. Confirm the source type (journal article, supplement, poster, regulatory document).
+2. **Always search for supplementary information.** Supplements frequently contain the NONMEM control stream and parameter tables that disambiguate model structure. If the user provided only a main article, ask whether a supplement exists and request it.
+3. **Verify parameters are final estimates, not initial estimates.** Supplement control streams usually list initial values in `$THETA` / `$OMEGA`; final values come from the paper's results table or `$TABLE` output. If only a control stream is available, confirm values against any published point estimates before treating them as final.
+4. **Multiple-model handling.**
+   - Base model + final model → extract only the final.
+   - Any other "multiple model" case (per-subpopulation, per-endpoint, sensitivity analyses) → list the candidates to the user and ask which to extract. Offer "one," "all," or "a subset."
+5. Confirm the target subdirectory under `inst/modeldb/` (usually `specificDrugs/`; endogenous, therapeuticArea, pharmacokinetics, and pharmacodynamics are also valid).
+
+## Phase 2 — Sync with origin/main and branch
+
+Do this before any file changes:
+
+```bash
+git fetch origin
+git checkout -b <firstauthor>-<year>-<drug> origin/main
+```
+
+Local `main` may be stale. The regenerated `data/modeldb.rda` / `inst/modeldb.qs2` must reflect current origin/main or they will clobber models added upstream. Never push directly to `main`; always open a PR.
+
+## Phase 3 — Model file
+
+File path: `inst/modeldb/<category>/<FirstAuthor>_<Year>_<drug>.R`.
+
+The function name **must equal the filename** minus `.R`; `buildModelDb()` enforces this.
+
+Use `references/model-file-template.md` as the starting skeleton and the two best-formed existing models as anchors:
+
+- `inst/modeldb/specificDrugs/Clegg_2024_nirsevimab.R` — covariates, maturation, correlated IIV, exported race-derivation helper.
+- `inst/modeldb/specificDrugs/Hu_2026_clesrovimab.R` — simpler case with Hill-type maturation.
+
+The file body has this shape:
+
+1. `description`, `reference`, `units`, `covariateData`, `population` — metadata before `ini()`.
+2. `ini()` — parameters with `label()` and a trailing **in-file comment pointing to the source location** for every value.
+3. `model()` — derived terms → individual parameters → micro-constants → ODEs → bioavailability → observation and error.
+
+Follow `references/naming-conventions.md` strictly:
+
+- Structural PK parameters log-transformed: `lka`, `lcl`, `lvc`, `lvp`, `lvp2`, `lq`, `lq2`, `lfdepot`.
+- IIV: `eta` + transformed name, e.g., `etalcl` (not `etacl`). Block correlations via `etalcl + etalvc ~ c(var, cov, var)`.
+- Residual error: `propSd`, `addSd`. Multi-output: `CcpropSd`, `tumorSizeaddSd`, etc.
+- Compartments: `depot`, `central`, `peripheral1`, `peripheral2`, `effect`. Observation: `Cc`.
+
+Covariate columns come from `references/covariate-columns.md`. Before writing any covariate into the file:
+
+- If the canonical name exists, use it and record the source column name in `covariateData[[name]]$source_name`.
+- If the source name is an alias of an existing canonical name (e.g., source uses `SEXM`, canonical is `SEXF`), use the canonical name, note the required value transformation (`SEXF = 1 - SEXM`), and **ask the user to confirm the effect-coefficient sign and reference-category implications** before committing.
+- If the concept isn't in the register at all, propose a new entry (canonical name, description, units, type, reference category, source aliases) and ask the user to confirm before adding it. The new entry is committed alongside the model.
+
+`population` uses the extensible schema in `naming-conventions.md`. Common fields: `n_subjects`, `n_studies`, `age_range`, `weight_range`, `sex_female_pct`, `race_ethnicity`, `disease_state`, `dose_range`, `regions`, `notes`. Add any additional keys the paper describes (e.g., `ga_range`, `renal_function`, `co_medication`) — do not force facts into the common schema.
+
+## Phase 4 — Verification (re-read the source)
+
+After the first pass, re-read the source independently and walk through `references/verification-checklist.md`. Common pitfalls:
+
+- NONMEM THETA log-vs-linear reporting and `omega² = log(CV² + 1)` for log-normal variance.
+- NONMEM "additive on log-scale" ≡ proportional in nlmixr2's linear space.
+- Reference weight / age for allometric and maturation terms (70 kg? 5 kg? 40 weeks PMA?).
+- Reference category for categorical effects after composite-group renames.
+- Bioavailability target compartment.
+- Units consistency (dose × F ÷ V must give the declared concentration units).
+
+Every parameter's in-file source-trace comment must be verified — the comment states where it came from, so checking is a line-by-line audit. 
+
+When any uncertainty remains, ask the user using this format:
+
+> Ambiguity at [source location]. Two plausible interpretations: (A) …, (B) …. Which applies?
+
+Never silently resolve ambiguity. Never tune parameter values to match a validation target.
+
+## Phase 5 — Validation vignette
+
+File path: `vignettes/<FirstAuthor>_<Year>_<drug>.Rmd`, with matching `VignetteIndexEntry`.
+
+Use `references/vignette-template.md`. Required sections, in order:
+
+1. **Header and setup** — libraries include `nlmixr2lib`, `PKNCA`, `rxode2`, `dplyr`, `ggplot2`.
+2. **Population** — narrative reproducing the `population` metadata; cite the source table listing baseline demographics.
+3. **Source trace** — a dedicated table listing the source location (page / table / equation / figure) for every model equation and every `ini()` parameter. This is in addition to the in-file comments; the vignette gives reviewers a single place to audit provenance.
+4. **Virtual cohort** — covariate distributions match the population metadata. Use WHO weight-for-age curves for pediatric models.
+5. **Simulation** — `rxode2::rxSolve(mod, events)` for stochastic VPCs; `rxode2::zeroRe()` + `rxSolve` for typical-value replications.
+6. **Replicate published figures** — one code chunk per figure, caption linking to the source figure number ("Replicates Figure 4 of <Author Year>").
+7. **PKNCA validation** — required; no inline trapezoidal NCA. See `references/pknca-recipes.md`. The PKNCA formula **must include a treatment grouping variable** (`conc ~ time | id/treatment`) so per-group results can be compared against the paper.
+8. **Comparison against published NCA** — if the source paper reports Cmax / Tmax / AUC / half-life, render a side-by-side comparison table. Flag differences > 20% in the narrative and investigate the source — do not tune.
+9. **Assumptions and deviations** — explicit list of what you had to assume because the paper didn't say (race distribution, z-score stability, etc.).
+
+For **endogenous / turnover models** where NCA isn't the right validation, replace the PKNCA section with a baseline-recovery / steady-state check. For **multi-output models**, run one PKNCA block per output.
+
+## Phase 6 — Registration, tests, docs, PR
+
+1. Re-confirm the branch is on top of fresh `origin/main` (`git fetch origin && git rebase origin/main` if needed).
+2. Run `nlmixr2lib::buildModelDb()` to regenerate `data/modeldb.rda` and `inst/modeldb.qs2`. Confirm the new model appears in `modellib()`.
+3. Run `devtools::check()`. Vignettes must build cleanly.
+4. Add a `NEWS.md` entry under the current development version:
+   ```
+   - Added <Author> <Year> population PK model for <drug> (#PR).
+   ```
+5. Commit the model file, the vignette, the regenerated `modeldb.rda` / `modeldb.qs2`, the `NEWS.md` entry, and any updates to `references/covariate-columns.md` (if a new covariate was registered) together on the feature branch.
+6. Push the branch and open a PR against `main`. Use `gh pr create` with a title like `Add <Author> <Year> <drug> model`.
+
+## Stop-and-ask triggers (consolidated)
+
+Don't guess — ask the user when:
+
+- The source has multiple non-hierarchical models and it's not obvious which to extract.
+- Parameter values look like initial estimates rather than final.
+- Covariate encoding isn't fully specified (reference category, units, transformation).
+- A source column name is not in `references/covariate-columns.md` (propose a new entry and confirm).
+- A source column is an alias of an existing canonical name and the mapping involves value inversion or a reference-category flip.
+- A parameter name deviates from the nlmixr2lib standard (propose the canonical name and confirm).
+- PKNCA output disagrees with a published NCA table by more than ~20% after careful review.
+- The source is paywalled and the user hasn't supplied the text.
+
+Use this fixed format for ambiguities:
+
+> Ambiguity at [source location]. Two plausible interpretations: (A) …, (B) …. Which applies?
+
+## Constraints
+
+- Never invent parameter values; if it's not in the source, ask.
+- Never tune parameters to make a validation output match a target.
+- This skill **only adds** new models. Retrofitting existing vignettes to use PKNCA, or renaming covariates in existing files, is a future separate skill.
+- Never push directly to `main`. Open a PR.

--- a/.claude/skills/extract-literature-model/references/covariate-columns.md
+++ b/.claude/skills/extract-literature-model/references/covariate-columns.md
@@ -1,0 +1,241 @@
+# Canonical covariate columns
+
+This file is the authoritative register of covariate column names used in nlmixr2lib models. Every covariate referenced inside a model's `model()` block must have an entry here. The register is seeded from a full audit of `inst/modeldb/` and extended whenever a new paper introduces a covariate that isn't yet registered.
+
+## How to use this register
+
+1. **Before adding a covariate to a new model**, search this file (by canonical name and by source alias) for the concept you need.
+2. **If the canonical name exists**, use it exactly. Document any source-paper rename in the model's `covariateData[[name]]$source_name` field.
+3. **If the source paper uses an alias listed under an existing canonical name**, use the canonical name and note in `covariateData[[name]]$notes` whether the values must be transformed (e.g., `SEXM → SEXF` inverts values; the effect coefficient sign / reference category must be inverted as well).
+4. **If the covariate is not in this register at all**, propose a new entry with a canonical name, description, units, type, and source aliases. Verify with the user before committing. The addition is part of the model's PR.
+5. **Do not modify existing model files when you discover an alias**; simply document the mapping in the register. Retrofitting existing models is a separate effort.
+
+## Case convention
+
+Covariate column names should be ALL CAPS unless the source paper uses a specific case that is well-known and unambiguous (e.g., `eGFR` is widely recognized in that case). Current registered non-all-caps names are noted below; new entries should default to all caps.
+
+## Entry schema
+
+```yaml
+- name: <CANONICAL_NAME>
+  description: <one-sentence definition>
+  units: <unit string, or "(binary)" / "(categorical)">
+  type: continuous | binary | categorical | count
+  reference_category: <the 0 group for binary/categorical, or NULL>
+  source_aliases:
+    - <ALIAS_NAME> (<transformation if any>) — used in <model.R>
+  example_models:
+    - <model.R>
+  notes: <free text>
+```
+
+---
+
+## Demographics
+
+### WT
+- **Description:** Body weight (baseline or time-varying).
+- **Units:** kg
+- **Type:** continuous
+- **Reference category:** n/a — used with allometric scaling `(WT / ref_wt)^exponent`. Reference weights observed: 70 kg (adults), 75 kg, 84.8 kg, 5 kg (infants).
+- **Source aliases:** none known.
+- **Example models:** `Clegg_2024_nirsevimab.R`, `Hu_2026_clesrovimab.R`, `Zhu_2017_lebrikizumab.R`, `Kovalenko_2020_dupilumab.R`, `CarlssonPetri_2021_liraglutide.R`, `Cirincione_2017_exenatide.R`, `Grimm_2023_gantenerumab.R`, `Grimm_2023_trontinemab.R`, `Kyhl_2016_nalmefene.R`, `Soehoel_2022_tralokinumab.R`, `Xie_2019_agomelatine.R`, `PK_2cmt_mAb_Davda_2014.R`, `phenylalanine_charbonneau_2021.R`.
+- **Notes:** Universal. Verify time-varying vs. baseline-only against the source paper.
+
+### AGE
+- **Description:** Subject age in years.
+- **Units:** years
+- **Type:** continuous
+- **Reference category:** n/a
+- **Source aliases:** none.
+- **Example models:** `Kyhl_2016_nalmefene.R`, `Zhu_2017_lebrikizumab.R`.
+- **Notes:** Zhu 2017 normalizes as `AGE/40`.
+
+### LBM
+- **Description:** Lean body mass.
+- **Units:** kg
+- **Type:** continuous
+- **Reference category:** n/a
+- **Source aliases:** none.
+- **Example models:** `Kyhl_2016_nalmefene.R` (reference 56.28 kg, exponent 0.626 on CL).
+
+### SEXF (**canonical for sex**)
+- **Description:** Biological sex indicator, 1 = female, 0 = male.
+- **Units:** (binary)
+- **Type:** binary
+- **Reference category:** 0 (male).
+- **Source aliases:**
+  - `SEXM` (values inverted: `SEXF = 1 - SEXM`; effect coefficient sign and reference category both invert) — used in `CarlssonPetri_2021_liraglutide.R`.
+  - `SEX` with `"M"`/`"F"` strings — derive `SEXF = as.integer(SEX == "F")`.
+- **Example models:** `Zhu_2017_lebrikizumab.R` (canonical), `CarlssonPetri_2021_liraglutide.R` (alias `SEXM`).
+- **Notes:** When translating a model that used `SEXM`, flag the sign/reference-category inversion to the user.
+
+### CHILD
+- **Description:** 1 = subject is a child, 0 = not a child.
+- **Units:** (binary)
+- **Type:** binary
+- **Reference category:** 0 (not child, i.e., adult baseline).
+- **Example models:** `CarlssonPetri_2021_liraglutide.R`.
+- **Notes:** Age-group indicator used alongside `ADOLESCENT`; paper's age cutoffs must be captured in `covariateData[[CHILD]]$notes`.
+
+### ADOLESCENT
+- **Description:** 1 = subject is an adolescent, 0 = not.
+- **Units:** (binary)
+- **Type:** binary
+- **Reference category:** 0.
+- **Example models:** `CarlssonPetri_2021_liraglutide.R`.
+- **Notes:** Paired with `CHILD`. Document age cutoffs.
+
+## Pediatric / maturation
+
+### PAGE
+- **Description:** Postmenstrual age in months (`GA_weeks / 4.35 + postnatal_months`). Time-varying.
+- **Units:** months
+- **Type:** continuous
+- **Example models:** `Clegg_2024_nirsevimab.R`.
+
+### PNA
+- **Description:** Postnatal age (chronological since birth). Time-varying.
+- **Units:** months
+- **Type:** continuous
+- **Example models:** `Hu_2026_clesrovimab.R`.
+
+### GA
+- **Description:** Gestational age at birth. Time-fixed per subject.
+- **Units:** weeks
+- **Type:** continuous
+- **Example models:** `Hu_2026_clesrovimab.R`, used implicitly in `Clegg_2024_nirsevimab.R` (folded into PAGE).
+
+## Renal / hepatic function
+
+### eGFR
+- **Description:** Estimated glomerular filtration rate (MDRD equation).
+- **Units:** mL/min/1.73 m²
+- **Type:** continuous
+- **Example models:** `Cirincione_2017_exenatide.R` (reference 80 mL/min/1.73 m², exponent 0.838).
+- **Notes:** Case preserved (lowercase `e`) because `eGFR` is the widely-used clinical notation.
+
+## Race / ethnicity
+
+**Canonical pattern: `RACE_<GROUP>`.** Use one indicator per race/ethnicity group the source models. Reference category is the implicit 0 = all other groups; document explicitly which groups are in the reference. When the source uses composite groups (e.g., "Black or Other"), name them accordingly (`RACE_BLACK_OTHER`) and list the components in `notes`.
+
+### RACE_BLACK (**canonical**)
+- **Description:** 1 = Black / African American, 0 = other.
+- **Units:** (binary)
+- **Type:** binary
+- **Reference category:** 0 (document the actual reference groups used).
+- **Source aliases:**
+  - `BLACK` — used in `Hu_2026_clesrovimab.R`.
+  - `BLACK_OTH` (Black or Other composite; reference: White or Native Hawaiian/Pacific Islander) — used in `Clegg_2024_nirsevimab.R`. Register as its own canonical `RACE_BLACK_OTH` since the grouping is not equivalent.
+- **Example models:** `Zhu_2017_lebrikizumab.R` (canonical form).
+
+### RACE_BLACK_OTH (**canonical for composite Black/Other group**)
+- **Description:** 1 = Black/African American or Other race, 0 = other groups.
+- **Reference category:** 0 = White or Native Hawaiian/Pacific Islander (Clegg 2024 grouping).
+- **Source aliases:** `BLACK_OTH` — used in `Clegg_2024_nirsevimab.R`.
+- **Notes:** Kept distinct from `RACE_BLACK` because the composite is not interchangeable.
+
+### RACE_ASIAN (**canonical**)
+- **Description:** 1 = Asian, 0 = other.
+- **Source aliases:** `ASIAN` — used in `Hu_2026_clesrovimab.R`.
+- **Example models:** `Zhu_2017_lebrikizumab.R` (canonical form).
+
+### RACE_ASIAN_AMIND_MULTI (**canonical for composite group**)
+- **Description:** 1 = Asian, American Indian / Alaskan Native, or Multiple races, 0 = other.
+- **Reference category:** 0 = White, Black / African American, Native Hawaiian / Pacific Islander, or Other (Clegg 2024 grouping).
+- **Source aliases:** `ASIAN_AMIND_MULTI` — used in `Clegg_2024_nirsevimab.R`.
+- **Notes:** Clegg 2024 applies this covariate to both CL and V2 with different coefficients.
+
+### RACE_MULTI
+- **Description:** 1 = multiracial, 0 = other.
+- **Source aliases:** `MULTIRACIAL` — used in `Hu_2026_clesrovimab.R`.
+
+### RACE_OTHER
+- **Description:** 1 = race category "Other," 0 = not.
+- **Example models:** `Zhu_2017_lebrikizumab.R`.
+
+## Immunogenicity
+
+### ADA_POS (**canonical**)
+- **Description:** 1 = antidrug-antibody-positive, 0 = ADA-negative.
+- **Units:** (binary)
+- **Type:** binary
+- **Reference category:** 0 (ADA-negative).
+- **Source aliases:**
+  - `ADA` (semantically "ever positive") — used in `Zhu_2017_lebrikizumab.R`. When translating from a paper that uses `ADA` as "ever positive," verify the time-frame matches ADA_POS semantics before renaming.
+- **Example models:** `Clegg_2024_nirsevimab.R`, `Hu_2026_clesrovimab.R`.
+
+## Formulation / assay / study
+
+### FED
+- **Description:** 1 = fed state at dosing, 0 = fasted.
+- **Type:** binary
+- **Reference category:** 0 (fasted).
+- **Example models:** `Kyhl_2016_nalmefene.R`.
+
+### TABLET
+- **Description:** 1 = tablet formulation, 0 = solution.
+- **Type:** binary
+- **Reference category:** 0 (solution).
+- **Example models:** `Kyhl_2016_nalmefene.R`.
+
+### RIA_ASSAY
+- **Description:** 1 = radioimmunoassay; 0 = LC-MS/MS.
+- **Type:** binary
+- **Example models:** `Kyhl_2016_nalmefene.R`.
+- **Notes:** Switches the additive residual-error magnitude.
+
+### FORM_NS0
+- **Description:** 1 = NS0 cell-line formulation, 0 = other.
+- **Type:** binary
+- **Example models:** `Zhu_2017_lebrikizumab.R`.
+
+### FORM_CHO_PHASE2
+- **Description:** 1 = CHO Phase 2 formulation, 0 = other.
+- **Type:** binary
+- **Example models:** `Zhu_2017_lebrikizumab.R`.
+
+### dilution
+- **Description:** 1 = drug diluted (Soehoel 2022 study D2213C00001), 0 = not diluted.
+- **Type:** binary
+- **Example models:** `Soehoel_2022_tralokinumab.R`.
+- **Notes:** Lower-case preserved from source; future models should rename to `DILUTION`. Kept as alias here to match existing file.
+
+### nonECZTRA
+- **Description:** 1 = not the ECZTRA trial; 0 = ECZTRA.
+- **Type:** binary
+- **Example models:** `Soehoel_2022_tralokinumab.R`.
+- **Notes:** Mixed case preserved from source; future models should rename to `NON_ECZTRA` or `STUDY_NON_ECZTRA`.
+
+### DVID
+- **Description:** Study identifier, character-valued: `"study1"`, `"study5"`, `"otherStudy"`.
+- **Type:** categorical
+- **Example models:** `Cirincione_2017_exenatide.R`.
+- **Notes:** Used to switch conditional residual-error models. Character type is atypical; new models should prefer numeric encoding or separate binary indicators.
+
+### SEASON2
+- **Description:** 1 = second RSV season at dosing, 0 = first RSV season.
+- **Type:** binary
+- **Example models:** `Clegg_2024_nirsevimab.R`.
+- **Notes:** Study-specific but semantically general (second-exposure indicator).
+
+## Occasion / period (IOV)
+
+### ooc1, ooc2, ooc3, ooc4
+- **Description:** Mutually exclusive occasion indicators for a crossover / multi-period design. Exactly one is 1 per observation.
+- **Type:** binary
+- **Example models:** `Xie_2019_agomelatine.R`.
+- **Notes:** Lower case preserved from source file. Future models should standardize on `OCC` as a categorical column with integer values (`OCC = 1`, `2`, …) and use `IOV` on the appropriate parameters.
+
+---
+
+## Change log
+
+- **Initial seed** (this PR): Every covariate observed in `inst/modeldb/` as of the audit. Canonical names established: `SEXF`, `ADA_POS`, `RACE_<GROUP>` prefix. Aliases documented but existing model files not modified.
+- Subsequent additions: append new canonical entries as new papers are processed. When adding, bump the audit-completed count in the summary below.
+
+## Summary
+
+- Files audited: 61 R files under `inst/modeldb/` (12 of which reference covariates).
+- Canonical entries: 22.
+- Aliases mapped: 7 (including SEXM→SEXF, ADA→ADA_POS, BLACK→RACE_BLACK, ASIAN→RACE_ASIAN, MULTIRACIAL→RACE_MULTI, BLACK_OTH→RACE_BLACK_OTH, ASIAN_AMIND_MULTI→RACE_ASIAN_AMIND_MULTI).

--- a/.claude/skills/extract-literature-model/references/covariate-columns.md
+++ b/.claude/skills/extract-literature-model/references/covariate-columns.md
@@ -207,12 +207,6 @@ Covariate column names should be ALL CAPS unless the source paper uses a specifi
 - **Example models:** `Soehoel_2022_tralokinumab.R`.
 - **Notes:** Mixed case preserved from source; future models should rename to `NON_ECZTRA` or `STUDY_NON_ECZTRA`.
 
-### DVID
-- **Description:** Study identifier, character-valued: `"study1"`, `"study5"`, `"otherStudy"`.
-- **Type:** categorical
-- **Example models:** `Cirincione_2017_exenatide.R`.
-- **Notes:** Used to switch conditional residual-error models. Character type is atypical; new models should prefer numeric encoding or separate binary indicators.
-
 ### SEASON2
 - **Description:** 1 = second RSV season at dosing, 0 = first RSV season.
 - **Type:** binary
@@ -237,5 +231,5 @@ Covariate column names should be ALL CAPS unless the source paper uses a specifi
 ## Summary
 
 - Files audited: 61 R files under `inst/modeldb/` (12 of which reference covariates).
-- Canonical entries: 22.
+- Canonical entries: 21.
 - Aliases mapped: 7 (including SEXM→SEXF, ADA→ADA_POS, BLACK→RACE_BLACK, ASIAN→RACE_ASIAN, MULTIRACIAL→RACE_MULTI, BLACK_OTH→RACE_BLACK_OTH, ASIAN_AMIND_MULTI→RACE_ASIAN_AMIND_MULTI).

--- a/.claude/skills/extract-literature-model/references/model-file-template.md
+++ b/.claude/skills/extract-literature-model/references/model-file-template.md
@@ -29,20 +29,35 @@ Related references:
   )
 
   population <- list(
-    #! Common fields, all optional except n_subjects. Add more keys as the source warrants.
+    #! Common fields, all optional except n_subjects. Units and wording are not fixed —
+    #! match the source. Pick whichever age/weight units match the study population.
+    #! Example A (adult study):
+    #!   age_range     = "18-75 years"
+    #!   age_median    = "52 years"
+    #!   weight_range  = "50-120 kg"
+    #!   weight_median = "78 kg"
+    #!   disease_state = "moderate-to-severe atopic dermatitis"
+    #!   dose_range    = "150-300 mg SC Q2W"
+    #! Example B (pediatric study):
+    #!   age_range     = "0-24 months"
+    #!   age_median    = "3 months"
+    #!   weight_range  = "2-12 kg"
+    #!   weight_median = "5 kg"
+    #!   disease_state = "healthy infants at risk for RSV"
+    #!   dose_range    = "50-200 mg IM single dose"
+    #! Additional keys welcome (ga_range, renal_function, hepatic_function, co_medication, ...).
     n_subjects     = <integer>,
     n_studies      = <integer>,
-    age_range      = "<e.g., 0-24 months>",
-    age_median     = "<e.g., 3 months>",
-    weight_range   = "<e.g., 2-12 kg>",
-    weight_median  = "<e.g., 5 kg>",
+    age_range      = "<adult: '18-75 years' | pediatric: '0-24 months'>",
+    age_median     = "<adult: '52 years' | pediatric: '3 months'>",
+    weight_range   = "<adult: '50-120 kg' | pediatric: '2-12 kg'>",
+    weight_median  = "<adult: '78 kg' | pediatric: '5 kg'>",
     sex_female_pct = <numeric>,
     race_ethnicity = c(White = <pct>, Black = <pct>, Asian = <pct>, Other = <pct>),
-    disease_state  = "<e.g., healthy infants at risk for RSV>",
-    dose_range     = "<e.g., 50-200 mg IM single dose>",
+    disease_state  = "<e.g., 'moderate-to-severe atopic dermatitis' or 'healthy infants at risk for RSV'>",
+    dose_range     = "<e.g., '150-300 mg SC Q2W' or '50-200 mg IM single dose'>",
     regions        = "<e.g., North America, EU>",
     notes          = "<free text; cite the Table in the source that lists baseline demographics>"
-    #! Additional keys welcome (ga_range, renal_function, hepatic_function, co_medication, ...).
   )
 
   ini({

--- a/.claude/skills/extract-literature-model/references/model-file-template.md
+++ b/.claude/skills/extract-literature-model/references/model-file-template.md
@@ -1,0 +1,133 @@
+# Model file template
+
+Copy this skeleton into `inst/modeldb/<category>/<FirstAuthor>_<Year>_<drug>.R` and fill in. Placeholders are wrapped in `<>`. Inline comments that start with `#!` are instructions for the person filling the template and must be deleted before committing.
+
+Related references:
+- `naming-conventions.md` — parameter / compartment / IIV naming
+- `covariate-columns.md` — required register of covariate column names (consult before inventing any new name)
+- `verification-checklist.md` — run through after first pass
+
+```r
+<FirstAuthor>_<Year>_<drug> <- function() {
+  description <- "<One-sentence summary, e.g., 'Two-compartment population PK model for <drug> in <population>'>"
+  reference   <- "<Full citation with DOI>"
+  units       <- list(time = "<day|hour>", dosing = "<mg|mg/kg>", concentration = "<ug/mL|ng/mL>")
+
+  covariateData <- list(
+    #! One entry per covariate. Canonical names come from references/covariate-columns.md.
+    #! If the source paper uses a different column name, set source_name and, if values must be
+    #! transformed (e.g., SEXM -> SEXF), note the transformation in notes and confirm with user.
+    WT = list(
+      description        = "Body weight",
+      units              = "kg",
+      type               = "continuous",
+      reference_category = NULL,
+      notes              = "Time-varying; used for allometric scaling with reference weight <ref_wt> kg.",
+      source_name        = "WT"
+    )
+    #! Add further covariates here.
+  )
+
+  population <- list(
+    #! Common fields, all optional except n_subjects. Add more keys as the source warrants.
+    n_subjects     = <integer>,
+    n_studies      = <integer>,
+    age_range      = "<e.g., 0-24 months>",
+    age_median     = "<e.g., 3 months>",
+    weight_range   = "<e.g., 2-12 kg>",
+    weight_median  = "<e.g., 5 kg>",
+    sex_female_pct = <numeric>,
+    race_ethnicity = c(White = <pct>, Black = <pct>, Asian = <pct>, Other = <pct>),
+    disease_state  = "<e.g., healthy infants at risk for RSV>",
+    dose_range     = "<e.g., 50-200 mg IM single dose>",
+    regions        = "<e.g., North America, EU>",
+    notes          = "<free text; cite the Table in the source that lists baseline demographics>"
+    #! Additional keys welcome (ga_range, renal_function, hepatic_function, co_medication, ...).
+  )
+
+  ini({
+    #! Every parameter has:
+    #!   1. A log-transform prefix where applicable.
+    #!   2. A label() with units and a plain-English description.
+    #!   3. A trailing in-file comment pointing to the source location the value came from.
+    #! Example: lcl <- log(0.0388); label("CL for 70 kg adult (L/day)")  # Clegg 2024 Table 3
+
+    # Structural parameters — reference values for <reference weight / age>
+    lka     <- log(<value>); label("<description with units>")  # <source location>
+    lcl     <- log(<value>); label("<description with units>")  # <source location>
+    lvc     <- log(<value>); label("<description with units>")  # <source location>
+    # Add lvp, lq, lfdepot, etc. as applicable
+
+    # Allometric / maturation parameters (if applicable)
+    allo_cl <- <value>; label("Allometric exponent on CL (unitless)")  # <source location>
+
+    # Covariate effects — one per covariate/parameter combination
+    e_<cov>_<param> <- <value>; label("<Effect of <cov> on <param>>")  # <source location>
+
+    # IIV — eta + transformed parameter name. Use a block for correlated IIV.
+    etalcl + etalvc ~ c(<var_cl>, <cov_cl_vc>, <var_vc>)  # <source location>
+    etalka          ~ <var_ka>                              # <source location>
+
+    # Residual error
+    propSd <- <value>; label("Proportional residual error (fraction)")  # <source location>
+    # addSd  <- <value>; label("Additive residual error (<units>)")     # uncomment if combined
+  })
+
+  model({
+    #! Order inside model():
+    #!   1. Derived covariate terms (maturation, race/season multipliers)
+    #!   2. Individual PK parameters (exp(lX + etaX) * scaling)
+    #!   3. Micro-constants (kel, k12, k21)
+    #!   4. ODE system (d/dt(...))
+    #!   5. Bioavailability / lag-time adjustments
+    #!   6. Observation variable (Cc) and error model
+
+    # 1. Derived terms
+    # maturation_cl <- 1 - (1 - beta_cl) * exp(-age_term * log(2) / t50_cl)
+    # race_cl       <- 1 + e_race_black_cl * RACE_BLACK
+
+    # 2. Individual parameters
+    ka <- exp(lka + etalka)
+    cl <- exp(lcl + etalcl) * (WT / <ref_wt>)^allo_cl  # * maturation_cl * race_cl ...
+    vc <- exp(lvc + etalvc) * (WT / <ref_wt>)^allo_v
+
+    # 3. Micro-constants (if using explicit ODEs)
+    kel <- cl / vc
+    # k12 <- q / vc
+    # k21 <- q / vp
+
+    # 4. ODE system
+    d/dt(depot)   <- -ka * depot
+    d/dt(central) <-  ka * depot - kel * central
+    # d/dt(peripheral1) <- k12 * central - k21 * peripheral1
+
+    # 5. Bioavailability
+    # f(depot) <- exp(lfdepot)
+
+    # 6. Observation and error
+    Cc <- central / vc
+    Cc ~ prop(propSd)
+    # Cc ~ add(addSd) + prop(propSd)
+  })
+}
+```
+
+## Notes
+
+- When the source paper uses `linCmt()`-compatible structure (simple 1/2/3-compartment with first-order or IV absorption), an equally valid body is:
+  ```r
+  model({
+    ka <- exp(lka + etalka)
+    cl <- exp(lcl + etalcl) * (WT / <ref_wt>)^allo_cl
+    vc <- exp(lvc + etalvc) * (WT / <ref_wt>)^allo_v
+    vp <- exp(lvp) * (WT / <ref_wt>)^allo_v
+    q  <- exp(lq)  * (WT / <ref_wt>)^allo_cl
+    Cc <- linCmt()
+    Cc ~ prop(propSd)
+  })
+  ```
+  Prefer explicit ODEs if the source includes mechanism-specific structure (TMDD, transit chains, enterohepatic cycling).
+
+- Helper functions (e.g., to derive one-hot race indicators from a raw race column) live in `R/` and are exported with roxygen. Name them `<modelname>_<action>()`, e.g., `Clegg_2024_nirsevimab_derive_race_indicators()`. Only add if the covariate encoding is non-trivial.
+
+- Before committing: delete every `#!` instruction comment. Leave the source-location `# <source>` comments — they are the audit trail.

--- a/.claude/skills/extract-literature-model/references/naming-conventions.md
+++ b/.claude/skills/extract-literature-model/references/naming-conventions.md
@@ -1,0 +1,113 @@
+# Naming conventions for nlmixr2lib models
+
+Authoritative source: `vignettes/create-model-library.Rmd`. This file collects the conventions relevant to model extraction and adds the standards agreed on when the `extract-literature-model` skill was introduced. When in doubt, prefer this file; if this file conflicts with `create-model-library.Rmd`, raise the conflict with the user rather than silently picking one.
+
+## Compartments
+
+Lower case. Snake case only when combining concepts.
+
+- `depot` — extravascular dosing compartment (oral, SC, IM).
+- `central` — IV / central sampling compartment.
+- `peripheral1`, `peripheral2` — peripheral compartments for 2- and 3-compartment models.
+- `effect` — effect compartment for PK/PD models.
+- `transit1`, `transit2`, … — transit-compartment absorption chains.
+- Therapeutic-area or mechanism-specific compartments: open a GitHub issue before adding new names.
+
+## Observation variable
+
+- `Cc` — concentration in the central compartment. Use even with `linCmt()`: `Cc <- linCmt()`.
+- Multi-output models add named output variables (e.g., `Cbrain_cerebellum`, `tumorSize`). Apply residual error to each output by name.
+
+## Structural PK parameters
+
+Log-transform any parameter that must be positive. Prefix `l` (lower-case L).
+
+- `lka` — absorption rate
+- `lcl` — clearance
+- `lvc` — central volume of distribution
+- `lvp`, `lvp2` — first / second peripheral volume
+- `lq`, `lq2` — inter-compartmental clearance to `peripheral1` / `peripheral2`
+- `lfdepot` — log bioavailability for the depot compartment
+
+Derived quantities inside `model()` are un-prefixed:
+`ka`, `cl`, `vc`, `vp`, `vp2`, `q`, `q2`, and micro-constants `kel` (= `cl/vc`), `k12`, `k21`, `k13`, `k31`.
+
+## Transform prefixes
+
+- `l` — natural log (`lka`, `lcl`, `lfdepot`)
+- `logit` — logit (`logitfr`, `logitemax`)
+- `probit` — probit
+- Any other transform: spell it out as a prefix
+
+Always label every parameter inside `ini()` with units and a short interpretation.
+
+## Inter-individual variability (IIV)
+
+Prefix `eta` + the **transformed** parameter name. Example: IIV on `lcl` is `etalcl`.
+
+- Single IIV: `etalcl ~ 0.09`
+- Correlated IIV (block): `etalcl + etalvc ~ c(var_cl, cov, var_vc)`
+- Fixed: wrap in `fixed()` when the source reports a known value.
+
+Do **not** use `iiv_`, `IIV_`, or `bsv_` prefixes for new models. The two most recent existing models (`Clegg_2024_nirsevimab`, `Hu_2026_clesrovimab`) write `etacl` without the `l`; this skill standardizes on `etalcl` going forward. Existing files are not migrated.
+
+Document `omega²` = `log(CV² + 1)` in a comment when translating CV% to the internal variance scale.
+
+## Covariate-effect parameters
+
+Multiplicative additive effect: `e_<cov>_<param>`. Examples: `e_wt_cl`, `e_ada_cl`, `e_black_cl`.
+
+Power-style effect: keep the same naming and apply as `cov^e_cov_param` if the source parameterizes it that way; comment the form.
+
+## Residual error
+
+- Proportional: `propSd`
+- Additive: `addSd`
+- Combined: `Cc ~ add(addSd) + prop(propSd)`
+
+For multi-output models, prefix with the output variable: `CcpropSd`, `CcaddSd`, `tumorSizepropSd`. Note in a comment when the source reports log-additive error (NONMEM `EPS(1)` on log-transformed observation); that maps to proportional error in nlmixr2.
+
+## Covariate column names
+
+Not listed here. See `references/covariate-columns.md` — the authoritative register. Any covariate used in a model must exist in that register; if it doesn't, propose adding an entry (skill workflow step).
+
+## File-level metadata
+
+Every model function body begins with:
+
+```r
+description <- "<One-sentence summary used in model listings>"
+reference   <- "<Full citation including DOI>"
+units       <- list(time = "<unit>", dosing = "<unit>", concentration = "<unit>")
+covariateData <- list(
+  <NAME> = list(
+    description       = "<what it is>",
+    units             = "<unit or (binary)>",
+    type              = "<continuous | binary | categorical | count>",
+    reference_category = "<for categorical/binary; the 0 group>",
+    notes             = "<derivation, time-varying vs fixed, etc.>",
+    source_name       = "<the column name used in the source paper, if different>"
+  )
+)
+population <- list(
+  n_subjects   = <integer>,
+  n_studies    = <integer>,
+  age_range    = "<e.g., 0-24 months>",
+  weight_range = "<e.g., 2-12 kg>",
+  sex_female_pct = <numeric>,
+  race_ethnicity = c(White = <pct>, Black = <pct>, Asian = <pct>, Other = <pct>),
+  disease_state = "<e.g., healthy infants at risk for RSV>",
+  dose_range    = "<e.g., 50-200 mg IM>",
+  regions       = "<e.g., North America, EU, Japan>",
+  notes         = "<free text>"
+  # Additional keys permitted — add any other important population details
+)
+```
+
+After this metadata block come `ini()` and `model()`.
+
+## File naming
+
+- Path: `inst/modeldb/<category>/<FirstAuthor>_<Year>_<drug>.R`
+- Function name **must** equal the filename minus `.R`. Enforced by `buildModelDb()`.
+- Use the paper's first-author surname (no accents or spaces), four-digit year, and drug INN in lowercase.

--- a/.claude/skills/extract-literature-model/references/pknca-recipes.md
+++ b/.claude/skills/extract-literature-model/references/pknca-recipes.md
@@ -1,0 +1,165 @@
+# PKNCA recipes for validation vignettes
+
+Every validation vignette uses PKNCA for NCA parameters (Cmax, Tmax, AUC, half-life, …) rather than inline trapezoidal calculations. All recipes include a **treatment grouping variable** in the formula so results can be compared against per-group values reported in the source paper.
+
+PKNCA reference: `?PKNCA::PKNCA` and `vignette("Introduction-and-Usage", package = "PKNCA")`.
+
+## Data shape required
+
+- **Concentration data:** one row per subject × time. Columns: `id`, `time`, `conc` (the `Cc` output from simulation), plus the grouping column (`treatment`, `cohort`, `regimen`, or similar).
+- **Dose data:** one row per dose event. Columns: `id`, `time`, `dose` (amount), plus the same grouping column.
+
+Both frames must agree on `id` and the grouping column.
+
+## Recipe 1 — Single-dose, dense sampling (Cmax, Tmax, AUC0-inf, half-life)
+
+Use when the paper reports NCA after a single dose with enough sampling to characterize the terminal phase.
+
+```r
+library(PKNCA)
+
+conc_df <- sim |>
+  filter(!is.na(Cc)) |>
+  transmute(id, time, conc = Cc, treatment)
+
+dose_df <- events |>
+  filter(evid == 1) |>
+  transmute(id, time, dose = amt, treatment)
+
+conc_obj <- PKNCAconc(conc_df, conc ~ time | id / treatment)
+dose_obj <- PKNCAdose(dose_df, dose ~ time | id / treatment)
+
+intervals <- data.frame(
+  start      = 0,
+  end        = Inf,
+  cmax       = TRUE,
+  tmax       = TRUE,
+  aucinf.obs = TRUE,
+  aucinf.pred = TRUE,
+  half.life  = TRUE,
+  clast.obs  = TRUE,
+  lambda.z   = TRUE
+)
+
+res <- pk.nca(PKNCAdata(conc_obj, dose_obj, intervals = intervals))
+summary(res)
+```
+
+## Recipe 2 — Single-dose, AUClast only (sparse terminal data)
+
+Use when terminal sampling is too sparse to estimate `lambda.z` reliably.
+
+```r
+intervals <- data.frame(
+  start     = 0,
+  end       = max(conc_df$time),
+  cmax      = TRUE,
+  tmax      = TRUE,
+  auclast   = TRUE,
+  clast.obs = TRUE
+)
+res <- pk.nca(PKNCAdata(conc_obj, dose_obj, intervals = intervals))
+```
+
+## Recipe 3 — Steady state (AUC0-tau, Cmax,ss, Cmin,ss, Cavg,ss)
+
+Use when the paper reports steady-state NCA over a dosing interval `tau`.
+
+```r
+tau <- <dosing interval, e.g., 24>  # same units as time
+
+# Pick the AUC0-tau interval at steady state, e.g., the last dosing interval
+start_ss <- max(dose_df$time)          # time of the final dose
+end_ss   <- start_ss + tau
+
+intervals <- data.frame(
+  start    = start_ss,
+  end      = end_ss,
+  cmax     = TRUE,
+  tmax     = TRUE,
+  cmin     = TRUE,
+  auclast  = TRUE,
+  cav      = TRUE,   # average concentration over the interval
+  ctau     = TRUE    # concentration at end of interval
+)
+
+res <- pk.nca(PKNCAdata(conc_obj, dose_obj, intervals = intervals))
+```
+
+## Recipe 4 — Multiple-dose with accumulation
+
+Compute AUC0-tau on the first dosing interval, AUC0-tau at steady state, and the accumulation ratio.
+
+```r
+intervals <- data.frame(
+  start = c(0, start_ss),
+  end   = c(tau, end_ss),
+  cmax     = TRUE,
+  auclast  = TRUE
+)
+
+res <- pk.nca(PKNCAdata(conc_obj, dose_obj, intervals = intervals))
+# Accumulation ratio = AUC0-tau at SS / AUC0-tau after first dose
+```
+
+## Recipe 5 — Per-subgroup summaries beyond the grouping variable
+
+PKNCA's `summary()` collapses within the group levels defined by the formula. If
+the source paper reports NCA stratified by an additional covariate (e.g., by
+baseline weight band), join the group metadata after summarizing:
+
+```r
+res_tbl <- as.data.frame(res$result)
+
+res_joined <- res_tbl |>
+  left_join(cohort |> select(id, weight_band), by = "id") |>
+  group_by(treatment, weight_band, PPTESTCD) |>
+  summarise(
+    median_value = median(PPORRES),
+    q05          = quantile(PPORRES, 0.05),
+    q95          = quantile(PPORRES, 0.95),
+    .groups      = "drop"
+  )
+```
+
+## Comparing against the published table
+
+When the source paper reports NCA values (e.g., geometric mean with 95% CI), the
+vignette should render a side-by-side table. A simple pattern:
+
+```r
+published <- tibble(
+  treatment   = c("50 mg", "100 mg"),
+  Cmax_pub    = c(<value>, <value>),
+  AUCinf_pub  = c(<value>, <value>)
+)
+
+simulated <- res_tbl |>
+  filter(PPTESTCD %in% c("cmax", "aucinf.obs")) |>
+  group_by(treatment, PPTESTCD) |>
+  summarise(value = median(PPORRES), .groups = "drop") |>
+  pivot_wider(names_from = PPTESTCD, values_from = value)
+
+comparison <- published |> left_join(simulated, by = "treatment")
+knitr::kable(comparison)
+```
+
+Flag any differences > 20% in the narrative; do not tune parameters to match.
+
+## Common pitfalls
+
+- **Missing treatment grouping** — if the formula is `conc ~ time | id` with no
+  `/ treatment`, PKNCA aggregates across dose groups and the Cmax / AUC results
+  are uninterpretable. Always include the grouping.
+- **Dose units ≠ concentration units** — PKNCA doesn't check. Confirm dose is
+  in the same mass unit as `conc × volume` implied by the model (e.g., mg vs.
+  ng × L).
+- **`lambda.z` warnings** — PKNCA will emit warnings when there aren't enough
+  post-peak points. That's informational; if the paper used a specific
+  regression window, set `lambda.z.time.first` and `lambda.z.n.points` in the
+  `intervals` data frame.
+- **BLQ handling** — the model emits continuous concentrations (no BLQ), so
+  BLQ handling in PKNCA is usually a no-op. If the paper applied a specific
+  BLQ rule (e.g., M3 method), that's outside the NCA step.
+- **Time-zero records** — PKNCA expects a pre-dose record for IV or a `time = 0`
+  observation for extravascular. Ensure the simulation grid includes `time = 0`.

--- a/.claude/skills/extract-literature-model/references/pknca-recipes.md
+++ b/.claude/skills/extract-literature-model/references/pknca-recipes.md
@@ -6,10 +6,12 @@ PKNCA reference: `?PKNCA::PKNCA` and `vignette("Introduction-and-Usage", package
 
 ## Data shape required
 
-- **Concentration data:** one row per subject × time. Columns: `id`, `time`, `conc` (the `Cc` output from simulation), plus the grouping column (`treatment`, `cohort`, `regimen`, or similar).
-- **Dose data:** one row per dose event. Columns: `id`, `time`, `dose` (amount), plus the same grouping column.
+- **Concentration data:** one row per subject × time. Columns: `id`, `time`, `Cc` (the simulated concentration from the model — keep the column named `Cc` to match nlmixr2lib conventions), plus the grouping column (`treatment`, `cohort`, `regimen`, or similar).
+- **Dose data:** one row per dose event. Columns: `id`, `time`, `amt` (dose amount — keep the rxode2/nlmixr2 column name), plus the same grouping column.
 
 Both frames must agree on `id` and the grouping column.
+
+The formula is always `Cc ~ time | treatment + id` (and `amt ~ time | treatment + id` for dose). The **treatment grouping variable goes first**, before `id`, so PKNCA summaries roll up per treatment as reported in most source papers.
 
 ## Recipe 1 — Single-dose, dense sampling (Cmax, Tmax, AUC0-inf, half-life)
 
@@ -18,16 +20,16 @@ Use when the paper reports NCA after a single dose with enough sampling to chara
 ```r
 library(PKNCA)
 
-conc_df <- sim |>
-  filter(!is.na(Cc)) |>
-  transmute(id, time, conc = Cc, treatment)
+sim_nca <- sim |>
+  dplyr::filter(!is.na(Cc)) |>
+  dplyr::select(id, time, Cc, treatment)
 
 dose_df <- events |>
-  filter(evid == 1) |>
-  transmute(id, time, dose = amt, treatment)
+  dplyr::filter(evid == 1) |>
+  dplyr::select(id, time, amt, treatment)
 
-conc_obj <- PKNCAconc(conc_df, conc ~ time | id / treatment)
-dose_obj <- PKNCAdose(dose_df, dose ~ time | id / treatment)
+conc_obj <- PKNCA::PKNCAconc(sim_nca, Cc ~ time | treatment + id)
+dose_obj <- PKNCA::PKNCAdose(dose_df, amt ~ time | treatment + id)
 
 intervals <- data.frame(
   start      = 0,
@@ -41,7 +43,7 @@ intervals <- data.frame(
   lambda.z   = TRUE
 )
 
-res <- pk.nca(PKNCAdata(conc_obj, dose_obj, intervals = intervals))
+res <- PKNCA::pk.nca(PKNCA::PKNCAdata(conc_obj, dose_obj, intervals = intervals))
 summary(res)
 ```
 
@@ -52,13 +54,13 @@ Use when terminal sampling is too sparse to estimate `lambda.z` reliably.
 ```r
 intervals <- data.frame(
   start     = 0,
-  end       = max(conc_df$time),
+  end       = max(sim_nca$time),
   cmax      = TRUE,
   tmax      = TRUE,
   auclast   = TRUE,
   clast.obs = TRUE
 )
-res <- pk.nca(PKNCAdata(conc_obj, dose_obj, intervals = intervals))
+res <- PKNCA::pk.nca(PKNCA::PKNCAdata(conc_obj, dose_obj, intervals = intervals))
 ```
 
 ## Recipe 3 — Steady state (AUC0-tau, Cmax,ss, Cmin,ss, Cavg,ss)
@@ -83,7 +85,7 @@ intervals <- data.frame(
   ctau     = TRUE    # concentration at end of interval
 )
 
-res <- pk.nca(PKNCAdata(conc_obj, dose_obj, intervals = intervals))
+res <- PKNCA::pk.nca(PKNCA::PKNCAdata(conc_obj, dose_obj, intervals = intervals))
 ```
 
 ## Recipe 4 — Multiple-dose with accumulation
@@ -98,7 +100,7 @@ intervals <- data.frame(
   auclast  = TRUE
 )
 
-res <- pk.nca(PKNCAdata(conc_obj, dose_obj, intervals = intervals))
+res <- PKNCA::pk.nca(PKNCA::PKNCAdata(conc_obj, dose_obj, intervals = intervals))
 # Accumulation ratio = AUC0-tau at SS / AUC0-tau after first dose
 ```
 
@@ -112,9 +114,9 @@ baseline weight band), join the group metadata after summarizing:
 res_tbl <- as.data.frame(res$result)
 
 res_joined <- res_tbl |>
-  left_join(cohort |> select(id, weight_band), by = "id") |>
-  group_by(treatment, weight_band, PPTESTCD) |>
-  summarise(
+  dplyr::left_join(cohort |> dplyr::select(id, weight_band), by = "id") |>
+  dplyr::group_by(treatment, weight_band, PPTESTCD) |>
+  dplyr::summarise(
     median_value = median(PPORRES),
     q05          = quantile(PPORRES, 0.05),
     q95          = quantile(PPORRES, 0.95),
@@ -128,19 +130,19 @@ When the source paper reports NCA values (e.g., geometric mean with 95% CI), the
 vignette should render a side-by-side table. A simple pattern:
 
 ```r
-published <- tibble(
+published <- tibble::tibble(
   treatment   = c("50 mg", "100 mg"),
   Cmax_pub    = c(<value>, <value>),
   AUCinf_pub  = c(<value>, <value>)
 )
 
 simulated <- res_tbl |>
-  filter(PPTESTCD %in% c("cmax", "aucinf.obs")) |>
-  group_by(treatment, PPTESTCD) |>
-  summarise(value = median(PPORRES), .groups = "drop") |>
-  pivot_wider(names_from = PPTESTCD, values_from = value)
+  dplyr::filter(PPTESTCD %in% c("cmax", "aucinf.obs")) |>
+  dplyr::group_by(treatment, PPTESTCD) |>
+  dplyr::summarise(value = median(PPORRES), .groups = "drop") |>
+  tidyr::pivot_wider(names_from = PPTESTCD, values_from = value)
 
-comparison <- published |> left_join(simulated, by = "treatment")
+comparison <- published |> dplyr::left_join(simulated, by = "treatment")
 knitr::kable(comparison)
 ```
 
@@ -148,11 +150,15 @@ Flag any differences > 20% in the narrative; do not tune parameters to match.
 
 ## Common pitfalls
 
-- **Missing treatment grouping** — if the formula is `conc ~ time | id` with no
-  `/ treatment`, PKNCA aggregates across dose groups and the Cmax / AUC results
-  are uninterpretable. Always include the grouping.
+- **Missing treatment grouping** — if the formula is `Cc ~ time | id` with no
+  treatment, PKNCA aggregates across dose groups and the Cmax / AUC results
+  are uninterpretable. Always include the treatment grouping, and put it
+  **before** `id` (`Cc ~ time | treatment + id`).
+- **Renaming `Cc` to `conc`** — keep the column named `Cc` (same as the
+  observation variable in the nlmixr2 model) rather than renaming it to
+  `conc`. Same for dose: keep `amt`, not `dose`.
 - **Dose units ≠ concentration units** — PKNCA doesn't check. Confirm dose is
-  in the same mass unit as `conc × volume` implied by the model (e.g., mg vs.
+  in the same mass unit as `Cc × volume` implied by the model (e.g., mg vs.
   ng × L).
 - **`lambda.z` warnings** — PKNCA will emit warnings when there aren't enough
   post-peak points. That's informational; if the paper used a specific

--- a/.claude/skills/extract-literature-model/references/verification-checklist.md
+++ b/.claude/skills/extract-literature-model/references/verification-checklist.md
@@ -1,0 +1,77 @@
+# Verification checklist
+
+After the first-pass model file is written, re-read the source independently and walk through every item below. Each item has a failure mode that has caused real translation errors in the past. Fix everything you can; **flag anything ambiguous to the user** using this format:
+
+> Ambiguity at [source location]. Two plausible interpretations: (A) …, (B) …. Which applies?
+
+Do not silently resolve ambiguity. Do not tune parameters to make a validation output match a target — if the validation disagrees with the paper, investigate the source, not the parameters.
+
+## A. Parameter values
+
+- [ ] Every parameter in `ini()` has an in-file trailing comment pointing to the source location (table, equation, page, or figure). Re-check each comment matches what the source actually says.
+- [ ] Values are **final estimates**, not initial estimates. Supplement NONMEM control streams often list initial values in `$THETA` and `$OMEGA`; the final values come from the `$TABLE` output or the main paper. If the only source is a control stream, confirm the values match any published point estimates.
+- [ ] **Log-vs-linear reporting.** NONMEM often reports THETAs on the estimation scale (already log), but tables in the paper usually show the back-transformed value. A `log()` wrapper in `ini()` must match what the paper reports: `lcl <- log(0.0388)` is correct when the paper says "CL = 0.0388 L/day."
+- [ ] **CV% vs. variance.** `omega²` in NONMEM output is the variance on the internal scale. For log-normal parameters, CV% relates via `omega² = log(CV² + 1)`. Do not paste CV% directly into `ini()` as if it were a variance.
+- [ ] **Correlated IIV.** If the paper reports a correlation `r` and individual CV%, the covariance is `cov = r × sqrt(var_1 × var_2)`. Verify the block matrix entries match this formula.
+- [ ] **Fixed parameters** the source holds fixed are wrapped in `fixed(...)` in `ini()`.
+
+## B. Structural model
+
+- [ ] The number of compartments matches the source.
+- [ ] ODEs (or `linCmt()` shortcut) reproduce the equations shown in the paper.
+- [ ] **Reference weight / age** for allometric and maturation terms matches the source (70 kg adult? 75 kg? 5 kg infant? 40 weeks PMA? term birth?).
+- [ ] **Allometric exponents** apply to the right parameters (usually 0.75 for CL/Q and 1.0 for volumes, but papers often fit custom exponents — use whatever the paper reports).
+- [ ] **Maturation form** matches the paper (sigmoidal asymptotic vs. Hill-type vs. exponential). The functional form determines whether `beta_cl` is "fraction mature at birth" or something else.
+- [ ] **Bioavailability** (`f(depot) <- ...`) applied to the correct compartment. `F1` in NONMEM sometimes targets a different compartment than you'd expect.
+- [ ] **Lag time / Tlag**, transit compartments, and zero-order absorption phases match the source.
+- [ ] **Units consistency.** Dose units × bioavailability ÷ volume units must yield the concentration units declared in `units`. Walk through the dimensional analysis at least once.
+
+## C. Covariate effects
+
+- [ ] Every covariate used in `model()` is registered in `references/covariate-columns.md` with a canonical name, or the PR adds a new entry.
+- [ ] Source column names different from the canonical names are recorded in `covariateData[[name]]$source_name` and any value transformation (e.g., `SEXM → SEXF` inverts values and flips the effect sign) is documented in `notes`.
+- [ ] **Reference categories** for categorical effects match the paper (especially after composite race groups like `RACE_BLACK_OTH` — the reference is everyone NOT in the composite).
+- [ ] **Effect form** is correct: multiplicative (`1 + e × COV`), power (`COV^e`), or exponential (`exp(e × COV)`). The form determines what `e` means.
+- [ ] **Continuous covariates** are centered / normalized the way the paper describes (e.g., `WT / 70`, `AGE / 40`, `PAGE - 40/4.35`). The skill uses the paper's convention even when it's not "round."
+- [ ] **Time-varying vs. time-fixed.** Covariates declared time-varying in the source (e.g., `WT`, `PAGE`, `PNA`) must be supplied at every time point in the event dataset. Fixed covariates (e.g., `GA`) are one-per-subject.
+
+## D. Error model
+
+- [ ] Residual error form matches the paper: proportional, additive, combined, or log-additive. NONMEM "additive on log-scale" = proportional in linear space for nlmixr2.
+- [ ] Error magnitude units match the concentration units (e.g., `addSd = 0.231 ug/mL` only if `units$concentration = "ug/mL"`).
+- [ ] Conditional error models (different error by study or assay, like `Cirincione_2017_exenatide`, `Kyhl_2016_nalmefene`) use the `| condition` syntax and the condition variable is in `covariateData`.
+
+## E. File plumbing
+
+- [ ] File path is `inst/modeldb/<category>/<FirstAuthor>_<Year>_<drug>.R`.
+- [ ] Function name inside the file **equals** the filename minus `.R`. `buildModelDb()` rejects mismatches.
+- [ ] `description`, `reference`, `units`, `covariateData`, `population` all present before `ini()`.
+- [ ] `population` uses the extensible schema documented in `naming-conventions.md`; any paper-specific keys are allowed.
+- [ ] No stray `#!` instruction comments from the template remain.
+
+## F. Sanity simulations
+
+- [ ] Running `readModelDb("<model>")` returns without error.
+- [ ] `rxode2::rxSolve(mod, events)` produces non-NaN, non-negative concentrations across the relevant time window.
+- [ ] Simulated Cmax, AUC, and half-life are within ~20% of published values for a typical dose in a typical subject. Larger discrepancies: investigate, don't tune.
+- [ ] A simulated VPC visually resembles the paper's VPC (dose-proportional scaling, right terminal slope, reasonable spread).
+
+## G. Registration
+
+- [ ] `nlmixr2lib::buildModelDb()` runs to completion.
+- [ ] The new model appears in `modellib()`.
+- [ ] `devtools::check()` passes (warnings OK to discuss; errors are blocking).
+- [ ] Vignette builds cleanly.
+- [ ] `NEWS.md` entry added.
+
+## Common escalations
+
+Ask the user when:
+
+- Parameters look like initial estimates, not final values, and no final-estimate table is available.
+- The source paper uses a covariate encoding that conflicts with an existing registered name (e.g., inverted sex convention) and a value transformation is required.
+- A new covariate is needed that isn't in `references/covariate-columns.md`.
+- The source defines multiple non-hierarchical models and it's unclear which to implement.
+- The simulation disagrees with a published figure or NCA table by more than ~20%.
+- Units in the source are ambiguous (e.g., "CL = 38.8" without units stated in the immediate context).
+- The source uses a parameterization that doesn't map cleanly to nlmixr2 (e.g., custom residual-error shapes that require `add() + prop() + lnorm()` combinations).

--- a/.claude/skills/extract-literature-model/references/vignette-template.md
+++ b/.claude/skills/extract-literature-model/references/vignette-template.md
@@ -35,6 +35,18 @@ library(ggplot2)
 
 * Citation: `r rxode2::rxode(readModelDb("<FirstAuthor>_<Year>_<drug>"))$reference`
 * Description: `r rxode2::rxode(readModelDb("<FirstAuthor>_<Year>_<drug>"))$description`
+* Article: [<Journal short citation>](<direct DOI or publisher URL>)
+
+<!--
+Always include a direct link to the original article (DOI preferred) so readers
+can jump to the source without searching for the citation. If a free
+supplementary document exists (open access supplement, regulatory review,
+author-hosted preprint), add additional lines for each. Examples:
+
+* Article: <https://doi.org/10.1002/cpt.3447>
+* Supplement: <https://doi.org/10.1002/cpt.3447-sup-0001>
+-->
+
 
 # Population
 
@@ -132,19 +144,19 @@ compared against any per-group values reported in the source paper. See
 steady-state, multiple-dose, and sparse-sampling cases.
 
 ```{r pknca}
-# Concentrations
+# Concentrations — keep the column named Cc (nlmixr2lib convention)
 sim_nca <- sim |>
-  filter(!is.na(Cc)) |>
-  transmute(id, time, conc = Cc, treatment)
+  dplyr::filter(!is.na(Cc)) |>
+  dplyr::select(id, time, Cc, treatment)
 
-conc_obj <- PKNCA::PKNCAconc(sim_nca, conc ~ time | id / treatment)
+conc_obj <- PKNCA::PKNCAconc(sim_nca, Cc ~ time | treatment + id)
 
-# Doses — one row per dose event per subject
+# Doses — one row per dose event per subject; keep the column named amt
 dose_df <- events |>
-  filter(evid == 1) |>
-  transmute(id, time, dose = amt, treatment)
+  dplyr::filter(evid == 1) |>
+  dplyr::select(id, time, amt, treatment)
 
-dose_obj <- PKNCA::PKNCAdose(dose_df, dose ~ time | id / treatment)
+dose_obj <- PKNCA::PKNCAdose(dose_df, amt ~ time | treatment + id)
 
 # Intervals: what parameters to compute, over what time window
 intervals <- data.frame(
@@ -181,10 +193,14 @@ match.>
 
 ## Notes
 
-- PKNCA formulas must include the `| id/treatment` grouping (or `| id/cohort`,
-  `| id/regimen` — whatever stratification the source paper uses). Omitting the
-  treatment grouping collapses all subjects into a single group and defeats the
-  comparison against per-group published values.
+- PKNCA formulas must include a treatment grouping (`| treatment + id`, or
+  `| cohort + id`, `| regimen + id` — whatever stratification the source paper
+  uses). The treatment grouping variable goes **before** `id` so summaries roll
+  up per treatment. Omitting the grouping collapses all subjects into a single
+  group and defeats the comparison against per-group published values.
+- Keep the column named `Cc` (observation variable in nlmixr2 models), not
+  `conc`. Keep dose named `amt`, not `dose`. This matches the rest of the
+  nlmixr2lib / rxode2 pipeline.
 - For endogenous / turnover models (where NCA isn't the right validation),
   replace the PKNCA section with:
   - baseline recovery (simulate with drug removed and confirm return to

--- a/.claude/skills/extract-literature-model/references/vignette-template.md
+++ b/.claude/skills/extract-literature-model/references/vignette-template.md
@@ -1,0 +1,198 @@
+# Validation vignette template
+
+File path: `vignettes/<FirstAuthor>_<Year>_<drug>.Rmd`.
+
+A validation vignette has two jobs:
+
+1. **Verification trail** — document exactly where each model equation and parameter came from.
+2. **Validation** — show that a simulation from the packaged model reproduces published results (usually one or more figures and an NCA table) using **PKNCA** for NCA parameters.
+
+Use this template as a starting point. Every section is required unless marked optional.
+
+## Template
+
+````markdown
+---
+title: "<FirstAuthor>_<Year>_<drug>"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{<FirstAuthor>_<Year>_<drug>}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include = FALSE}
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
+library(nlmixr2lib)
+library(PKNCA)
+library(rxode2)
+library(dplyr)
+library(tidyr)
+library(ggplot2)
+```
+
+# Model and source
+
+* Citation: `r rxode2::rxode(readModelDb("<FirstAuthor>_<Year>_<drug>"))$reference`
+* Description: `r rxode2::rxode(readModelDb("<FirstAuthor>_<Year>_<drug>"))$description`
+
+# Population
+
+<One or two paragraphs summarizing the study population that informed the model:
+N subjects, age / weight range, sex balance, race / ethnicity distribution,
+disease state, dose levels, regions, and any relevant baseline characteristics.
+Cite the source Table that lists baseline demographics.>
+
+The same information is available programmatically via the model's `population`
+metadata (`readModelDb("<model>")$population` after the model is loaded).
+
+# Source trace
+
+The per-parameter origin is recorded as an in-file comment next to each `ini()`
+entry in `inst/modeldb/<category>/<FirstAuthor>_<Year>_<drug>.R`. The table
+below collects them in one place for review.
+
+| Equation / parameter | Value | Source location |
+|----------------------|-------|-----------------|
+| `<param1>`           | `<value>` | <Table / equation / page / figure of the source> |
+| `<param2>`           | `<value>` | <...> |
+| `<equation: d/dt(central)>` | n/a | <Equation 3, page X> |
+| ...                  | ...     | ... |
+
+# Virtual cohort
+
+Original observed data are not publicly available. The figures below use virtual
+populations whose covariate distributions approximate the published trial
+demographics.
+
+```{r cohort}
+set.seed(<seed>)
+n_subj <- <integer>
+
+# Build a cohort whose covariate distributions match the `population` metadata.
+# Use helper functions (WHO weight curves, allometric-scaled baselines, etc.) where relevant.
+# Include: ID, TIME, AMT, EVID, CMT, DV, and every covariate the model consumes.
+cohort <- tibble(
+  id    = seq_len(n_subj),
+  # ... covariate columns by canonical name (see references/covariate-columns.md)
+)
+
+# Build an event table: doses + sampling times.
+events <- cohort |>
+  # expand into dosing and observation rows
+  ...
+```
+
+# Simulation
+
+```{r simulate}
+mod <- readModelDb("<FirstAuthor>_<Year>_<drug>")
+sim <- rxode2::rxSolve(mod, events = events)
+```
+
+For deterministic replication (reproducing Figure N without between-subject
+variability), zero out the random effects:
+
+```{r simulate-typical, eval = FALSE}
+mod_typical <- mod |> rxode2::zeroRe()
+sim_typical <- rxode2::rxSolve(mod_typical, events = events)
+```
+
+# Replicate published figures
+
+Name each figure block with the source figure number so reviewers can pair them
+up at a glance.
+
+```{r figure-4}
+# Replicates Figure 4 of <Author Year>: VPC of Cc vs. time by dose group.
+sim |>
+  group_by(time, treatment) |>
+  summarise(
+    Q05 = quantile(Cc, 0.05, na.rm = TRUE),
+    Q50 = quantile(Cc, 0.50, na.rm = TRUE),
+    Q95 = quantile(Cc, 0.95, na.rm = TRUE),
+    .groups = "drop"
+  ) |>
+  ggplot(aes(time, Q50)) +
+  geom_ribbon(aes(ymin = Q05, ymax = Q95), alpha = 0.25) +
+  geom_line() +
+  facet_wrap(~treatment) +
+  scale_y_log10() +
+  labs(x = "Time (<unit>)", y = "Cc (<unit>)",
+       title = "Figure 4 — VPC by dose group",
+       caption = "Replicates Figure 4 of <Author Year>.")
+```
+
+# PKNCA validation
+
+Use PKNCA for Cmax, Tmax, AUC, and half-life. **Always include a treatment
+grouping variable** (dose group, cohort, regimen) so the results can be
+compared against any per-group values reported in the source paper. See
+`references/pknca-recipes.md` for recipes covering single-dose,
+steady-state, multiple-dose, and sparse-sampling cases.
+
+```{r pknca}
+# Concentrations
+sim_nca <- sim |>
+  filter(!is.na(Cc)) |>
+  transmute(id, time, conc = Cc, treatment)
+
+conc_obj <- PKNCA::PKNCAconc(sim_nca, conc ~ time | id / treatment)
+
+# Doses — one row per dose event per subject
+dose_df <- events |>
+  filter(evid == 1) |>
+  transmute(id, time, dose = amt, treatment)
+
+dose_obj <- PKNCA::PKNCAdose(dose_df, dose ~ time | id / treatment)
+
+# Intervals: what parameters to compute, over what time window
+intervals <- data.frame(
+  start       = 0,
+  end         = Inf,
+  cmax        = TRUE,
+  tmax        = TRUE,
+  aucinf.obs  = TRUE,
+  half.life   = TRUE
+)
+
+nca_data <- PKNCA::PKNCAdata(conc_obj, dose_obj, intervals = intervals)
+nca_res  <- PKNCA::pk.nca(nca_data)
+
+nca_summary <- summary(nca_res)
+knitr::kable(nca_summary, caption = "Simulated NCA parameters by dose group.")
+```
+
+## Comparison against published NCA
+
+<If the source paper reports NCA parameters (e.g., mean Cmax and AUC by dose
+group in a Table), reproduce that table side-by-side with the simulated values
+here. Note any differences > 20% and investigate — do not tune parameters to
+match.>
+
+# Assumptions and deviations
+
+- <Any distributional assumption you had to make because the paper did not
+  specify, e.g., "Race distribution set to X% White / Y% Black to match Table 1."
+- <Any simplification, e.g., "Time-varying weight held constant at the baseline
+  z-score over the follow-up window."
+- <Any parameter the paper did not publish, and what was used instead.>
+````
+
+## Notes
+
+- PKNCA formulas must include the `| id/treatment` grouping (or `| id/cohort`,
+  `| id/regimen` — whatever stratification the source paper uses). Omitting the
+  treatment grouping collapses all subjects into a single group and defeats the
+  comparison against per-group published values.
+- For endogenous / turnover models (where NCA isn't the right validation),
+  replace the PKNCA section with:
+  - baseline recovery (simulate with drug removed and confirm return to
+    `css` within the reported time)
+  - turnover / steady-state check (integrate long enough to verify the
+    reported steady-state concentration)
+- For multi-output models (e.g., parent + metabolite, or plasma + tissue),
+  run one PKNCA block per output, each with its own `conc ~ time | id/treatment`.
+- `rxode2::zeroRe()` is helpful when the published figure is a typical-value
+  prediction rather than a VPC. Simulating with between-subject variability
+  always, then plotting percentiles, matches VPC-style figures.

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ inst/doc
 docs
 *-nonmem
 .Rproj.user
+.claude/settings.local.json
+.claude/worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,43 @@
+# nlmixr2lib — Claude project notes
+
+This file gives AI coding assistants a fast orientation to the repository. Human contributors should read `vignettes/create-model-library.Rmd` for the full conventions and the README for a project overview.
+
+## What this package is
+
+`nlmixr2lib` is a model library for `nlmixr2`. It ships curated pharmacometric models (PK, PD, endogenous, therapeutic-area-specific) that users can load by name and combine or modify.
+
+## Layout highlights
+
+- `inst/modeldb/` — every distributed model, organized by category (`specificDrugs/`, `endogenous/`, `pharmacokinetics/`, `pharmacodynamics/`, `therapeuticArea/`). The function name inside each `.R` file must match the filename.
+- `R/modeldb.R` — the registry-building machinery (`buildModelDb()`, `readModelDb()`, `modellib()`).
+- `vignettes/` — validation vignettes, one per published model.
+- `vignettes/create-model-library.Rmd` — the canonical naming conventions document.
+
+## Skills
+
+Repo-scoped skills live under `.claude/skills/`:
+
+- **`extract-literature-model`** — guided workflow for extracting a pharmacometric model from a scientific source (journal article, supplement, poster, regulatory document) into the package. Use when a user provides a paper and asks to add the model. See `.claude/skills/extract-literature-model/SKILL.md`.
+
+The skill's `references/` folder contains the templates and standards it enforces. The authoritative covariate-column register is `.claude/skills/extract-literature-model/references/covariate-columns.md` — consult it before introducing any new covariate column.
+
+## Conventions (quick reference)
+
+For full details see `vignettes/create-model-library.Rmd` and `.claude/skills/extract-literature-model/references/naming-conventions.md`.
+
+- Compartments: `depot`, `central`, `peripheral1`, `peripheral2`, `effect`. Observation: `Cc`.
+- PK parameters (log-scale): `lka`, `lcl`, `lvc`, `lvp`, `lq`, `lfdepot`; derived `ka`, `cl`, `vc`, `vp`, `q`, `kel`, `k12`, etc.
+- IIV: `eta` + transformed name (`etalcl`, `etalvc`). Use `etalcl` even when the paper used `etacl`.
+- Residual error: `propSd`, `addSd`; multi-output prefixes with the output (`CcpropSd`).
+- Covariate columns: canonical names in `covariate-columns.md`. Standardized choices include `SEXF` (1 = female), `ADA_POS` (1 = ADA-positive), and a `RACE_<GROUP>` prefix for race indicators.
+
+## Git workflow
+
+- Never push directly to `main`. Always branch and open a PR.
+- Before regenerating `data/modeldb.rda` / `inst/modeldb.qs2`, sync with `origin/main` so upstream additions aren't clobbered.
+- `nlmixr2lib::buildModelDb()` regenerates the registry; commit the regenerated artifacts alongside the model file and vignette.
+
+## Testing
+
+- `devtools::check()` must pass. Model files are validated via `buildModelDb()` (filename ↔ function-name match, parseable `ini()` / `model()`).
+- Vignettes must build cleanly; they use `PKNCA` (in `Suggests`) for NCA validation.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,6 +35,7 @@ Suggests:
     covr,
     dplyr,
     knitr,
+    PKNCA,
     rmarkdown,
     testthat (>= 3.0.0),
     qs2,


### PR DESCRIPTION
Codifies the workflow for extracting pharmacometric models from scientific literature into nlmixr2lib. Standardizes on SEXF, ADA_POS, and RACE_<GROUP> covariate names and on `eta<transformed>` IIV naming; existing model files are not modified. Adds PKNCA to Suggests for vignette-based NCA validation.