### PR TITLE
Extract-literature-model skill: preprocessor integration, checkModelC…

### DIFF
--- a/.claude/skills/extract-literature-model/SKILL.md
+++ b/.claude/skills/extract-literature-model/SKILL.md
@@ -25,13 +25,33 @@ Read these on demand; don't load them up front.
 ## Phase 1 — Source acquisition and scoping
 
 1. Confirm the source type (journal article, supplement, poster, regulatory document).
-2. **Always search for supplementary information.** Supplements frequently contain the NONMEM control stream and parameter tables that disambiguate model structure. If the user provided only a main article, ask whether a supplement exists and request it.
-3. **Always search for errata, corrigenda, or author corrections.** Check the journal's landing page for the article, the publisher's "corrections" / "notices" feed, and a search like `"<first author> <year> <drug>" erratum` on PubMed and Google Scholar. Ask the user whether they are aware of any corrections if the source is paywalled or the search is inconclusive. **When an erratum revises a value used in the model (parameter estimate, covariate effect, equation, units), the erratum value takes precedence over the main publication.** If multiple errata exist, the most recent supersedes earlier ones. Record the erratum citation in the model file's `reference` metadata alongside the main paper, and in every in-file source-trace comment whose value comes from the erratum, point to the erratum (not the original table).
-4. **Verify parameters are final estimates, not initial estimates.** Supplement control streams usually list initial values in `$THETA` / `$OMEGA`; final values come from the paper's results table or `$TABLE` output. If only a control stream is available, confirm values against any published point estimates before treating them as final.
-5. **Multiple-model handling.**
+2. **Check the study population species.** Skim the Methods / Subjects section. If every PK dataset contributing to the final model is non-human (rat, mouse, cyno, dog, etc.), stop and sidecar-ask the operator before drafting anything:
+
+   > This paper reports a preclinical-only (<species>) population PK model. nlmixr2lib is a library of human population-PK models. Should I (A) extract it anyway with clear preclinical metadata, (B) extract only a human-scaled projection if the paper includes one, or (C) skip this paper?
+
+   If the paper has both preclinical and human cohorts and the final model is fit to pooled or human-only data, proceed normally — this trigger is specifically for animal-only final models. Record the operator's decision in the PR body.
+
+3. **Prefer trimmed markdown when available.** The preprocessor at `mab_human_consensus/tracking/preprocess_papers.py` writes a `<stem>_trimmed.md` next to each source file (PMC XML, PDF, DOCX, XLSX) containing only the sections the extraction actually needs: Title + Abstract + Methods + Results + Tables + Figure captions. The Introduction, Discussion, Conclusions, References, Acknowledgments, and publisher boilerplate are stripped. If `PMID_<pmid>_pmc_trimmed.md` (or `PMID_<pmid>_trimmed.md` for a PDF, or `<stem>_trimmed.md` for a supplement) exists, read it **instead of** the raw `.xml` / `.pdf` / `.docx` — it's typically 40-95% smaller with no loss of extractable content. Full-text sanity check on the trimmed file: ~15 KB+ (full-text trim) vs < 3 KB (abstract-only trim). Fall back to the raw source only if the `_trimmed.md` doesn't exist, the trim appears to have lost a specific piece of information you need (rare — only when the paper is structurally unusual), or you explicitly need the discarded sections (e.g., to quote a Discussion claim in the vignette narrative).
+
+4. **Verify the source contains full text, not just the abstract.** Wiley / BJCP and some other publishers serve PMC XML containing only front matter + abstract. Before reading for model structure, run a quick sanity check (against the trimmed file if present, otherwise the raw source):
+
+   - Trimmed `.md` file size ≥ ~15 KB, or raw PMC XML ≥ ~40 KB (full-text XML is typically 100 KB+; abstract-only is usually < 20 KB).
+   - The file contains a materially-present Methods section (not just a "Methods" heading followed by one abstract paragraph).
+   - If only a PDF is on disk, confirm it runs past the abstract (multi-page, Methods / Results / Tables present).
+
+   If only the abstract is available, sidecar-ask:
+
+   > The source on disk for <paper> contains only the abstract and front matter; full text appears to be blocked by the publisher. Options: (A) pause this task until full text is provided, (B) proceed only if a supplement / regulatory review on disk contains the model equations and parameter tables, (C) skip this paper. Which applies?
+
+   Never attempt extraction from an abstract alone — population-PK parameter values, covariate effects, and equations are not in an abstract.
+
+5. **Always search for supplementary information.** Supplements frequently contain the NONMEM control stream and parameter tables that disambiguate model structure. If the user provided only a main article, ask whether a supplement exists and request it.
+6. **Always search for errata, corrigenda, or author corrections.** Check the journal's landing page for the article, the publisher's "corrections" / "notices" feed, and a search like `"<first author> <year> <drug>" erratum` on PubMed and Google Scholar. Ask the user whether they are aware of any corrections if the source is paywalled or the search is inconclusive. **When an erratum revises a value used in the model (parameter estimate, covariate effect, equation, units), the erratum value takes precedence over the main publication.** If multiple errata exist, the most recent supersedes earlier ones. Record the erratum citation in the model file's `reference` metadata alongside the main paper, and in every in-file source-trace comment whose value comes from the erratum, point to the erratum (not the original table).
+7. **Verify parameters are final estimates, not initial estimates.** Supplement control streams usually list initial values in `$THETA` / `$OMEGA`; final values come from the paper's results table or `$TABLE` output. If only a control stream is available, confirm values against any published point estimates before treating them as final.
+8. **Multiple-model handling.**
    - Base model + final model → extract only the final.
    - Any other "multiple model" case (per-subpopulation, per-endpoint, sensitivity analyses) → list the candidates to the user and ask which to extract. Offer "one," "all," or "a subset."
-6. Confirm the target subdirectory under `inst/modeldb/` (usually `specificDrugs/`; endogenous, therapeuticArea, pharmacokinetics, and pharmacodynamics are also valid).
+9. Confirm the target subdirectory under `inst/modeldb/` (usually `specificDrugs/`; endogenous, therapeuticArea, pharmacokinetics, and pharmacodynamics are also valid).
 
 ## Phase 2 — Sync with origin/main and branch
 
@@ -103,7 +123,7 @@ Never silently resolve ambiguity. Never tune parameter values to match a validat
 
 ## Phase 5 — Validation vignette
 
-File path: `vignettes/articles/<FirstAuthor>_<Year>_<drug>.Rmd`, with matching `VignetteIndexEntry`. Drug-specific vignettes live under `vignettes/articles/` so pkgdown builds them for the site but CRAN does not — `.Rbuildignore` excludes that directory. The basename (without `.Rmd`) must match the `vignette <- "..."` field in the model file.
+File path: `vignettes/articles/<FirstAuthor>_<Year>_<drug>.Rmd`, with matching `VignetteIndexEntry`. Drug-specific vignettes live under `vignettes/articles/` so pkgdown builds them for the site but CRAN does not — `.Rbuildignore` excludes that directory. The basename (without `.Rmd`) must match the `vignette <- "..."` field in the model file. Only the legacy `PK_2cmt_mAb_Davda_2014.Rmd` remains at top-level `vignettes/`.
 
 Use `references/vignette-template.md`. Required sections, in order:
 
@@ -135,8 +155,11 @@ Naming conventions for mechanistic parameters are documented in `references/nami
 
 1. Re-confirm the branch is on top of fresh `origin/main` (`git fetch origin && git rebase origin/main` if needed).
 2. Run `nlmixr2lib::buildModelDb()` to regenerate `data/modeldb.rda` and `inst/modeldb.qs2`. Confirm the new model appears in `modellib()`. **When verifying in R, do `devtools::load_all(".")` first so `modellib()` reads the worktree's in-development package, not the stale system install** — see `references/verification-checklist.md` § "Verifying against the worktree's nlmixr2lib" for why a bare `library(nlmixr2lib)` can return a misleading `FALSE`.
-3. Run `devtools::check()`. Vignettes must build cleanly.
-4. Add a short, single-line `NEWS.md` entry under the current development
+3. Run `nlmixr2lib::checkModelConventions(model = "<FirstAuthor>_<Year>_<drug>")` and review the output. Any deviations from the canonical parameter / IIV / residual-error / covariate / compartment conventions (see `references/naming-conventions.md` and `inst/references/covariate-columns.md`) that the function flags should be either fixed in the model file before committing, or explicitly justified in the vignette's Assumptions and deviations section. `buildModelDb()` runs `checkModelConventions()` implicitly at package-build time, but running it explicitly on your new model makes drift visible before commit, not after CI. Paste the key lines of the output into the PR body so a reviewer can see what was checked.
+4. Run `devtools::check()`. Vignettes must build cleanly.
+
+   A C-level segfault (`*** caught segfault ***`) during `check()` or vignette rendering is a red flag — it indicates a broken R / rxode2 / nlmixr2 install in the environment, not a model-file problem. Stop, sidecar-ask the operator to investigate and fix the environment, and do not work around it with `--no-build-vignettes` or similar flags.
+5. Add a short, single-line `NEWS.md` entry under the current development
    version. The goal is a scannable changelog — the model file and vignette
    already contain the full detail, so NEWS should only mention:
    - the drug,
@@ -158,8 +181,8 @@ Naming conventions for mechanistic parameters are documented in `references/nami
    residual-error form, data origin, study counts, PKNCA sentence, or
    anything else that lives in the model file's metadata or vignette. A
    reviewer who wants those details clicks through to the model file.
-5. Commit the model file, the vignette under `vignettes/articles/`, the regenerated `modeldb.rda` / `modeldb.qs2`, the `NEWS.md` entry, and any updates to `inst/references/covariate-columns.md` (if a new covariate was registered) together on the feature branch.
-6. Push the branch and open a PR against `main`. Use `gh pr create` with a title like `Add <Author> <Year> <drug> model`.
+6. Commit the model file, the vignette under `vignettes/articles/`, the regenerated `modeldb.rda` / `modeldb.qs2`, the `NEWS.md` entry, and any updates to `inst/references/covariate-columns.md` (if a new covariate was registered) together on the feature branch.
+7. Push the branch and open a PR against `main`. Use `gh pr create` with a title like `Add <Author> <Year> <drug> model`.
 
 ## Stop-and-ask triggers (consolidated)
 
@@ -174,6 +197,9 @@ Don't guess — ask the user when:
 - PKNCA output disagrees with a published NCA table by more than ~20% after careful review.
 - The source is paywalled and the user hasn't supplied the text.
 - An erratum search is inconclusive (e.g., paywalled journal, ambiguous correction notice) — ask the user to confirm whether any corrections apply.
+- The paper's final model was fit to animal-only data (see Phase 1 species-check step).
+- The PMC XML / PDF on disk contains only the paper's abstract (see Phase 1 full-text-check step).
+- `devtools::check()` or vignette rendering produces a C-level segfault — the environment is broken; do not paper over with `--no-build-vignettes` or similar.
 
 Use this fixed format for ambiguities:
 

--- a/.claude/skills/extract-literature-model/references/pknca-recipes.md
+++ b/.claude/skills/extract-literature-model/references/pknca-recipes.md
@@ -28,8 +28,16 @@ dose_df <- events |>
   dplyr::filter(evid == 1) |>
   dplyr::select(id, time, amt, treatment)
 
-conc_obj <- PKNCA::PKNCAconc(sim_nca, Cc ~ time | treatment + id)
-dose_obj <- PKNCA::PKNCAdose(dose_df, amt ~ time | treatment + id)
+# Always declare units: `concu` + `timeu` on PKNCAconc, `doseu` on PKNCAdose.
+# PKNCA uses these to do automatic unit-consistent AUC / clearance calculations;
+# without them the summary tables carry only numbers and downstream consumers
+# can't tell ng/mL from ug/mL. Use the same units that appear in the model
+# file's `units` metadata and the paper's Table footnotes.
+conc_obj <- PKNCA::PKNCAconc(sim_nca, Cc ~ time | treatment + id,
+                             concu = "<conc unit, e.g. ug/mL>",
+                             timeu = "<time unit, e.g. day>")
+dose_obj <- PKNCA::PKNCAdose(dose_df, amt ~ time | treatment + id,
+                             doseu = "<dose unit, e.g. mg>")
 
 intervals <- data.frame(
   start      = 0,
@@ -154,6 +162,14 @@ Flag any differences > 20% in the narrative; do not tune parameters to match.
   treatment, PKNCA aggregates across dose groups and the Cmax / AUC results
   are uninterpretable. Always include the treatment grouping, and put it
   **before** `id` (`Cc ~ time | treatment + id`).
+- **Missing unit declarations** — pass `concu` + `timeu` to `PKNCAconc()` and
+  `doseu` to `PKNCAdose()`. Without them, PKNCA's output is unit-blind: AUC
+  values are just numbers, clearance is not derivable, and the summary
+  tables cannot be cross-checked against the paper's own NCA values (which
+  always report units). Match the units to the model file's `units`
+  metadata (`time = "day"`, `dosing = "mg"`, `concentration = "ug/mL"` —
+  whatever the paper uses). Note that the units are strings, not R
+  objects — e.g. `concu = "ug/mL"`, not `concu = units::as_units("ug/mL")`.
 - **Renaming `Cc` to `conc`** — keep the column named `Cc` (same as the
   observation variable in the nlmixr2 model) rather than renaming it to
   `conc`. Same for dose: keep `amt`, not `dose`.
@@ -169,3 +185,18 @@ Flag any differences > 20% in the narrative; do not tune parameters to match.
   BLQ rule (e.g., M3 method), that's outside the NCA step.
 - **Time-zero records** — PKNCA expects a pre-dose record for IV or a `time = 0`
   observation for extravascular. Ensure the simulation grid includes `time = 0`.
+- **Duplicate IDs across cohorts** — when `events` is assembled from multiple
+  `make_cohort()` calls and `bind_rows`-ed together, confirm
+  `anyDuplicated(sim[, c("id", "time")]) == 0` before handing `sim` to PKNCA.
+  `rxSolve` silently collapses duplicated-ID rows into a single subject;
+  PKNCA then aggregates a single (wrong) subject as if it were the whole
+  group. Use the `id_offset` pattern in the `make_cohort` snippet in
+  `references/vignette-template.md` to keep ID ranges disjoint.
+- **Carry grouping via `rxSolve(..., keep = ...)`, not a post-hoc
+  `left_join`.** `rxSolve` accepts a `keep = c("col1", "col2")` argument
+  that attaches source columns (cohort, treatment, dose group, regimen)
+  directly to the simulation output. This is aligned per row and far
+  cleaner than joining back from `events` — a post-hoc `left_join` will
+  produce multiplied rows if any IDs collide or if rxSolve expanded
+  observation times. Round-trip `treatment` / `cohort` through `keep` and
+  PKNCA's grouping formula picks it up automatically.

--- a/.claude/skills/extract-literature-model/references/verification-checklist.md
+++ b/.claude/skills/extract-literature-model/references/verification-checklist.md
@@ -51,6 +51,7 @@ Do not silently resolve ambiguity. Do not tune parameters to make a validation o
 - [ ] Validation vignette lives at `vignettes/articles/<FirstAuthor>_<Year>_<drug>.Rmd`, and the model file's `vignette <- "..."` value matches that basename (no path, no extension). Confirm `readModelDb("<model>")$meta$vignette` returns the basename after `devtools::load_all()`.
 - [ ] `population` uses the extensible schema documented in `naming-conventions.md`; any paper-specific keys are allowed.
 - [ ] No stray `#!` instruction comments from the template remain.
+- [ ] Vignette path is `vignettes/articles/<...>.Rmd` (not top-level `vignettes/`), matching the pkgdown "articles" convention used by every non-legacy vignette in the package.
 
 ## F. Sanity simulations
 
@@ -58,6 +59,7 @@ Do not silently resolve ambiguity. Do not tune parameters to make a validation o
 - [ ] `rxode2::rxSolve(mod, events)` produces non-NaN, non-negative concentrations across the relevant time window.
 - [ ] Simulated Cmax, AUC, and half-life are within ~20% of published values for a typical dose in a typical subject. Larger discrepancies: investigate, don't tune.
 - [ ] A simulated VPC visually resembles the paper's VPC (dose-proportional scaling, right terminal slope, reasonable spread).
+- [ ] If the event table was built from multiple cohorts via `bind_rows()`, ID ranges are disjoint (`anyDuplicated(events[, c("id","time","evid")]) == 0`). See `vignette-template.md`'s `make_cohort(..., id_offset = )` snippet for the pattern.
 
 ### F.1 Endogenous / mechanistic models
 
@@ -74,7 +76,8 @@ See `references/endogenous-validation.md` for full recipes.
 
 - [ ] `nlmixr2lib::buildModelDb()` runs to completion.
 - [ ] The new model appears in `modellib()`.
-- [ ] `devtools::check()` passes (warnings OK to discuss; errors are blocking).
+- [ ] `nlmixr2lib::checkModelConventions(model = "<...>")` returns clean (or all deviations are justified in the vignette's Assumptions and deviations section and noted in the PR body).
+- [ ] `devtools::check()` passes (warnings OK to discuss; errors are blocking). A C-level segfault during `check()` or vignette rendering is a red flag — stop, sidecar-ask the operator to investigate the environment, and do **not** work around with `--no-build-vignettes` or similar flags. See SKILL.md Phase 6 step 4.
 - [ ] Vignette builds cleanly.
 - [ ] `NEWS.md` entry added.
 

--- a/.claude/skills/extract-literature-model/references/vignette-template.md
+++ b/.claude/skills/extract-literature-model/references/vignette-template.md
@@ -1,6 +1,6 @@
 # Validation vignette template
 
-File path: `vignettes/articles/<FirstAuthor>_<Year>_<drug>.Rmd`. Drug-specific vignettes live under `vignettes/articles/` so pkgdown builds them for the site but CRAN skips them (`.Rbuildignore` excludes the directory). The basename must match the `vignette <- "..."` field in the model file.
+File path: `vignettes/articles/<FirstAuthor>_<Year>_<drug>.Rmd` — the pkgdown "articles" directory, not top-level `vignettes/`. Drug-specific vignettes live under `vignettes/articles/` so pkgdown builds them for the site but CRAN skips them (`.Rbuildignore` excludes the directory). The top-level `vignettes/` directory is reserved for the one legacy vignette (`PK_2cmt_mAb_Davda_2014.Rmd`). The basename must match the `vignette <- "..."` field in the model file.
 
 A validation vignette has two jobs:
 
@@ -79,27 +79,43 @@ demographics.
 
 ```{r cohort}
 set.seed(<seed>)
-n_subj <- <integer>
 
-# Build a cohort whose covariate distributions match the `population` metadata.
-# Use helper functions (WHO weight curves, allometric-scaled baselines, etc.) where relevant.
-# Include: ID, TIME, AMT, EVID, CMT, DV, and every covariate the model consumes.
-cohort <- tibble(
-  id    = seq_len(n_subj),
-  # ... covariate columns by canonical name (see references/covariate-columns.md)
-)
+# Helper: build one cohort as a self-contained event table. `id_offset`
+# shifts subject IDs so multiple cohorts can be bind_rows()-ed without
+# colliding. rxSolve treats ID as the subject key; duplicate IDs across
+# cohorts silently collapse into single (wrong) subjects, so offsetting
+# is mandatory, not decorative, for any multi-cohort simulation.
+make_cohort <- function(n, ..., id_offset = 0L) {
+  tibble(
+    id = id_offset + seq_len(n),
+    # ... covariate columns by canonical name (see inst/references/covariate-columns.md)
+    # ... cohort/treatment/regimen label as a column so it can ride through rxSolve via `keep = `
+  ) |>
+    # expand into dosing + observation rows (evid, amt, cmt, time, ...)
+    ...
+}
 
-# Build an event table: doses + sampling times.
-events <- cohort |>
-  # expand into dosing and observation rows
-  ...
+# Single-cohort case:
+events <- make_cohort(n = <integer>, ...)
+
+# Multi-cohort case — pass distinct id_offset per call so IDs are disjoint:
+# events <- dplyr::bind_rows(
+#   make_cohort(200, ..., id_offset =   0L) |> mutate(cohort = "A"),
+#   make_cohort(200, ..., id_offset = 200L) |> mutate(cohort = "B"),
+#   make_cohort(200, ..., id_offset = 400L) |> mutate(cohort = "C")
+# )
+# stopifnot(!anyDuplicated(unique(events[, c("id", "time", "evid")])))
 ```
 
 # Simulation
 
 ```{r simulate}
 mod <- readModelDb("<FirstAuthor>_<Year>_<drug>")
-sim <- rxode2::rxSolve(mod, events = events)
+# Prefer `keep = c("col1", "col2")` to carry source columns (cohort,
+# treatment, dose group, regimen) through to the simulation output.
+# This is cleaner than a post-hoc left_join back from `events`, and
+# avoids row-alignment surprises when rxSolve drops or expands rows.
+sim <- rxode2::rxSolve(mod, events = events, keep = c("cohort"))
 ```
 
 For deterministic replication (reproducing Figure N without between-subject
@@ -212,3 +228,19 @@ match.>
 - `rxode2::zeroRe()` is helpful when the published figure is a typical-value
   prediction rather than a VPC. Simulating with between-subject variability
   always, then plotting percentiles, matches VPC-style figures.
+- **Multi-cohort simulations.** If you build the event table by
+  `bind_rows()`-ing several cohorts (dose groups, regimens, age strata, etc.),
+  each cohort's `id` column must span a disjoint integer range. The
+  `make_cohort(..., id_offset = )` helper in the cohort chunk above shows the
+  pattern. Duplicate IDs across cohorts are silently merged by `rxSolve` into
+  a single subject and are a recurring bug — the `Robbie_2012_palivizumab`
+  vignette has a worked example. Add the assertion
+  `stopifnot(!anyDuplicated(unique(events[, c("id", "time", "evid")])))`
+  after the bind_rows as a cheap regression guard.
+- **Prefer `rxSolve(..., keep = c("col1", "col2"))`** over a post-hoc
+  `left_join` from `events` back into the simulation output. `keep` attaches
+  source columns directly in the rxode2 output, aligned per row. Use it for
+  `cohort`, `treatment`, dose-group labels, and any grouping column the plots
+  or PKNCA formulas need. The column-name is up to you (`"cohort"`,
+  `"treatment"`, `"regimen"` — whatever the paper's figure legends use); the
+  skill does not mandate one.


### PR DESCRIPTION
Distills lessons from the 75-paper extraction batch and the Robbie 2012 duplicate-id debrief into the extract-literature-model skill.

SKILL.md Phase 1: prefer <stem>_trimmed.md over raw PMC XML / PDF / DOCX when the preprocessor has run; explicit sidecar triggers for preclinical-only and abstract-only sources.
SKILL.md Phase 6: run nlmixr2lib::checkModelConventions() explicitly per model and include output in PR body; treat segfaults in devtools::check() / vignette render as hard blockers, not workarounds.
references/vignette-template.md: promotes make_cohort(..., id_offset = 0L) + rxSolve(..., keep = c(...)) as canonical multi-cohort pattern (Robbie 2012 as worked example).
references/pknca-recipes.md: declare concu / timeu on PKNCAconc() and doseu on PKNCAdose(); pitfalls for duplicate IDs + preferring rxSolve(keep=) over post-hoc left_join.
references/verification-checklist.md: bullets for vignettes/articles/ path, disjoint cohort IDs, checkModelConventions clean, segfault blockers.

Paired with tracking/preprocess_papers.py in mab_human_consensus (174 papers processed, 95.3% byte reduction).