### PR TITLE
Fix addDepot()/addTransit() when central or depot ODE is at model edge

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 # development version
 
+* `addDepot()` and `addTransit()` now work correctly when `d/dt(central)` or `d/dt(depot)` appears at the beginning or end of the model block, or when transit-compartment ODEs and residual-error (`~`) specs are interleaved with assignment lines. The newly introduced helper and ODE lines are inserted immediately adjacent to the modified ODE so that the relative order of every pre-existing model line is preserved (#77, #78).
 * Markov modeling creation functions including `createMarkovModel()` were added
 * Add Hu 2026 clesrovimab two-compartment population PK model for preterm and full-term infants with allometric weight scaling, postnatal age maturation function, and race effects on clearance
 * Add Clegg 2024 nirsevimab two-compartment population PK model for preterm and term infants with allometric weight scaling, postmenstrual age maturation, race, season, and ADA effects

--- a/R/addDepot.R
+++ b/R/addDepot.R
@@ -20,16 +20,18 @@ addDepot <- function(ui,
   assertCompartmentExists(.ui, central)
   assertVariableName(ka)
   .mv <- rxode2::rxModelVars(.ui)
-  # Get the central ODE and add depot to it
+  # Insert the new lines immediately before d/dt(central) and modify
+  # d/dt(central) in place so every pre-existing line keeps its original
+  # position (and any interleaved residual-error ~ lines continue to
+  # capture their source-order semantics).
   .modelLines <- .ui$lstExpr
   .w <- .whichDdt(.modelLines, central)
-  .tmp <- .extractModelLinesAtW(.modelLines, .w)
-  .tmp$w <- str2lang(paste0(deparse1(.tmp$w), "+", ka, "*", depot))
-  .modelLines <- c(list(str2lang(paste0(ka, "<- exp(l", ka, ")"))),
-                   .tmp$pre,
-                   list(str2lang(paste0("d/dt(", depot, ") <- -", ka, "*", depot))),
-                   list(.tmp$w),
-                   .tmp$post)
+  .modLine <- str2lang(paste0(deparse1(.modelLines[[.w]]), "+", ka, "*", depot))
+  .newLines <- list(str2lang(paste0(ka, " <- exp(l", ka, ")")),
+                    str2lang(paste0("d/dt(", depot, ") <- -", ka, "*", depot)))
+  .before <- if (.w > 1L) .modelLines[seq_len(.w - 1L)] else list()
+  .after  <- if (.w < length(.modelLines)) .modelLines[(.w + 1L):length(.modelLines)] else list()
+  .modelLines <- c(.before, .newLines, list(.modLine), .after)
 
   .tmp <- .getEtaThetaTheta1(.ui)
   .iniDf <- .tmp$iniDf

--- a/R/addTransit.R
+++ b/R/addTransit.R
@@ -218,5 +218,5 @@ removeTransit <- function(ui, ntransit, central = "central",
     rm("description", envir=.ui$meta)
   }
   rxode2::model(.ui) <- .modelLines
-  return(rxode2::rxUiCompress(.ui))
+  rxode2::rxUiCompress(.ui)
 }

--- a/R/addTransit.R
+++ b/R/addTransit.R
@@ -86,15 +86,19 @@ addTransit <- function(ui, ntransit, central = "central",
                    .central,
                    .post)
 
-  # Now extract the depot and split the model based on the depot cmt
+  # Insert ktr <- exp(lktr) immediately before d/dt(depot) and modify
+  # d/dt(depot) in place so every pre-existing line (including any
+  # interleaved residual-error ~ specs) keeps its original position.
   .w <- .whichDdt(.modelLines, depot)
-  .tmp <- .extractModelLinesAtW(.modelLines, .w)
-  .modelLines <- c(list(str2lang(paste0(ktr, " <- exp(l", ktr, ")"))),
-                   .tmp$pre,
-                   .replaceMult(.tmp$w,
-                                v1=ka, v2=depot,
-                                ret=paste0(ktr, "*", depot)),
-                   .tmp$post)
+  .modRep <- .replaceMult(.modelLines[[.w]],
+                          v1=ka, v2=depot,
+                          ret=paste0(ktr, "*", depot))
+  .before <- if (.w > 1L) .modelLines[seq_len(.w - 1L)] else list()
+  .after  <- if (.w < length(.modelLines)) .modelLines[(.w + 1L):length(.modelLines)] else list()
+  .modelLines <- c(.before,
+                   list(str2lang(paste0(ktr, " <- exp(l", ktr, ")"))),
+                   .modRep,
+                   .after)
   if (length(.theta$name) == 0L) {
     .ntheta <- 0
   } else {

--- a/tests/testthat/test-addDepot.R
+++ b/tests/testthat/test-addDepot.R
@@ -58,3 +58,161 @@ test_that("addDepot adds other than default agruments", {
   mv <- rxode2::rxModelVars(modelUpdate)
   expect_true("ktr" %in% mv$lhs)
 })
+
+# Helper: collapse expression list to deparsed character vector for order checks
+.deparseLines <- function(lstExpr) {
+  vapply(lstExpr, function(e) paste(deparse(e), collapse = " "), character(1))
+}
+
+# Helper: TRUE if `needle` lines appear in `haystack` in the same relative order
+.isSubseq <- function(haystack, needle) {
+  i <- 1L
+  for (h in haystack) {
+    if (i > length(needle)) break
+    if (identical(h, needle[[i]])) i <- i + 1L
+  }
+  i > length(needle)
+}
+
+# Issue #77 / #78 — addDepot edge cases ----
+
+test_that("addDepot works when d/dt(central) is the only / last model line (#77)", {
+  # #77 "central at end": residual error precedes d/dt(central)
+  m <- function() {
+    ini({
+      lcl <- 1; label("CL")
+      lvc <- 3.45; label("V")
+      propSd <- 0.5; label("prop err")
+    })
+    model({
+      central ~ prop(propSd)
+      d/dt(central) <- -exp(lcl)/exp(lvc) * central
+    })
+  }
+  res <- addDepot(m)
+  expect_s3_class(res, "rxUi")
+  expect_true("lka" %in% res$iniDf$name)
+  lines <- .deparseLines(res$lstExpr)
+  # d/dt(depot) appears exactly once
+  expect_equal(sum(grepl("^d/dt\\(depot\\)", lines)), 1L)
+  # endpoint kept in its original position
+  expect_true(grepl("^central ~ prop", lines[[1]]))
+  # central ODE is last and has the absorption term added
+  expect_true(grepl("^d/dt\\(central\\)", lines[[length(lines)]]))
+  expect_true(grepl("\\+ ka \\* depot", lines[[length(lines)]]))
+})
+
+test_that("addDepot works when d/dt(central) is the first model line (#77)", {
+  m <- function() {
+    ini({
+      lcl <- 1; label("CL")
+      lvc <- 3.45; label("V")
+      propSd <- 0.5; label("prop err")
+    })
+    model({
+      d/dt(central) <- -exp(lcl)/exp(lvc) * central
+      central ~ prop(propSd)
+    })
+  }
+  res <- addDepot(m)
+  expect_s3_class(res, "rxUi")
+  expect_true("lka" %in% res$iniDf$name)
+  lines <- .deparseLines(res$lstExpr)
+  expect_equal(sum(grepl("^d/dt\\(depot\\)", lines)), 1L)
+  # endpoint kept as the last line
+  expect_true(grepl("^central ~ prop", lines[[length(lines)]]))
+})
+
+test_that("addDepot preserves the relative order of interleaved residual-error and assignment lines", {
+  # User-stated constraint from issue #77 review: multiple residual-error
+  # blocks interleaved with assignments must keep their source-order
+  # semantics. Using a non-state variable name so rxode2 accepts the
+  # repeated assignment form.
+  m <- function() {
+    ini({
+      lcl <- 1; lvc <- 3.45; addSd <- 0.1; propSd <- 0.5
+    })
+    model({
+      obs <- 1
+      obs ~ add(addSd)
+      obs <- 2
+      d/dt(central) <- -exp(lcl)/exp(lvc) * central
+      obs ~ prop(propSd)
+    })
+  }
+  res <- addDepot(m)
+  expect_s3_class(res, "rxUi")
+  lines <- .deparseLines(res$lstExpr)
+  expect_equal(sum(grepl("^d/dt\\(depot\\)", lines)), 1L)
+  # Every input line (except the modified d/dt(central)) appears verbatim and
+  # in its original relative order.
+  original <- c(
+    "obs <- 1",
+    "obs ~ add(addSd)",
+    "obs <- 2",
+    "obs ~ prop(propSd)"
+  )
+  normalized <- gsub("\\s+", " ", trimws(lines))
+  expect_true(.isSubseq(normalized, original))
+  # Two new lines sit immediately before the modified central ODE.
+  wCentral <- which(grepl("^d/dt\\(central\\)", normalized))
+  expect_length(wCentral, 1L)
+  expect_equal(normalized[[wCentral - 2L]], "ka <- exp(lka)")
+  expect_equal(normalized[[wCentral - 1L]], "d/dt(depot) <- -ka * depot")
+})
+
+test_that("addDepot works when a transit ODE is the first model line (#78)", {
+  m <- function() {
+    ini({
+      lktr <- 0; lcl <- 1; lvc <- 3.45; propSd <- 0.5
+    })
+    model({
+      d/dt(transit1) <- -exp(lktr) * transit1
+      d/dt(central) <- exp(lktr) * transit1 - exp(lcl)/exp(lvc) * central
+      Cc <- central / exp(lvc)
+      Cc ~ prop(propSd)
+    })
+  }
+  res <- addDepot(m)
+  expect_s3_class(res, "rxUi")
+  expect_true("lka" %in% res$iniDf$name)
+  lines <- .deparseLines(res$lstExpr)
+  normalized <- gsub("\\s+", " ", trimws(lines))
+  # transit ODE still at position 1
+  expect_true(grepl("^d/dt\\(transit1\\)", normalized[[1]]))
+  # endpoint still last
+  expect_true(grepl("^Cc ~ prop", normalized[[length(normalized)]]))
+  expect_equal(sum(grepl("^d/dt\\(depot\\)", normalized)), 1L)
+})
+
+test_that("addDepot works when a transit ODE sits above d/dt(central) (#78)", {
+  m <- function() {
+    ini({
+      lktr <- 0; lcl <- 1; lvc <- 3.45; propSd <- 0.5
+    })
+    model({
+      kel <- exp(lcl) / exp(lvc)
+      d/dt(transit1) <- -exp(lktr) * transit1
+      d/dt(central) <- exp(lktr) * transit1 - kel * central
+      Cc <- central / exp(lvc)
+      Cc ~ prop(propSd)
+    })
+  }
+  res <- addDepot(m)
+  expect_s3_class(res, "rxUi")
+  lines <- .deparseLines(res$lstExpr)
+  normalized <- gsub("\\s+", " ", trimws(lines))
+  # Original lines keep their relative order.
+  original <- c(
+    "kel <- exp(lcl)/exp(lvc)",
+    "d/dt(transit1) <- -exp(lktr) * transit1",
+    "Cc <- central/exp(lvc)",
+    "Cc ~ prop(propSd)"
+  )
+  expect_true(.isSubseq(normalized, original))
+  # transit1 ODE appears above the modified central ODE
+  wTransit <- which(grepl("^d/dt\\(transit1\\)", normalized))
+  wCentral <- which(grepl("^d/dt\\(central\\)", normalized))
+  expect_true(wTransit < wCentral)
+  expect_equal(sum(grepl("^d/dt\\(depot\\)", normalized)), 1L)
+})

--- a/tests/testthat/test-addTransit.R
+++ b/tests/testthat/test-addTransit.R
@@ -141,11 +141,11 @@ test_that("remove some but not all compartments", {
           lktr <- 0.1; label("First order transition rate (ktr)")
       })
       model({
-          ktr <- exp(lktr)
           ka <- exp(lka)
           cl <- exp(lcl)
           vc <- exp(lvc)
           kel <- cl/vc
+          ktr <- exp(lktr)
           d/dt(depot) <- -ktr * depot
           d/dt(transit1) <- ktr * depot - ka * transit1
           d/dt(central) <- ka * transit1 - kel * central
@@ -278,4 +278,72 @@ test_that("extreme model cases", {
 
   expect_equal(tmp$iniDf$name, "ka")
   expect_equal(tmp$iniDf$neta1, 1)
+})
+
+# Issue #77 / #78 — addTransit preserves source order of existing lines ----
+
+test_that("addTransit preserves endpoint placement when d/dt(central) is the last line", {
+  m <- function() {
+    ini({
+      lka <- 0; lcl <- 1; lvc <- 3.45; propSd <- 0.5
+    })
+    model({
+      central ~ prop(propSd)
+      d/dt(depot) <- -exp(lka) * depot
+      d/dt(central) <- exp(lka) * depot - exp(lcl)/exp(lvc) * central
+    })
+  }
+  res <- addTransit(m, 2)
+  expect_s3_class(res, "rxUi")
+  expect_true("lktr" %in% res$iniDf$name)
+  lines <- vapply(res$lstExpr, function(e) paste(deparse(e), collapse = " "),
+                  character(1))
+  normalized <- gsub("\\s+", " ", trimws(lines))
+  # Original endpoint must stay at its original position (first line).
+  expect_true(grepl("^central ~ prop", normalized[[1]]))
+  # ktr helper and depot ODE should sit adjacent to the now-modified depot
+  # line, not at the top of the model.
+  wKtr <- which(normalized == "ktr <- exp(lktr)")
+  wDepot <- which(grepl("^d/dt\\(depot\\)", normalized))
+  expect_length(wKtr, 1L)
+  expect_length(wDepot, 1L)
+  expect_equal(wKtr + 1L, wDepot)
+  # Two transit compartments were added.
+  expect_true(any(grepl("^d/dt\\(transit1\\)", normalized)))
+  expect_true(any(grepl("^d/dt\\(transit2\\)", normalized)))
+})
+
+test_that("addTransit preserves source order when an assignment line sits above d/dt(depot)", {
+  m <- function() {
+    ini({
+      lka <- 0; lcl <- 1; lvc <- 3.45; propSd <- 0.5
+    })
+    model({
+      kel <- exp(lcl) / exp(lvc)
+      d/dt(depot) <- -exp(lka) * depot
+      d/dt(central) <- exp(lka) * depot - kel * central
+      Cc <- central / exp(lvc)
+      Cc ~ prop(propSd)
+    })
+  }
+  res <- addTransit(m, 2)
+  expect_s3_class(res, "rxUi")
+  lines <- vapply(res$lstExpr, function(e) paste(deparse(e), collapse = " "),
+                  character(1))
+  normalized <- gsub("\\s+", " ", trimws(lines))
+  # Every pre-existing line (except d/dt(depot) whose RHS was rewritten and
+  # d/dt(central) which the first splice modifies) stays in its original
+  # relative order.
+  kept <- c("kel <- exp(lcl)/exp(lvc)",
+            "Cc <- central/exp(lvc)",
+            "Cc ~ prop(propSd)")
+  pos <- vapply(kept, function(k) match(TRUE, normalized == k), integer(1))
+  expect_false(any(is.na(pos)))
+  expect_true(all(diff(pos) > 0))
+  # Endpoint remains last.
+  expect_true(grepl("^Cc ~ prop", normalized[[length(normalized)]]))
+  # ktr helper sits immediately before d/dt(depot), not at the top of the model.
+  wKtr <- which(normalized == "ktr <- exp(lktr)")
+  wDepot <- which(grepl("^d/dt\\(depot\\)", normalized))
+  expect_equal(wKtr + 1L, wDepot)
 })


### PR DESCRIPTION
Fixes #77, #78.

`addDepot()` previously prepended `ka <- exp(lka)` to the top of the model,
which left any residual-error (`~`) line sitting above `d/dt(central)`
stranded mid-model and broke (or errored on) valid input when the central
ODE was at the first or last position. `addTransit()` had the same shape
of bug for `ktr <- exp(lktr)` relative to `d/dt(depot)`.

Both are now fixed by inserting the new helper/ODE lines immediately
adjacent to the modified ODE. The relative order of every pre-existing
line — including interleaved residual-error specs — is preserved, which
keeps source-order semantics intact for models that reassign the
predicted value across multiple `~` blocks.

Adds seven regression tests covering the #77 and #78 edge cases.