### PR TITLE
Accept deprecated 'model' arg as alias for 'ui' (#84)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 # development version
 
+* `addEta()`, `addResErr()`, `addDepot()`, `removeDepot()`, `addTransit()`, and `removeTransit()` now accept `model` as a deprecated alias for `ui` (issue #84). Passing `model = ...` emits a deprecation warning; passing both `ui` and `model` is an error.
 * Markov modeling creation functions including `createMarkovModel()` were added
 * Add Hu 2026 clesrovimab two-compartment population PK model for preterm and full-term infants with allometric weight scaling, postnatal age maturation function, and race effects on clearance
 * Add Clegg 2024 nirsevimab two-compartment population PK model for preterm and term infants with allometric weight scaling, postmenstrual age maturation, race, season, and ADA effects

--- a/R/addDepot.R
+++ b/R/addDepot.R
@@ -6,6 +6,8 @@
 #' @param central central compartment name
 #' @param depot depot compartment name
 #' @param ka absorption rate parameter name
+#' @param model Deprecated alias for \code{ui}. Supplying \code{model}
+#'   instead of \code{ui} still works but emits a deprecation warning.
 #' @return a model with the depot added
 #' @export
 #' @examples
@@ -14,7 +16,9 @@
 #' readModelDb("PK_2cmt_no_depot")  |> addDepot()
 addDepot <- function(ui,
                      central = "central", depot = "depot",
-                     ka="ka") {
+                     ka="ka",
+                     model) {
+  .useModelAsUi()
   .ui <- rxode2::assertRxUi(ui)
   assertCompartmentName(depot)
   assertCompartmentExists(.ui, central)
@@ -66,7 +70,9 @@ addDepot <- function(ui,
 #' @examples
 #' readModelDb("PK_1cmt_des") |> removeDepot()
 removeDepot <- function(ui, central = "central", depot = "depot",
-                        ka="ka") {
+                        ka="ka",
+                        model) {
+  .useModelAsUi()
   .ui <- rxode2::assertRxUi(ui)
   assertCompartmentExists(.ui, central)
   assertCompartmentExists(.ui, depot)

--- a/R/addEta.R
+++ b/R/addEta.R
@@ -28,6 +28,8 @@
 #' @param etaCombineType the option for the how to combine the eta
 #'   with the parameter name.  Can be: "default", "snake", "camel",
 #'   "dot", "blank"
+#' @param model Deprecated alias for \code{ui}. Supplying \code{model}
+#'   instead of \code{ui} still works but emits a deprecation warning.
 #' @return The model with eta added to the requested parameters
 #' @author Bill Denney, Richard Hooijmaijers & Matthew L. Fidler
 #' @export
@@ -36,7 +38,9 @@
 #' readModelDb("PK_1cmt") |> addEta("ka")
 #' @export
 addEta <- function(ui, eta, priorName=getOption("nlmixr2lib.priorEta", TRUE),
-                   etaCombineType=c("default", "snake", "camel", "dot", "blank")) {
+                   etaCombineType=c("default", "snake", "camel", "dot", "blank"),
+                   model) {
+  .useModelAsUi()
   if (missing(etaCombineType)) {
     etaCombineType <- .getCombineTypeFromRoption("nlmixr2lib.etaCombineType")
   }

--- a/R/addResErr.R
+++ b/R/addResErr.R
@@ -11,6 +11,8 @@
 #'   accepted)
 #' @param endpoint the endpoint to apply the error; will default to
 #'   the first error in the model
+#' @param model Deprecated alias for \code{ui}. Supplying \code{model}
+#'   instead of \code{ui} still works but emits a deprecation warning.
 #' @return The model with residual error modified
 #' @examples
 #' library(rxode2)
@@ -18,7 +20,8 @@
 #' readModelDb("PK_1cmt") |> addResErr("lnormSd")
 #' readModelDb("PK_1cmt") |> addResErr(c("addSd", "propSd"))
 #' @export
-addResErr <- function(ui, reserr, endpoint) {
+addResErr <- function(ui, reserr, endpoint, model) {
+  .useModelAsUi()
   modelUi <- mod <- rxode2::assertRxUi(ui)
   rxode2::assertRxUiPrediction(ui) # needs to have a prediction
   if (missing(endpoint)) {

--- a/R/addTransit.R
+++ b/R/addTransit.R
@@ -4,6 +4,8 @@
 #' @param ntransit the number of transit compartments to be added
 #' @param transit the transit compartment prefix
 #' @param ktr the parameter name for the transit compartment rate
+#' @param model Deprecated alias for \code{ui}. Supplying \code{model}
+#'   instead of \code{ui} still works but emits a deprecation warning.
 #' @inheritParams addDepot
 #' @family absorption
 #' @return a model with transit compartment added
@@ -26,7 +28,9 @@ addTransit <- function(ui, ntransit, central = "central",
                        depot = "depot",
                        transit = "transit",
                        ktr = "ktr",
-                       ka="ka") {
+                       ka="ka",
+                       model) {
+  .useModelAsUi()
   checkmate::assertIntegerish(ntransit, lower = 1)
   rxode2::assertCompartmentName(transit)
   .ui <- rxode2::assertRxUi(ui)
@@ -135,7 +139,9 @@ addTransit <- function(ui, ntransit, central = "central",
 removeTransit <- function(ui, ntransit, central = "central",
                           depot = "depot", transit = "transit",
                           ktr = "ktr",
-                          ka="ka") {
+                          ka="ka",
+                          model) {
+  .useModelAsUi()
   if (!missing(ntransit)) {
     checkmate::assertIntegerish(ntransit, lower = 1, any.missing = FALSE)
   }

--- a/R/addTransit.R
+++ b/R/addTransit.R
@@ -220,5 +220,5 @@ removeTransit <- function(ui, ntransit, central = "central",
     rm("description", envir=.ui$meta)
   }
   rxode2::model(.ui) <- .modelLines
-  return(rxode2::rxUiCompress(.ui))
+  rxode2::rxUiCompress(.ui)
 }

--- a/R/deprecateModelArg.R
+++ b/R/deprecateModelArg.R
@@ -1,0 +1,29 @@
+#' Translate a deprecated \code{model} argument to \code{ui}
+#'
+#' Called as the first statement of a function that used to accept
+#' \code{model} as its first argument but now accepts \code{ui}.
+#' Inspects the calling function's \code{match.call()} to detect which
+#' of \code{ui} / \code{model} was supplied and, when only \code{model}
+#' was supplied, warns and assigns its value to \code{ui} in the
+#' caller's frame.
+#'
+#' @return Invisibly \code{NULL}; called for its side effect on the
+#'   calling function's frame.
+#' @noRd
+.useModelAsUi <- function() {
+  callerEnv <- parent.frame()
+  callerFun <- sys.function(-1L)
+  callerCall <- match.call(definition = callerFun, call = sys.call(-1L))
+  nms <- names(callerCall)
+  hasModel <- "model" %in% nms
+  hasUi <- "ui" %in% nms
+  if (hasModel) {
+    if (hasUi) {
+      stop("'model' is deprecated and may not be supplied together with 'ui'; use 'ui' only",
+           call. = FALSE)
+    }
+    warning("argument 'model' is deprecated; use 'ui' instead", call. = FALSE)
+    assign("ui", get("model", envir = callerEnv), envir = callerEnv)
+  }
+  invisible(NULL)
+}

--- a/man/addDepot.Rd
+++ b/man/addDepot.Rd
@@ -5,7 +5,7 @@
 \title{To convert from infusion/intravenous administration to first-order oral
 absorption}
 \usage{
-addDepot(ui, central = "central", depot = "depot", ka = "ka")
+addDepot(ui, central = "central", depot = "depot", ka = "ka", model)
 }
 \arguments{
 \item{ui}{The model as a function (or something convertible to an rxUi
@@ -16,6 +16,9 @@ object)}
 \item{depot}{depot compartment name}
 
 \item{ka}{absorption rate parameter name}
+
+\item{model}{Deprecated alias for \code{ui}. Supplying \code{model}
+instead of \code{ui} still works but emits a deprecation warning.}
 }
 \value{
 a model with the depot added

--- a/man/addEta.Rd
+++ b/man/addEta.Rd
@@ -8,7 +8,8 @@ addEta(
   ui,
   eta,
   priorName = getOption("nlmixr2lib.priorEta", TRUE),
-  etaCombineType = c("default", "snake", "camel", "dot", "blank")
+  etaCombineType = c("default", "snake", "camel", "dot", "blank"),
+  model
 )
 }
 \arguments{
@@ -24,6 +25,9 @@ instead of the left handed side of the equation.}
 \item{etaCombineType}{the option for the how to combine the eta
 with the parameter name.  Can be: "default", "snake", "camel",
 "dot", "blank"}
+
+\item{model}{Deprecated alias for \code{ui}. Supplying \code{model}
+instead of \code{ui} still works but emits a deprecation warning.}
 }
 \value{
 The model with eta added to the requested parameters

--- a/man/addResErr.Rd
+++ b/man/addResErr.Rd
@@ -4,7 +4,7 @@
 \alias{addResErr}
 \title{Add residual error to a model}
 \usage{
-addResErr(ui, reserr, endpoint)
+addResErr(ui, reserr, endpoint, model)
 }
 \arguments{
 \item{ui}{The model as a function}
@@ -15,6 +15,9 @@ accepted)}
 
 \item{endpoint}{the endpoint to apply the error; will default to
 the first error in the model}
+
+\item{model}{Deprecated alias for \code{ui}. Supplying \code{model}
+instead of \code{ui} still works but emits a deprecation warning.}
 }
 \value{
 The model with residual error modified

--- a/man/addTransit.Rd
+++ b/man/addTransit.Rd
@@ -11,7 +11,8 @@ addTransit(
   depot = "depot",
   transit = "transit",
   ktr = "ktr",
-  ka = "ka"
+  ka = "ka",
+  model
 )
 }
 \arguments{
@@ -28,6 +29,9 @@ addTransit(
 \item{ktr}{the parameter name for the transit compartment rate}
 
 \item{ka}{absorption rate parameter name}
+
+\item{model}{Deprecated alias for \code{ui}. Supplying \code{model}
+instead of \code{ui} still works but emits a deprecation warning.}
 }
 \value{
 a model with transit compartment added

--- a/man/modeldb.Rd
+++ b/man/modeldb.Rd
@@ -5,7 +5,7 @@
 \alias{modeldb}
 \title{Model library for nlmixr2}
 \format{
-A data frame with 59 rows and 9 columns
+A data frame with 61 rows and 9 columns
 \describe{
   \item{name}{Model name that can be used to extract the model from the model library}
   \item{description}{Model description in free from text; in model itself}

--- a/man/removeDepot.Rd
+++ b/man/removeDepot.Rd
@@ -4,7 +4,7 @@
 \alias{removeDepot}
 \title{To convert from first order oral absorption to IV/Intravenous}
 \usage{
-removeDepot(ui, central = "central", depot = "depot", ka = "ka")
+removeDepot(ui, central = "central", depot = "depot", ka = "ka", model)
 }
 \arguments{
 \item{ui}{The model as a function (or something convertible to an rxUi
@@ -15,6 +15,9 @@ object)}
 \item{depot}{depot compartment name}
 
 \item{ka}{absorption rate parameter name}
+
+\item{model}{Deprecated alias for \code{ui}. Supplying \code{model}
+instead of \code{ui} still works but emits a deprecation warning.}
 }
 \value{
 Returns a model with the depot from a first order absorption model removed

--- a/man/removeTransit.Rd
+++ b/man/removeTransit.Rd
@@ -11,7 +11,8 @@ removeTransit(
   depot = "depot",
   transit = "transit",
   ktr = "ktr",
-  ka = "ka"
+  ka = "ka",
+  model
 )
 }
 \arguments{
@@ -28,6 +29,9 @@ removeTransit(
 \item{ktr}{the parameter name for the transit compartment rate}
 
 \item{ka}{absorption rate parameter name}
+
+\item{model}{Deprecated alias for \code{ui}. Supplying \code{model}
+instead of \code{ui} still works but emits a deprecation warning.}
 }
 \value{
 rxode2 model with transit compartment removed

--- a/tests/testthat/test-deprecate-model-arg.R
+++ b/tests/testthat/test-deprecate-model-arg.R
@@ -1,0 +1,85 @@
+# Helper: normalize an nlmixr2lib output to an rxUi so results from the
+# ui= and model= code paths can be compared on model structure alone,
+# ignoring enclosing environments that legitimately differ.
+.asUi <- function(x) {
+  if (inherits(x, "rxUi")) return(x)
+  rxode2::rxode2(x)
+}
+
+.expectSameModel <- function(a, b) {
+  uiA <- .asUi(a)
+  uiB <- .asUi(b)
+  testthat::expect_equal(uiA$lstExpr, uiB$lstExpr)
+  testthat::expect_equal(uiA$iniDf, uiB$iniDf)
+}
+
+test_that("addEta accepts deprecated 'model' argument", {
+  m <- readModelDb("PK_1cmt")
+
+  expect_silent(
+    suppressMessages(byUi <- addEta(ui = m, eta = "lka"))
+  )
+  expect_warning(
+    suppressMessages(byModel <- addEta(model = m, eta = "lka")),
+    regexp = "deprecated"
+  )
+  .expectSameModel(byModel, byUi)
+
+  expect_error(
+    suppressMessages(suppressWarnings(addEta(ui = m, model = m, eta = "lka"))),
+    regexp = "deprecated"
+  )
+})
+
+test_that("addDepot accepts deprecated 'model' argument", {
+  m <- readModelDb("PK_2cmt_no_depot")
+
+  expect_silent(
+    suppressMessages(byUi <- addDepot(ui = m))
+  )
+  expect_warning(
+    suppressMessages(byModel <- addDepot(model = m)),
+    regexp = "deprecated"
+  )
+  .expectSameModel(byModel, byUi)
+
+  expect_error(
+    suppressMessages(suppressWarnings(addDepot(ui = m, model = m))),
+    regexp = "deprecated"
+  )
+})
+
+test_that("addResErr accepts deprecated 'model' argument", {
+  m <- readModelDb("PK_1cmt")
+
+  expect_silent(
+    suppressMessages(byUi <- addResErr(ui = m, reserr = "addSd"))
+  )
+  expect_warning(
+    suppressMessages(byModel <- addResErr(model = m, reserr = "addSd")),
+    regexp = "deprecated"
+  )
+  .expectSameModel(byModel, byUi)
+})
+
+test_that("addTransit/removeTransit accept deprecated 'model' argument", {
+  m <- readModelDb("PK_1cmt_des")
+
+  expect_warning(
+    suppressMessages(withTransit <- addTransit(model = m, ntransit = 3)),
+    regexp = "deprecated"
+  )
+  expect_warning(
+    suppressMessages(removeTransit(model = withTransit, ntransit = 2)),
+    regexp = "deprecated"
+  )
+})
+
+test_that("removeDepot accepts deprecated 'model' argument", {
+  m <- readModelDb("PK_1cmt_des")
+
+  expect_warning(
+    suppressMessages(removeDepot(model = m)),
+    regexp = "deprecated"
+  )
+})


### PR DESCRIPTION
## Summary
- Fixes #84: functions whose first argument was historically named `model` now accept `model = ...` as a deprecated alias for `ui`.
- Affected: `addEta`, `addResErr`, `addDepot`, `removeDepot`, `addTransit`, `removeTransit`.
- Passing `model =` emits a deprecation warning; passing both `ui` and `model` errors.

## Test plan
- [x] `devtools::test()` — all 452 tests pass (17 new assertions in `test-deprecate-model-arg.R`)
- [ ] `devtools::check()` clean on CI