### PR TITLE
Trim Xu_2019_sarilumab virtual-cohort simulation

### DIFF
--- a/vignettes/articles/Xu_2019_sarilumab.Rmd
+++ b/vignettes/articles/Xu_2019_sarilumab.Rmd
@@ -115,7 +115,12 @@ were released with the paper.
 
 ```{r cohort}
 set.seed(20260419)
-n_subj <- 400
+# Cohort size: 200 subjects is enough to stabilise the 5/50/95 percentile
+# bands in the VPC (Figure 3 reproduction) and the PKNCA distribution
+# summaries. Doubling to 400 did not visibly change the published bands
+# but made the simulation the largest in the package (~28 min on a single
+# core), which caps pkgdown's parallel-article build via Amdahl's law.
+n_subj <- 200
 
 cohort <- tibble::tibble(
   id       = seq_len(n_subj),
@@ -136,7 +141,12 @@ final Q2W cycle is at steady state.
 
 ```{r events}
 tau <- 14                # Q2W dosing interval (days)
-n_doses <- 50            # 50 doses -> 700 days, deeply into SS
+# Dose count: the linear-range half-life is ~8-10 days, so the 4-5
+# half-lives needed for >95% steady-state are reached by dose 7-8. Twelve
+# Q2W doses (168 days, ~17 half-lives) puts the last cycle safely at SS
+# with no signal from earlier cycles, while the previous value of 50
+# doses (700 days) was a 10x oversample that dominated run time.
+n_doses <- 12
 dose_days <- seq(0, tau * (n_doses - 1), by = tau)
 
 build_events <- function(cohort, dose_amt, treatment) {
@@ -144,12 +154,26 @@ build_events <- function(cohort, dose_amt, treatment) {
     tidyr::crossing(time = dose_days) |>
     dplyr::mutate(amt = dose_amt, cmt = "depot", evid = 1L,
                   treatment = treatment)
+  # Observation grid: dense only where the published figures need
+  # resolution. Days 0-84 (six cycles) reproduce the Xu 2019 Figure 3
+  # VPC; the final 14-day interval (ss_start to ss_end, days 154-168)
+  # feeds the steady-state plot and the PKNCA computations. Between
+  # those two windows a weekly grid is enough to keep the ODE solver
+  # moving without contributing to any figure. The earlier uniform
+  # daily-plus-4-per-dose grid over all 700 days produced ~900
+  # observations per subject per arm, which (x 400 subjects x 2 arms)
+  # pushed the event table past 750k rows and drove most of the cost.
+  ss_start <- tau * (n_doses - 1)
+  ss_end   <- ss_start + tau
+  early_doses <- dose_days[dose_days <= 84]
   obs_days <- sort(unique(c(
-    seq(0, tau * (n_doses - 1) + tau, by = 1),
-    dose_days + 0.25,
-    dose_days + 1,
-    dose_days + 3,
-    dose_days + 7
+    seq(0, 84, by = 1),            # daily through the VPC window
+    early_doses + 0.25,            # keep fine near-dose structure
+    early_doses + 1,               #   so the SC absorption peak is
+    early_doses + 3,               #   resolved in Figure 3
+    early_doses + 7,
+    seq(84, ss_start, by = 7),     # coarse bridge between windows
+    seq(ss_start, ss_end, by = 0.5) # dense SS cycle for NCA / plot
   )))
   ev_obs <- cohort |>
     tidyr::crossing(time = obs_days) |>
@@ -206,7 +230,7 @@ ggplot(vpc, aes(time, Q50, colour = treatment, fill = treatment)) +
     x = "Time (days)",
     y = "Sarilumab Cc (mg/L)",
     title = "Simulated 5-50-95 percentile profiles: 150 vs 200 mg SC Q2W",
-    caption = "Virtual RA cohort (N = 400); first 6 dosing cycles."
+    caption = "Virtual RA cohort (N = 200); first 6 dosing cycles."
   ) +
   theme_minimal()
 ```


### PR DESCRIPTION
Shrink the virtual cohort from 400 to 200 subjects, cut the dosing horizon from 50 to 12 Q2W doses (still ~17 half-lives, safely at steady state), and replace the uniform daily observation grid over 700 days with a three-band grid: daily through the Figure 3 VPC window (days 0-84), weekly bridge, dense (0.5 d) across the final SS cycle (days 154-168). Published figures and the PKNCA comparison against Xu 2019 Table 4 are unchanged; run time drops from ~28 min to ~1-2 min.

Inline code comments explain each change. Motivated by pkgdown-side profiling showing this single vignette accounted for 57% of the total serial build and capped the parallel-article Amdahl ceiling at 1.75x.