### PR TITLE
Fix vignettes: metadata-driven concentration units and PKNCA improvements

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 # development version
 
+* Fix vignettes: derive concentration units in `labs()` from model `$units` metadata; replace inline trapezoidal NCA with PKNCA; add PKNCA sections to nalmefene and clesrovimab vignettes; add PKNCA treatment grouping to benralizumab and durvalumab vignettes.
+* Add `concentration` field to `units` metadata for `Wang_2017_benralizumab` and `Ogasawara_2020_durvalumab` models.
+
 * Add Li 2019 abatacept ([doi:10.1002/jcph.1308](https://doi.org/10.1002/jcph.1308)) — adults with rheumatoid arthritis.
 * Add Narwal 2013 sifalimumab ([doi:10.1007/s40262-013-0085-2](https://doi.org/10.1007/s40262-013-0085-2)) — adults with moderately active systemic lupus erythematosus.
 * Add Valenzuela 2025 nipocalimab ([doi:10.1002/psp4.70109](https://doi.org/10.1002/psp4.70109)) — healthy adults and adults with generalized myasthenia gravis.

--- a/inst/modeldb/specificDrugs/Ogasawara_2020_durvalumab.R
+++ b/inst/modeldb/specificDrugs/Ogasawara_2020_durvalumab.R
@@ -2,7 +2,7 @@ Ogasawara_2020_durvalumab <- function() {
   description <- "Two compartment PK model of durvalumab (anti-PD-L1) in patients with hematologic malignancies (Ogasawara 2020)"
   reference <- "Ogasawara K, Newhall K, Maxwell SE, et al. Population Pharmacokinetics of an Anti-PD-L1 Antibody, Durvalumab in Patients with Hematologic Malignancies. Clin Pharmacokinet. 2020;59(2):217-227. doi:10.1007/s40262-019-00804-x"
   vignette <- "Ogasawara_2020_durvalumab"
-  units <- list(time = "hour", dosing = "mg")
+  units <- list(time = "hour", dosing = "mg", concentration = "mg/L")
   covariateData <- list(
     WT    = "Body weight in kg",
     ALB   = "Serum albumin in g/L (note: g/L not g/dL; 40 g/L = 4.0 g/dL)",

--- a/inst/modeldb/specificDrugs/Wang_2017_benralizumab.R
+++ b/inst/modeldb/specificDrugs/Wang_2017_benralizumab.R
@@ -2,7 +2,7 @@ Wang_2017_benralizumab <- function() {
   description <- "Two compartment PK model of benralizumab (anti-IL-5Ralpha) in healthy volunteers and patients with asthma (Wang 2017)"
   reference <- "Wang B, Lau YY, Liang M, et al. Population Pharmacokinetics and Pharmacodynamics of Benralizumab in Healthy Volunteers and Patients With Asthma. CPT Pharmacometrics Syst Pharmacol. 2017;6(4):249-257. doi:10.1002/psp4.12160"
   vignette <- "Wang_2017_benralizumab"
-  units <- list(time = "day", dosing = "mg")
+  units <- list(time = "day", dosing = "mg", concentration = "mg/L")
   covariateData <- list(
     WT = "Body weight in kg",
     ADA = "Anti-drug antibody status, high-titer (0 = negative/low-titer, 1 = high-titer with titer >= 400; called ADAs in the original publication; time-varying: assessed at each predesignated sampling visit; exp(1.52) = ~4.6-fold increase in CL)",

--- a/vignettes/articles/CarlssonPetri_2021_liraglutide.Rmd
+++ b/vignettes/articles/CarlssonPetri_2021_liraglutide.Rmd
@@ -131,6 +131,7 @@ events <- dplyr::bind_rows(dose_rows, obs_rows) |>
 
 ```{r simulate}
 mod <- rxode2::rxode2(readModelDb("CarlssonPetri_2021_liraglutide"))
+conc_unit <- mod$units[["concentration"]]
 sim <- rxode2::rxSolve(
   mod, events = events,
   keep = c("SEXF", "WT", "CHILD", "ADOLESCENT", "treatment")
@@ -177,7 +178,7 @@ sim_typical |>
   dplyr::filter(!is.na(Cc)) |>
   ggplot(aes(time / 24, Cc)) +
   geom_line(linewidth = 0.8) +
-  labs(x = "Time (days)", y = "Liraglutide concentration (nmol/L)",
+  labs(x = "Time (days)", y = paste0("Liraglutide concentration (", conc_unit, ")"),
     title = "Typical adolescent: 3 mg QD SC, 100 kg female",
     caption = "Deterministic typical-value prediction.") +
   theme_minimal()
@@ -202,7 +203,7 @@ sim |>
   ggplot(aes(time / 24, Q50)) +
   geom_ribbon(aes(ymin = Q05, ymax = Q95), alpha = 0.25) +
   geom_line() +
-  labs(x = "Time (days)", y = "Liraglutide concentration (nmol/L)",
+  labs(x = "Time (days)", y = paste0("Liraglutide concentration (", conc_unit, ")"),
     title = "Simulated 5-50-95 percentiles across adolescent cohort (3 mg QD SC)",
     caption = "Cohort covariates approximate Carlsson Petri 2021 Table 1 (trial NN2211-4180).")
 ```
@@ -229,7 +230,7 @@ cavg_by_id <- sim |>
 ggplot(cavg_by_id, aes(WT, Cavg_nmol_L, colour = Sex)) +
   geom_point(alpha = 0.6) +
   geom_smooth(method = "loess", se = FALSE) +
-  labs(x = "Body weight (kg)", y = "C_avg,ss (nmol/L)",
+  labs(x = "Body weight (kg)", y = paste0("C_avg,ss (", conc_unit, ")"),
     title = "Steady-state Cavg vs. body weight",
     caption = "Replicates the shape of Carlsson Petri 2021 Figure 3A (adolescents, 3 mg QD).") +
   theme_minimal()

--- a/vignettes/articles/Cirincione_2017_exenatide.Rmd
+++ b/vignettes/articles/Cirincione_2017_exenatide.Rmd
@@ -116,6 +116,7 @@ events <- cohort |>
 
 ```{r simulate}
 mod <- rxode2::rxode2(readModelDb("Cirincione_2017_exenatide"))
+conc_unit <- mod$units[["concentration"]]
 sim <- rxode2::rxSolve(mod, events = events, keep = c("WT", "CRCL", "treatment"))
 ```
 
@@ -164,7 +165,7 @@ clearance, respectively).
 sim_typical |>
   ggplot(aes(time, Cc, colour = scenario)) +
   geom_line(linewidth = 0.8) +
-  labs(x = "Time (h)", y = "Exenatide concentration (pg/mL)",
+  labs(x = "Time (h)", y = paste0("Exenatide concentration (", conc_unit, ")"),
     colour = NULL,
     title = "Typical concentration profiles (replicates Figure 5)",
     caption = "Replicates Figure 5 of Cirincione 2017: 10 ug SC, typical values.") +
@@ -190,7 +191,7 @@ sim |>
   geom_ribbon(aes(ymin = Q05, ymax = Q95), alpha = 0.2) +
   geom_line() +
   facet_wrap(~treatment) +
-  labs(x = "Time (h)", y = "Exenatide concentration (pg/mL)",
+  labs(x = "Time (h)", y = paste0("Exenatide concentration (", conc_unit, ")"),
     title = "Simulated 5-50-95 percentiles by renal-function band",
     caption = "10 ug SC; cohort covariate distributions approximate Table 1.")
 ```

--- a/vignettes/articles/Clegg_2024_nirsevimab.Rmd
+++ b/vignettes/articles/Clegg_2024_nirsevimab.Rmd
@@ -16,6 +16,7 @@ knitr::opts_chunk$set(
 
 ```{r setup}
 library(nlmixr2lib)
+library(PKNCA)
 library(dplyr)
 library(tidyr)
 library(ggplot2)
@@ -124,6 +125,7 @@ make_cohort <- function(n, ga_range, pna0_range, max_day,
 
 ```{r load-model}
 mod <- readModelDb("Clegg_2024_nirsevimab")
+conc_unit <- rxode2::rxode(mod)$units[["concentration"]]
 ```
 
 ---
@@ -191,7 +193,7 @@ ggplot(d_f4, aes(x = time, y = Q50)) +
   scale_x_continuous(breaks = seq(0, 500, by = 100)) +
   labs(
     x = "Time after dose (days)",
-    y = "Nirsevimab serum concentration (\u03bcg/mL)\nPrediction corrected",
+    y = paste0("Nirsevimab serum concentration (", conc_unit, ")\nPrediction corrected"),
     title = "Figure 4 \u2014 Prediction-corrected VPC by trial and season",
     caption = paste0(
       "Simulated median (line) and 90% prediction interval (shaded).\n",
@@ -242,7 +244,7 @@ ggplot(d_f5_plot, aes(x = time, y = Q50)) +
   scale_x_continuous(breaks = seq(0, 360, by = 30)) +
   labs(
     x = "Time after dose (days)",
-    y = "Nirsevimab serum concentration (\u03bcg/mL)\nPrediction corrected",
+    y = paste0("Nirsevimab serum concentration (", conc_unit, ")\nPrediction corrected"),
     title = "Figure 5 \u2014 Prediction-corrected VPC: MELODY safety cohort",
     caption = paste0(
       "Simulated 10th/50th/90th percentiles (N = 500 virtual infants, \u226535 wGA).\n",
@@ -310,20 +312,33 @@ sim_f6_list <- lapply(ga_groups, function(g) {
   out <- rxode2::rxSolve(mod, events = d_events) |>
     as.data.frame()
 
-  # NCA by individual
-  nca <- out |>
+  # NCA by individual: AUC0_365 and Cmax via PKNCA; C_day151 as direct lookup
+  out_nca <- out |> filter(time >= 0, !is.na(Cc))
+
+  # Build PKNCA dose data from the per-subject dose amounts
+  dose_df <- pop |>
+    mutate(time = 0, ga_group = g$label) |>
+    select(id = ID, time, amt = AMT, ga_group)
+
+  conc_obj <- PKNCAconc(out_nca, Cc ~ time | ga_group + id)
+  dose_obj <- PKNCAdose(dose_df, amt ~ time | ga_group + id)
+  nca_res  <- pk.nca(PKNCAdata(conc_obj, dose_obj,
+    intervals = data.frame(start = 0, end = 365,
+                           auclast = TRUE, cmax = TRUE)))
+
+  nca_pknca <- as.data.frame(nca_res$result) |>
+    filter(PPTESTCD %in% c("auclast", "cmax")) |>
+    select(id, PPTESTCD, PPORRES) |>
+    tidyr::pivot_wider(names_from = PPTESTCD, values_from = PPORRES) |>
+    rename(AUC0_365 = auclast, Cmax = cmax)
+
+  # Day-151 concentration: direct lookup (not a standard NCA parameter)
+  c_day151 <- out |>
     group_by(id) |>
-    summarise(
-      AUC0_365 = {
-        t <- time
-        c <- Cc
-        sum(diff(t) * (c[-length(c)] + c[-1]) / 2) # trapezoid
-      },
-      Cmax = max(Cc),
-      C_day151 = Cc[which.min(abs(time - 151))],
-      WT_base = WT_0[1],
-      .groups = "drop"
-    ) |>
+    summarise(C_day151 = Cc[which.min(abs(time - 151))],
+              WT_base  = WT_0[1], .groups = "drop")
+
+  nca <- left_join(nca_pknca, c_day151, by = "id") |>
     mutate(ga_group = g$label)
 })
 
@@ -419,7 +434,7 @@ ggplot(d_f6_pi, aes(x = wt_mid)) +
 - **Weight trajectories**: WHO weight-for-age LMS growth standards (combined sex, 0–24 months), with each infant's growth percentile (z-score) held constant.
 - **IIV**: Simulated using published omega² values: CL (26% CV), V2 (43% CV), Ka (44% CV; high shrinkage 83%), with correlation r = 0.785 between CL and V2. Q and V3 have no IIV in the final model.
 - **Residual error**: Proportional 21%.
-- **Figure 6 NCA**: AUC₀₋₃₆₅ computed by the trapezoidal rule on daily simulated concentrations; C_max and Day-151 concentration derived from the same densely sampled time course.
+- **Figure 6 NCA**: AUC₀₋₃₆₅ and C_max computed via PKNCA on daily simulated concentrations; Day-151 concentration derived by direct lookup from the same densely sampled time course.
 
 ## Reference
 

--- a/vignettes/articles/Clegg_2024_nirsevimab.Rmd
+++ b/vignettes/articles/Clegg_2024_nirsevimab.Rmd
@@ -313,7 +313,7 @@ sim_f6_list <- lapply(ga_groups, function(g) {
     as.data.frame()
 
   # NCA by individual: AUC0_365 and Cmax via PKNCA; C_day151 as direct lookup
-  out_nca <- out |> filter(time >= 0, !is.na(Cc))
+  out_nca <- out |> filter(time >= 0, !is.na(Cc)) |> mutate(ga_group = g$label)
 
   # Build PKNCA dose data from the per-subject dose amounts
   dose_df <- pop |>

--- a/vignettes/articles/Fasanmade_2009_infliximab.Rmd
+++ b/vignettes/articles/Fasanmade_2009_infliximab.Rmd
@@ -109,6 +109,7 @@ d_sim <- bind_rows(d_dose, d_obs) %>%
 
 ```{r simulate}
 mod <- readModelDb("Fasanmade_2009_infliximab")
+conc_unit <- rxode2::rxode(mod)$units[["concentration"]]
 sim <- rxSolve(mod, d_sim, returnType = "data.frame")
 ```
 
@@ -131,7 +132,7 @@ ggplot(sim_summary, aes(x = time / 7)) +
   scale_y_log10() +
   labs(
     x = "Time (weeks)",
-    y = "Infliximab concentration (ug/mL)",
+    y = paste0("Infliximab concentration (", conc_unit, ")"),
     title = "Simulated infliximab PK (5 mg/kg IV, induction + q8w maintenance)",
     subtitle = "Median and 90% prediction interval (N = 500 virtual UC patients)",
     caption = "Model: Fasanmade et al. (2009) Eur J Clin Pharmacol"
@@ -157,7 +158,7 @@ ggplot(sim_ada, aes(x = time / 7, y = median, color = ADA_label)) +
   scale_color_manual(values = c("ADA-negative" = "steelblue", "ADA-positive" = "tomato")) +
   labs(
     x = "Time (weeks)",
-    y = "Infliximab concentration (ug/mL)",
+    y = paste0("Infliximab concentration (", conc_unit, ")"),
     title = "Infliximab median concentrations by ADA status",
     subtitle = "ADA-positive patients have 47% higher clearance",
     color = "Immunogenicity",

--- a/vignettes/articles/Fiedler-Kelly_2019_fremanezumab.Rmd
+++ b/vignettes/articles/Fiedler-Kelly_2019_fremanezumab.Rmd
@@ -140,6 +140,7 @@ events_all <- bind_rows(events_monthly, events_quarterly)
 
 ```{r simulate}
 mod <- readModelDb("Fiedler-Kelly_2019_fremanezumab")
+conc_unit <- rxode2::rxode(mod)$units[["concentration"]]
 
 sim <- events_all %>%
   group_by(treatment) %>%
@@ -172,7 +173,7 @@ ggplot(fig7, aes(x = time / 7)) +
   facet_wrap(~treatment, scales = "free_y") +
   labs(
     x       = "Time since first dose (weeks)",
-    y       = "Fremanezumab concentration (ug/mL)",
+    y       = paste0("Fremanezumab concentration (", conc_unit, ")"),
     title   = "Figure 7 replication - simulated fremanezumab exposure",
     caption = "Replicates Figure 7 of Fiedler-Kelly et al. 2019. Median and 90% prediction interval (N = 500)."
   ) +
@@ -213,7 +214,7 @@ ggplot(cav_bind, aes(x = wt_quartile, y = Cav)) +
   facet_wrap(~interval, scales = "free_y") +
   labs(
     x       = "Body-weight quartile",
-    y       = "Average steady-state concentration (ug/mL)",
+    y       = paste0("Average steady-state concentration (", conc_unit, ")"),
     title   = "Figure 8 replication - steady-state exposure by body-weight quartile",
     caption = "Replicates qualitative trend shown in Figure 8 of Fiedler-Kelly et al. 2019."
   ) +

--- a/vignettes/articles/Grimm_2023.Rmd
+++ b/vignettes/articles/Grimm_2023.Rmd
@@ -55,6 +55,7 @@ dSimObs <-
   )
 dSimPrep <- dplyr::bind_rows(dSimDose, dSimObs)
 Grimm2023Tront <- readModelDb("Grimm_2023_trontinemab")
+conc_unit <- rxode2::rxode(Grimm2023Tront)$units[["concentration"]]
 # Set BSV to zero for simulation to get a reproducible result
 dSimTront <- rxode2::rxSolve(Grimm2023Tront |> rxode2::zeroRe(), events = dSimPrep)
 dSimTront$Analyte <- "Trontinemab"
@@ -103,7 +104,7 @@ ggplot(dSim, aes(x = time, y = sim)) +
   geom_line() +
   labs(
     x = "Time (h)",
-    y = "Concentration (ng/mL)"
+    y = paste0("Concentration (", conc_unit, ")")
   ) +
   scale_y_log10() +
   scale_x_continuous(breaks = seq(0, 336, by = 48)) +

--- a/vignettes/articles/Hu_2026_clesrovimab.Rmd
+++ b/vignettes/articles/Hu_2026_clesrovimab.Rmd
@@ -16,6 +16,7 @@ knitr::opts_chunk$set(
 
 ```{r setup}
 library(nlmixr2lib)
+library(PKNCA)
 library(dplyr)
 library(ggplot2)
 ```
@@ -155,6 +156,7 @@ d_sim <- bind_rows(d_dose, d_obs) |>
 
 ```{r simulate}
 mod <- readModelDb("Hu_2026_clesrovimab")
+conc_unit <- rxode2::rxode(mod)$units[["concentration"]]
 
 # Simulate: rxSolve uses the N=500 subjects' IIV from the model ini() block.
 # Setting seed for reproducibility.
@@ -211,7 +213,7 @@ ggplot(d_overall, aes(x = time, y = Q50)) +
   scale_x_continuous(breaks = seq(0, 150, by = 30)) +
   labs(
     x = "Time after dose (days)",
-    y = "Clesrovimab concentration (\u03bcg/mL)",
+    y = paste0("Clesrovimab concentration (", conc_unit, ")"),
     title = "Overall population\nMedian and 90% prediction interval"
   ) +
   theme_bw()
@@ -230,7 +232,7 @@ ggplot(d_strat, aes(x = time, y = Q50)) +
   scale_x_continuous(breaks = seq(0, 150, by = 60)) +
   labs(
     x = "Time after dose (days)",
-    y = "Clesrovimab concentration (\u03bcg/mL)",
+    y = paste0("Clesrovimab concentration (", conc_unit, ")"),
     title = "By baseline body weight category\nMedian and 90% prediction interval"
   ) +
   theme_bw()
@@ -250,6 +252,41 @@ ggplot(d_strat, aes(x = time, y = Q50)) +
 - **Residual error**: Combined proportional (14.3%) and additive (0.231 µg/mL).
 - The prediction intervals reflect both inter-individual variability and
   residual error from the final population PK model.
+
+## NCA analysis
+
+Non-compartmental analysis of simulated clesrovimab PK (single 105 mg IM dose,
+N = 500 virtual infants stratified by baseline weight group).
+
+```{r nca}
+# Build NCA data: use days 0-150, group by baseline weight category
+# (use sim_out to include time 0 for the dose anchor)
+sim_nca <- sim_out |>
+  as.data.frame() |>
+  filter(!is.na(Cc)) |>
+  left_join(
+    pop |> select(ID, wt_group),
+    by = c("id" = "ID")
+  )
+
+dose_nca <- sim_nca |>
+  group_by(id) |>
+  slice(1) |>
+  ungroup() |>
+  mutate(time = 0, AMT = 105) |>
+  select(id, wt_group, time, AMT)
+
+conc_obj <- PKNCAconc(sim_nca, Cc ~ time | wt_group + id)
+dose_obj <- PKNCAdose(dose_nca, AMT ~ time | wt_group + id)
+data_obj <- PKNCAdata(conc_obj, dose_obj,
+  intervals = data.frame(start = 0, end = 150,
+                         cmax = TRUE, tmax = TRUE,
+                         auclast = TRUE, half.life = TRUE))
+nca_results <- pk.nca(data_obj)
+nca_summary <- summary(nca_results)
+knitr::kable(nca_summary, digits = 2,
+             caption = "NCA summary by baseline weight group (single 105 mg IM dose)")
+```
 
 ## Reference
 

--- a/vignettes/articles/Kovalenko_2020_dupilumab.Rmd
+++ b/vignettes/articles/Kovalenko_2020_dupilumab.Rmd
@@ -154,6 +154,7 @@ events <- dplyr::bind_rows(ev_dose, ev_obs) |>
 
 ```{r simulate}
 mod <- rxode2::rxode2(readModelDb("Kovalenko_2020_dupilumab"))
+conc_unit <- mod$units[["concentration"]]
 sim <- rxode2::rxSolve(mod, events = events, keep = "WT")
 ```
 
@@ -183,7 +184,7 @@ ggplot(vpc, aes(time, Q50)) +
   scale_y_continuous(limits = c(0, NA)) +
   labs(
     x = "Time (days)",
-    y = "Dupilumab Cc (mg/L)",
+    y = paste0("Dupilumab Cc (", conc_unit, ")"),
     title = "Simulated 5-50-95 percentile profile; 600 mg SC load then 300 mg SC Q2W",
     caption = "Virtual AD cohort (N = 400); WT ~N(75, 18) kg, truncated 40-165 kg."
   ) +
@@ -214,7 +215,7 @@ ggplot(ss_summary, aes(time - ss_start, Q50)) +
   geom_line(colour = "#b4464b", linewidth = 0.8) +
   labs(
     x = "Time after final dose (days)",
-    y = "Dupilumab Cc (mg/L)",
+    y = paste0("Dupilumab Cc (", conc_unit, ")"),
     title = "Steady-state Q2W cycle (dose 13 of 13)",
     caption = "Median and 90% prediction interval over one 14-day dosing interval."
   ) +

--- a/vignettes/articles/Kyhl_2016_nalmefene.Rmd
+++ b/vignettes/articles/Kyhl_2016_nalmefene.Rmd
@@ -16,6 +16,7 @@ knitr::opts_chunk$set(
 
 ```{r setup}
 library(nlmixr2lib)
+library(PKNCA)
 library(dplyr)
 library(ggplot2)
 ```
@@ -62,6 +63,7 @@ dSimPrep <-
     TABLET = 1
   )
 Kyhl2016Nalmefene <- readModelDb("Kyhl_2016_nalmefene")
+conc_unit <- rxode2::rxode(Kyhl2016Nalmefene)$units[["concentration"]]
 # Set BSV to zero for simulation to get a reproducible result
 dSimNalmefene <- rxode2::rxSolve(Kyhl2016Nalmefene, events = dSimPrep, nStud = 500)
 dSimNalmefene$Analyte <- "Nalmefene"
@@ -89,7 +91,7 @@ ggplot(dSimNalmefenePlot, aes(x = time, y = Q50_pk, ymin = Q025_pk, ymax = Q975_
   geom_line() +
   labs(
     x = "Time (h)",
-    y = "Estimated plasma concentration (ng mL^-1)"
+    y = paste0("Estimated plasma concentration (", conc_unit, ")")
   ) +
   geom_ribbon(fill = "gray") +
   geom_line() +
@@ -105,5 +107,35 @@ ggplot(dSimNalmefenePlot, aes(x = time, y = Q50_occ, ymin = Q025_occ, ymax = Q97
   geom_line() +
   geom_hline(yintercept = c(60, 90)) +
   scale_x_continuous(breaks = seq(0, 24, by = 5))
+```
+
+## NCA analysis
+
+Non-compartmental analysis of simulated nalmefene plasma PK (single 20 mg
+oral tablet in the fed state, 500 virtual subjects via IIV sampling).
+
+```{r nca}
+# Each replicate (sim.id) is treated as an independent subject
+sim_nca <- dSimNalmefene |>
+  as.data.frame() |>
+  mutate(treatment = "20 mg PO (fed, tablet)")
+
+dose_nca <- sim_nca |>
+  group_by(sim.id) |>
+  slice(1) |>
+  ungroup() |>
+  mutate(time = 0, AMT = 20) |>
+  select(sim.id, treatment, time, AMT)
+
+conc_obj <- PKNCAconc(sim_nca, Cc ~ time | treatment + sim.id)
+dose_obj <- PKNCAdose(dose_nca, AMT ~ time | treatment + sim.id)
+data_obj <- PKNCAdata(conc_obj, dose_obj,
+  intervals = data.frame(start = 0, end = 24,
+                         cmax = TRUE, tmax = TRUE,
+                         auclast = TRUE, half.life = TRUE))
+nca_results <- pk.nca(data_obj)
+nca_summary <- summary(nca_results)
+knitr::kable(nca_summary, digits = 2,
+             caption = "NCA summary (single 20 mg oral tablet, fed state)")
 ```
 

--- a/vignettes/articles/Ogasawara_2020_durvalumab.Rmd
+++ b/vignettes/articles/Ogasawara_2020_durvalumab.Rmd
@@ -99,6 +99,7 @@ d_sim <- bind_rows(d_dose, d_obs) %>%
 
 ```{r simulate}
 mod <- readModelDb("Ogasawara_2020_durvalumab")
+conc_unit <- rxode2::rxode(mod)$units[["concentration"]]
 sim <- rxSolve(mod, d_sim, returnType = "data.frame")
 ```
 
@@ -120,7 +121,7 @@ ggplot(sim_summary, aes(x = time / (24 * 7))) +
   geom_line(aes(y = median), color = "purple4", linewidth = 1) +
   labs(
     x = "Time (weeks)",
-    y = "Durvalumab concentration (mg/L)",
+    y = paste0("Durvalumab concentration (", conc_unit, ")"),
     title = "Simulated durvalumab PK (1500 mg IV q4w)",
     subtitle = "Median and 90% PI (N = 500 virtual hematologic malignancy patients)",
     caption = "Model: Ogasawara et al. (2020) Clin Pharmacokinet"
@@ -145,7 +146,7 @@ ggplot(sim_disease_summary, aes(x = time / (24 * 7), y = median, color = Disease
   scale_color_manual(values = c("MDS/AML" = "firebrick", "Other" = "navy")) +
   labs(
     x = "Time (weeks)",
-    y = "Durvalumab concentration (mg/L)",
+    y = paste0("Durvalumab concentration (", conc_unit, ")"),
     title = "Durvalumab median concentrations by disease type",
     subtitle = "MDS/AML patients have 26% higher CL and lower exposures",
     caption = "Model: Ogasawara et al. (2020)"
@@ -166,17 +167,21 @@ if (all(c("sim.id", "id") %in% names(sim_df))) {
 } else {
   sim_df$subject <- sim_df$sim.id
 }
+sim_df$Disease <- ifelse(sim_df$MDSAML == 1, "MDS/AML", "Other")
 nca_data <- data.frame(
   subject  = sim_df$subject,
+  Disease  = sim_df$Disease,
   time_rel = (sim_df$time - 1344) / 24,  # Convert to days relative to dose 3
   Cc       = sim_df$Cc
 )
 nca_data <- nca_data[nca_data$time_rel >= 0 & nca_data$time_rel <= 28 & nca_data$Cc > 0, ]
 
-conc_obj <- PKNCAconc(nca_data, Cc ~ time_rel | subject)
+conc_obj <- PKNCAconc(nca_data, Cc ~ time_rel | Disease + subject)
 dose_obj <- PKNCAdose(
-  data.frame(subject = unique(nca_data$subject), time_rel = 0, AMT = 1500),
-  AMT ~ time_rel | subject
+  data.frame(subject = unique(nca_data$subject),
+             Disease = nca_data$Disease[match(unique(nca_data$subject), nca_data$subject)],
+             time_rel = 0, AMT = 1500),
+  AMT ~ time_rel | Disease + subject
 )
 data_obj <- PKNCAdata(conc_obj, dose_obj,
                        intervals = data.frame(start = 0, end = 28,

--- a/vignettes/articles/Soehoel_2022_tralokinumab.Rmd
+++ b/vignettes/articles/Soehoel_2022_tralokinumab.Rmd
@@ -138,6 +138,7 @@ events <- dplyr::bind_rows(ev_dose, ev_obs) |>
 
 ```{r simulate}
 mod <- rxode2::rxode2(readModelDb("Soehoel_2022_tralokinumab"))
+conc_unit <- mod$units[["concentration"]]
 sim <- rxode2::rxSolve(
   mod, events = events,
   keep = c("WT", "SEXF", "nonECZTRA", "dilution")
@@ -171,7 +172,7 @@ ggplot(vpc, aes(time, Q50)) +
   scale_y_continuous(limits = c(0, NA)) +
   labs(
     x = "Time (days)",
-    y = expression("Tralokinumab Cc (" * mu * "g/mL)"),
+    y = paste0("Tralokinumab Cc (", conc_unit, ")"),
     title = "Simulated 5-50-95 percentile VPC; 600 mg SC load then 300 mg SC Q2W",
     caption = "Virtual AD cohort (N = 400); WT median 74.5 kg; nonECZTRA = 0, dilution = 0."
   ) +
@@ -202,7 +203,7 @@ ggplot(ss_summary, aes(time - ss_start, Q50)) +
   geom_line(colour = "#b4464b", linewidth = 0.8) +
   labs(
     x = "Time after final dose (days)",
-    y = expression("Tralokinumab Cc (" * mu * "g/mL)"),
+    y = paste0("Tralokinumab Cc (", conc_unit, ")"),
     title = "Steady-state Q2W cycle (dose 13 of 13)",
     caption = "Median and 90% prediction interval over one 14-day dosing interval."
   ) +

--- a/vignettes/articles/Thakre_2022_risankizumab.Rmd
+++ b/vignettes/articles/Thakre_2022_risankizumab.Rmd
@@ -124,6 +124,7 @@ d_sim <- bind_rows(d_dose, d_obs) %>%
 
 ```{r simulate}
 mod <- readModelDb("Thakre_2022_risankizumab")
+conc_unit <- rxode2::rxode(mod)$units[["concentration"]]
 sim <- rxSolve(mod, d_sim, returnType = "data.frame")
 ```
 
@@ -146,7 +147,7 @@ ggplot(sim_summary, aes(x = time / 7)) +
   scale_y_log10() +
   labs(
     x = "Time (weeks)",
-    y = "Risankizumab concentration (ug/mL)",
+    y = paste0("Risankizumab concentration (", conc_unit, ")"),
     title = "Simulated risankizumab PK (150 mg SC, weeks 0, 4, 16, 28)",
     subtitle = "Median and 90% prediction interval (N = 500 virtual PsA patients)",
     caption = "Model: Thakre et al. (2022) Rheumatol Ther"

--- a/vignettes/articles/Tiraboschi_2025_amlitelimab.Rmd
+++ b/vignettes/articles/Tiraboschi_2025_amlitelimab.Rmd
@@ -16,6 +16,7 @@ knitr::opts_chunk$set(
 
 ```{r setup}
 library(nlmixr2lib)
+library(PKNCA)
 library(dplyr)
 library(ggplot2)
 ```
@@ -228,23 +229,37 @@ typ_ev <- bind_rows(typ_dose, typ_obs) |>
 
 typ_sim <- rxode2::rxSolve(mod, events = typ_ev, omega = NA, sigma = NA)
 
-trapz_auc <- function(time, conc) {
-  sum(diff(time) * (head(conc, -1) + tail(conc, -1)) / 2)
-}
+ss_start <- 20 * 28   # day 560
+tau      <- 28        # dosing interval in days
 
-typ_auc <- as.data.frame(typ_sim) |>
-  filter(time >= 20 * 28) |>
-  group_by(id) |>
-  summarise(
-    WT  = WT[1],
-    AUC = trapz_auc(time, Cc),
-    .groups = "drop"
+typ_nca_conc <- as.data.frame(typ_sim) |>
+  dplyr::filter(time >= ss_start, time <= ss_start + tau, !is.na(Cc)) |>
+  dplyr::mutate(time_rel = time - ss_start, WT_group = paste0(WT, " kg")) |>
+  dplyr::select(id, time = time_rel, Cc, WT, WT_group)
+
+typ_nca_dose <- typ_nca_conc |>
+  dplyr::group_by(id) |> dplyr::slice(1) |> dplyr::ungroup() |>
+  dplyr::mutate(time = 0, amt = 62.5) |>
+  dplyr::select(id, time, amt, WT_group)
+
+conc_ss <- PKNCA::PKNCAconc(typ_nca_conc, Cc ~ time | WT_group + id)
+dose_ss <- PKNCA::PKNCAdose(typ_nca_dose, amt ~ time | WT_group + id)
+nca_ss  <- PKNCA::pk.nca(PKNCA::PKNCAdata(conc_ss, dose_ss,
+  intervals = data.frame(start = 0, end = tau, auclast = TRUE)))
+
+typ_auc <- as.data.frame(nca_ss$result) |>
+  dplyr::filter(PPTESTCD == "auclast") |>
+  dplyr::rename(AUC = PPORRES) |>
+  dplyr::left_join(
+    typ_nca_conc |> dplyr::group_by(id) |> dplyr::slice(1) |>
+      dplyr::select(id, WT),
+    by = "id"
   )
 
 ref_auc <- typ_auc$AUC[typ_auc$WT == 75]
 typ_auc$pct_change <- 100 * (typ_auc$AUC - ref_auc) / ref_auc
 knitr::kable(
-  typ_auc,
+  typ_auc[, c("id", "WT", "AUC", "pct_change")],
   digits  = c(0, 0, 2, 1),
   caption = "Simulated AUC4W at steady state (62.5 mg Q4W) vs body weight"
 )

--- a/vignettes/articles/Wang_2017_benralizumab.Rmd
+++ b/vignettes/articles/Wang_2017_benralizumab.Rmd
@@ -88,6 +88,7 @@ d_sim <- bind_rows(d_dose, d_obs) %>%
 
 ```{r simulate}
 mod <- readModelDb("Wang_2017_benralizumab")
+conc_unit <- rxode2::rxode(mod)$units[["concentration"]]
 sim <- rxSolve(mod, d_sim, returnType = "data.frame")
 ```
 
@@ -109,7 +110,7 @@ ggplot(sim_summary, aes(x = time / 7)) +
   geom_line(aes(y = median), color = "darkorange", linewidth = 1) +
   labs(
     x = "Time (weeks)",
-    y = "Benralizumab concentration (mg/L)",
+    y = paste0("Benralizumab concentration (", conc_unit, ")"),
     title = "Simulated benralizumab PK (30 mg SC, q4w x3 then q8w)",
     subtitle = "Median and 90% prediction interval (N = 500 virtual asthma patients)",
     caption = "Model: Wang et al. (2017) CPT Pharmacometrics Syst Pharmacol"
@@ -131,17 +132,21 @@ if (all(c("sim.id", "id") %in% names(sim_df))) {
 } else {
   sim_df$subject <- sim_df$sim.id
 }
+sim_df$treatment <- ifelse(sim_df$ADA == 1, "High-titer ADA", "Negative/Low-titer ADA")
 nca_data <- data.frame(
-  subject  = sim_df$subject,
-  time_rel = sim_df$time - 28,
-  Cc       = sim_df$Cc
+  subject   = sim_df$subject,
+  treatment = sim_df$treatment,
+  time_rel  = sim_df$time - 28,
+  Cc        = sim_df$Cc
 )
 nca_data <- nca_data[nca_data$time_rel >= 0 & nca_data$time_rel <= 28 & nca_data$Cc > 0, ]
 
-conc_obj <- PKNCAconc(nca_data, Cc ~ time_rel | subject)
+conc_obj <- PKNCAconc(nca_data, Cc ~ time_rel | treatment + subject)
 dose_obj <- PKNCAdose(
-  data.frame(subject = unique(nca_data$subject), time_rel = 0, AMT = 30),
-  AMT ~ time_rel | subject
+  data.frame(subject = unique(nca_data$subject),
+             treatment = nca_data$treatment[match(unique(nca_data$subject), nca_data$subject)],
+             time_rel = 0, AMT = 30),
+  AMT ~ time_rel | treatment + subject
 )
 data_obj <- PKNCAdata(conc_obj, dose_obj,
                        intervals = data.frame(start = 0, end = 28,

--- a/vignettes/articles/Xie_2019_agomelatine.Rmd
+++ b/vignettes/articles/Xie_2019_agomelatine.Rmd
@@ -34,6 +34,7 @@ The dose was a single 25 mg dose based on the methods section of the reference.
 
 ```{r sim-setup}
 Xie_2019_agomelatine <- nlmixr(readModelDb("Xie_2019_agomelatine"))
+conc_unit <- rxode2::rxode(readModelDb("Xie_2019_agomelatine"))$units[["concentration"]]
 
 d_sim_dosing <-
   data.frame(
@@ -92,7 +93,7 @@ ggplot(d_plot, aes(x = time, y = Q50_calmt, ymin = Q05_calmt, ymax = Q95_calmt))
   scale_y_log10(sec.axis = sec_axis(transform = identity, breaks = 0.046, labels = "LLOQ")) +
   labs(
     x = "Time after dose (hours)",
-    y = "Plasma agomelatine concentration (ng/mL)\nMedian and 90% prediction intervals"
+    y = paste0("Plasma agomelatine concentration (", conc_unit, ")\nMedian and 90% prediction intervals")
   )
 ```
 
@@ -113,7 +114,7 @@ ggplot(d_plot, aes(x = time, y = Q50_c3oh, ymin = Q05_c3oh, ymax = Q95_c3oh)) +
   scale_y_log10(sec.axis = sec_axis(transform = identity, breaks = 0.460, labels = "LLOQ")) +
   labs(
     x = "Time after dose (hours)",
-    y = "Plasma 3-hydroxy-agomelatine concentration (ng/mL)\nMedian and 90% prediction intervals"
+    y = paste0("Plasma 3-hydroxy-agomelatine concentration (", conc_unit, ")\nMedian and 90% prediction intervals")
   )
 ```
 
@@ -137,7 +138,7 @@ ggplot(d_plot, aes(x = time, y = Q50_c7dm, ymin = Q05_c7dm, ymax = Q95_c7dm)) +
   scale_y_log10(sec.axis = sec_axis(transform = identity, breaks = 0.137, labels = "LLOQ")) +
   labs(
     x = "Time after dose (hours)",
-    y = "Plasma 7-desmethyl-agomelatine concentration (ng/mL)\nMedian and 90% prediction intervals"
+    y = paste0("Plasma 7-desmethyl-agomelatine concentration (", conc_unit, ")\nMedian and 90% prediction intervals")
   )
 ```
 

--- a/vignettes/articles/Xu_2019_sarilumab.Rmd
+++ b/vignettes/articles/Xu_2019_sarilumab.Rmd
@@ -170,6 +170,7 @@ events <- dplyr::bind_rows(events_200, events_150)
 
 ```{r simulate}
 mod <- rxode2::rxode2(readModelDb("Xu_2019_sarilumab"))
+conc_unit <- mod$units[["concentration"]]
 keep_cols <- c("WT", "SEXF", "ADA_POS", "FORM_DP2",
                "ALBR", "CRCL", "CRP", "treatment")
 
@@ -204,7 +205,7 @@ ggplot(vpc, aes(time, Q50, colour = treatment, fill = treatment)) +
   geom_line(linewidth = 0.8) +
   labs(
     x = "Time (days)",
-    y = "Sarilumab Cc (mg/L)",
+    y = paste0("Sarilumab Cc (", conc_unit, ")"),
     title = "Simulated 5-50-95 percentile profiles: 150 vs 200 mg SC Q2W",
     caption = "Virtual RA cohort (N = 400); first 6 dosing cycles."
   ) +
@@ -235,7 +236,7 @@ ggplot(ss_summary, aes(time - ss_start, Q50, colour = treatment, fill = treatmen
   geom_line(linewidth = 0.8) +
   labs(
     x = "Time within dosing interval (days)",
-    y = "Sarilumab Cc (mg/L)",
+    y = paste0("Sarilumab Cc (", conc_unit, ")"),
     title = "Steady-state Q2W cycle",
     caption = "Median and 90% prediction interval over the final 14-day interval."
   ) +

--- a/vignettes/articles/Zhu_2017_lebrikizumab.Rmd
+++ b/vignettes/articles/Zhu_2017_lebrikizumab.Rmd
@@ -148,6 +148,7 @@ events <- dplyr::bind_rows(ev_dose, ev_obs) |>
 
 ```{r simulate}
 mod <- rxode2::rxode2(readModelDb("Zhu_2017_lebrikizumab"))
+conc_unit <- mod$units[["concentration"]]
 sim <- rxode2::rxSolve(mod, events = events,
   keep = c("WT", "AGE", "SEXF",
     "RACE_BLACK", "RACE_ASIAN", "RACE_OTHER",
@@ -180,7 +181,7 @@ ggplot(vpc, aes(time, Q50)) +
   scale_y_continuous(limits = c(0, NA)) +
   labs(
     x = "Time (days)",
-    y = expression("Lebrikizumab Cc (" * mu * "g/mL)"),
+    y = paste0("Lebrikizumab Cc (", conc_unit, ")"),
     title = "Simulated 5-50-95 percentile VPC, 125 mg Q4W SC (6 doses)",
     caption = "Virtual cohort (N = 400); covariate distributions synthesized to approximate Zhu 2017 Table 1."
   ) +
@@ -210,7 +211,7 @@ ggplot(ss_summary, aes(time - 140, Q50)) +
   geom_line(colour = "#b4464b", linewidth = 0.8) +
   labs(
     x = "Time after dose 6 (days)",
-    y = expression("Lebrikizumab Cc (" * mu * "g/mL)"),
+    y = paste0("Lebrikizumab Cc (", conc_unit, ")"),
     title = "Steady-state dose cycle: 125 mg SC Q4W",
     caption = "Median and 90% prediction interval over the 6th Q4W cycle."
   ) +


### PR DESCRIPTION
## Summary

- **All 16 drug vignettes**: Add `conc_unit <- rxode2::rxode(mod)$units[["concentration"]]` after model loading and replace every hardcoded concentration unit string in `labs(y = ...)` with `paste0("...(", conc_unit, ")")` — concentration units are now auto-derived from model metadata.
- **Trapz → PKNCA**: Replace inline trapezoidal NCA with PKNCA in `Tiraboschi_2025_amlitelimab` and `Clegg_2024_nirsevimab`.
- **New PKNCA sections**: Added full NCA section to `Kyhl_2016_nalmefene` and `Hu_2026_clesrovimab` (previously missing entirely).
- **PKNCA grouping fixes**: Added treatment grouping variable to `Wang_2017_benralizumab` (ADA status) and `Ogasawara_2020_durvalumab` (disease type / MDSAML).
- **Model metadata**: Added `concentration = "mg/L"` to `$units` for `Wang_2017_benralizumab` and `Ogasawara_2020_durvalumab` (both were missing this field).

## Test plan

- [ ] Vignettes build cleanly with `devtools::build_vignettes()`
- [ ] Concentration unit strings in plots match model `$units[["concentration"]]`
- [ ] PKNCA summaries complete without errors for all 6 fixed vignettes
- [ ] `expression()` → `paste0()` conversions display correctly in plot y-axes

🤖 Generated with [Claude Code](https://claude.com/claude-code)