### PR TITLE
Use programmatic citation pattern in 10 vignettes

### DIFF
--- a/vignettes/articles/Grimm_2023.Rmd
+++ b/vignettes/articles/Grimm_2023.Rmd
@@ -20,6 +20,13 @@ library(dplyr)
 library(ggplot2)
 ```
 
+# Model and source
+
+* Citation: `r rxode2::rxode(readModelDb("Grimm_2023_trontinemab"))$reference`
+* Description (trontinemab): `r rxode2::rxode(readModelDb("Grimm_2023_trontinemab"))$description`
+* Description (gantenerumab): `r rxode2::rxode(readModelDb("Grimm_2023_gantenerumab"))$description`
+* Article: <https://doi.org/10.1080/19420862.2023.2261509>
+
 # Trontinemab replication
 
 ## Simulate trontinemab PK in plasma and brain

--- a/vignettes/articles/Kyhl_2016_nalmefene.Rmd
+++ b/vignettes/articles/Kyhl_2016_nalmefene.Rmd
@@ -20,6 +20,12 @@ library(dplyr)
 library(ggplot2)
 ```
 
+# Model and source
+
+* Citation: `r rxode2::rxode(readModelDb("Kyhl_2016_nalmefene"))$reference`
+* Description: `r rxode2::rxode(readModelDb("Kyhl_2016_nalmefene"))$description`
+* Article: <https://doi.org/10.1111/bcp.12805>
+
 # Nalmefene replication
 
 Replicate figures 5 in the publication with a single 20 mg dose in the fed

--- a/vignettes/articles/Lon_2013_abatacept.Rmd
+++ b/vignettes/articles/Lon_2013_abatacept.Rmd
@@ -23,6 +23,12 @@ library(ggplot2)
 library(PKNCA)
 ```
 
+# Model and source
+
+* Citation: `r rxode2::rxode(readModelDb("Lon_2013_abatacept"))$reference`
+* Description: `r rxode2::rxode(readModelDb("Lon_2013_abatacept"))$description`
+* Article: [J Pharmacokinet Pharmacodyn 40(6):701-712](https://doi.org/10.1007/s10928-013-9341-1)
+
 # Abatacept population PK simulation (Lon 2013)
 
 Simulate abatacept plasma concentration-time profiles in collagen-induced
@@ -33,8 +39,6 @@ characterized abatacept PK in a rat CIA model using IV and SC single-dose
 and SC multiple-dose regimens, fitting all three arms simultaneously with
 a two-compartment linear-elimination model and a short-term zero-order SC
 absorption pattern (Eq. 3 of the paper).
-
-Article: [J Pharmacokinet Pharmacodyn 40(6):701-712](https://doi.org/10.1007/s10928-013-9341-1)
 
 ## Population
 

--- a/vignettes/articles/Masters_2022_avelumab.Rmd
+++ b/vignettes/articles/Masters_2022_avelumab.Rmd
@@ -19,15 +19,9 @@ library(ggplot2)
 
 # Model and source
 
-* Citation: Masters JC, Khandelwal A, di Pietro A, Dai H, Brar S.
-  Model-informed drug development supporting the approval of the avelumab
-  flat-dose regimen in patients with advanced renal cell carcinoma.
-  *CPT Pharmacometrics Syst Pharmacol.* 2022;11(4):458-468.
-  doi:[10.1002/psp4.12771](https://doi.org/10.1002/psp4.12771)
-* Description: Two-compartment population PK model for avelumab
-  (anti-PD-L1 IgG1) with time-dependent clearance in patients with
-  advanced solid tumors.
-* Modality: Therapeutic monoclonal antibody (IgG1), IV infusion.
+* Citation: `r rxode2::rxode(readModelDb("Masters_2022_avelumab"))$reference`
+* Description: `r rxode2::rxode(readModelDb("Masters_2022_avelumab"))$description`
+* Article: <https://doi.org/10.1002/psp4.12771>
 
 Avelumab is a fully human anti-PD-L1 IgG1 monoclonal antibody. The
 Masters 2022 paper supported approval of the **800 mg Q2W flat-dose**

--- a/vignettes/articles/Narwal_2013_sifalimumab.Rmd
+++ b/vignettes/articles/Narwal_2013_sifalimumab.Rmd
@@ -19,17 +19,10 @@ library(ggplot2)
 
 # Model and source
 
-* Citation: Narwal R, Roskos LK, Robbie GJ. Population pharmacokinetics of
-  sifalimumab, an investigational anti-interferon-alpha monoclonal
-  antibody, in systemic lupus erythematosus. *Clin Pharmacokinet.*
-  2013;52(11):1017-1027.
-  doi:[10.1007/s40262-013-0085-2](https://doi.org/10.1007/s40262-013-0085-2)
+* Citation: `r rxode2::rxode(readModelDb("Narwal_2013_sifalimumab"))$reference`
+* Description: `r rxode2::rxode(readModelDb("Narwal_2013_sifalimumab"))$description`
+* Article: <https://doi.org/10.1007/s40262-013-0085-2>
 * Article (open access): <https://pmc.ncbi.nlm.nih.gov/articles/PMC3824374/>
-* Description: Two-compartment linear population PK model for
-  sifalimumab (anti-IFN-alpha IgG1 monoclonal antibody) in adult
-  patients with systemic lupus erythematosus (SLE).
-* Modality: Fully human IgG1-kappa therapeutic monoclonal antibody,
-  intravenous infusion over 30-60 minutes.
 
 Sifalimumab is a fully human IgG1-kappa mAb that neutralises a majority
 of the subtypes of human interferon-alpha. Narwal 2013 developed the

--- a/vignettes/articles/Ogasawara_2020_durvalumab.Rmd
+++ b/vignettes/articles/Ogasawara_2020_durvalumab.Rmd
@@ -23,6 +23,12 @@ library(ggplot2)
 library(PKNCA)
 ```
 
+# Model and source
+
+* Citation: `r rxode2::rxode(readModelDb("Ogasawara_2020_durvalumab"))$reference`
+* Description: `r rxode2::rxode(readModelDb("Ogasawara_2020_durvalumab"))$description`
+* Article: <https://doi.org/10.1007/s40262-019-00804-x>
+
 # Durvalumab population PK simulation
 
 Simulate durvalumab concentration-time profiles using the final population

--- a/vignettes/articles/Wang_2017_benralizumab.Rmd
+++ b/vignettes/articles/Wang_2017_benralizumab.Rmd
@@ -23,6 +23,12 @@ library(ggplot2)
 library(PKNCA)
 ```
 
+# Model and source
+
+* Citation: `r rxode2::rxode(readModelDb("Wang_2017_benralizumab"))$reference`
+* Description: `r rxode2::rxode(readModelDb("Wang_2017_benralizumab"))$description`
+* Article: <https://doi.org/10.1002/psp4.12160>
+
 # Benralizumab population PK simulation
 
 Simulate benralizumab concentration-time profiles using the final population

--- a/vignettes/articles/Xie_2019_agomelatine.Rmd
+++ b/vignettes/articles/Xie_2019_agomelatine.Rmd
@@ -22,6 +22,12 @@ library(dplyr)
 library(ggplot2)
 ```
 
+# Model and source
+
+* Citation: `r rxode2::rxode(readModelDb("Xie_2019_agomelatine"))$reference`
+* Description: `r rxode2::rxode(readModelDb("Xie_2019_agomelatine"))$description`
+* Article: <https://doi.org/10.1111/bcp.13902>
+
 # Recreate figure 4 from the original paper
 
 The dose was a single 25 mg dose based on the methods section of the reference.
@@ -146,4 +152,4 @@ ggplot(d_plot, aes(x = time, y = prob_blq_c7dm)) +
 
 # Reference
 
-* `r Xie_2019_agomelatine$reference`
+* `r rxode2::rxode(readModelDb("Xie_2019_agomelatine"))$reference`

--- a/vignettes/articles/Xu_2011_sirukumab.Rmd
+++ b/vignettes/articles/Xu_2011_sirukumab.Rmd
@@ -23,6 +23,12 @@ library(ggplot2)
 library(PKNCA)
 ```
 
+# Model and source
+
+* Citation: `r rxode2::rxode(readModelDb("Xu_2011_sirukumab"))$reference`
+* Description: `r rxode2::rxode(readModelDb("Xu_2011_sirukumab"))$description`
+* Article: [Br J Clin Pharmacol 72(2):270-281](https://doi.org/10.1111/j.1365-2125.2011.03964.x)
+
 # Sirukumab population PK simulation
 
 Simulate sirukumab concentration-time profiles using the final population
@@ -33,8 +39,6 @@ single-dose first-in-human (FIH) trial in healthy adult volunteers
 (study C0524T01). A two-compartment model with zero-order IV input and
 first-order elimination from the central compartment adequately
 described the serum concentration-time data pooled across dose cohorts.
-
-Article: [Br J Clin Pharmacol 72(2):270-281](https://doi.org/10.1111/j.1365-2125.2011.03964.x)
 
 ## Population
 

--- a/vignettes/articles/Zheng_2016_sifalimumab.Rmd
+++ b/vignettes/articles/Zheng_2016_sifalimumab.Rmd
@@ -23,6 +23,12 @@ library(ggplot2)
 library(PKNCA)
 ```
 
+# Model and source
+
+* Citation: `r rxode2::rxode(readModelDb("Zheng_2016_sifalimumab"))$reference`
+* Description: `r rxode2::rxode(readModelDb("Zheng_2016_sifalimumab"))$description`
+* Article: [Br J Clin Pharmacol 81(5):918-928](https://doi.org/10.1111/bcp.12864)
+
 # Sifalimumab population PK simulation
 
 Simulate sifalimumab serum concentration-time profiles using the final
@@ -39,8 +45,6 @@ cohorts. Body weight, baseline 21-gene type I interferon signature
 score, dose, and baseline steroid use were identified as
 statistically significant covariates on CL and V1 but accounted for
 < 10% of PK variability.
-
-Article: [Br J Clin Pharmacol 81(5):918-928](https://doi.org/10.1111/bcp.12864)
 
 ## Population
 


### PR DESCRIPTION
Replace hardcoded Citation/Description text with the canonical `rxode2::rxode(readModelDb(...))$reference` and `...$description` inline-R pattern in all vignettes that were missing it.  Also add a "# Model and source" section to vignettes that had none (Grimm_2023, Kyhl_2016_nalmefene, Lon_2013_abatacept, Ogasawara_2020_durvalumab, Wang_2017_benralizumab, Xie_2019_agomelatine, Xu_2011_sirukumab, Zheng_2016_sifalimumab) and deduplicate the inline Article: lines now covered by the new section.