### PR TITLE
Deduplicate covariate-columns.md: merge IGG, BGENE21, STEROID_BL, ECOG_PS_GT0

### DIFF
--- a/inst/modeldb/specificDrugs/Zhang_2019_nivolumab.R
+++ b/inst/modeldb/specificDrugs/Zhang_2019_nivolumab.R
@@ -29,7 +29,7 @@ Zhang_2019_nivolumab <- function() {
       notes              = "Exponential effect on CL and on Vc; female reference value lower for both parameters. Source paper denotes the column SEX (1 = female, 0 = male per the Figure 1 caption naming the male reference patient).",
       source_name        = "SEX"
     ),
-    ECOG_PS_GT0 = list(
+    ECOG_GE1 = list(
       description        = "ECOG performance status > 0 indicator (binary collapse of the four-level scale)",
       units              = "(binary)",
       type               = "binary",
@@ -168,13 +168,13 @@ Zhang_2019_nivolumab <- function() {
     # Individual baseline CL (CL at t=0). All categorical effects are exponential
     # of the form exp(theta * indicator); continuous effects are power form
     # (cov / ref)^exponent. Reference covariates: WT 80 kg, eGFR 90 mL/min/1.73 m^2,
-    # male (SEXF=0), PS 0 (ECOG_PS_GT0=0), white/other race (RACE_BLACK=0 and
+    # male (SEXF=0), PS 0 (ECOG_GE1=0), white/other race (RACE_BLACK=0 and
     # RACE_ASIAN=0), monotherapy (all COADMIN_*=0).
     cl0 <- exp(lcl + etalcl) *
       (WT   / 80)^e_wt_cl *
       (CRCL / 90)^e_egfr_cl *
       exp(e_sexf_cl    * SEXF) *
-      exp(e_ecog_cl    * ECOG_PS_GT0) *
+      exp(e_ecog_cl    * ECOG_GE1) *
       exp(e_black_cl   * RACE_BLACK) *
       exp(e_asian_cl   * RACE_ASIAN) *
       exp(e_ipi3q3w_cl * COADMIN_IPI_3Q3W) *
@@ -194,7 +194,7 @@ Zhang_2019_nivolumab <- function() {
     # Time-varying CL: Hill-Emax function of time since first dose.
     t50  <- exp(lt50)
     hill <- exp(lhill)
-    Emax_i <- Emax + e_ecog_emax * ECOG_PS_GT0 + e_ipico_emax * COADMIN_IPI_ANY + etaEmax
+    Emax_i <- Emax + e_ecog_emax * ECOG_GE1 + e_ipico_emax * COADMIN_IPI_ANY + etaEmax
     cl <- cl0 * exp(Emax_i * t^hill / (t50^hill + t^hill))
 
     # Two-compartment micro-constants.

--- a/inst/modeldb/specificDrugs/Zheng_2016_sifalimumab.R
+++ b/inst/modeldb/specificDrugs/Zheng_2016_sifalimumab.R
@@ -21,12 +21,12 @@ Zheng_2016_sifalimumab <- function() {
       notes              = "Used for power-form scaling of CL with reference value 12.04 (median of the SLE cohort; range 0.32-38.59). The 21-gene panel is the AstraZeneca/MedImmune SLE development programme signature; effect exponent 0.09 on CL (Zheng 2016 Table 2).",
       source_name        = "BGENE21"
     ),
-    STEROID_BL = list(
+    STEROID = list(
       description        = "Baseline (concomitant) systemic corticosteroid use at study entry",
       units              = "(binary)",
       type               = "binary",
       reference_category = "0 (not on steroids at baseline)",
-      notes              = "85% of the phase IIb cohort were on baseline steroids. Applied as a multiplicative fractional effect on CL `(1 + 0.11 * STEROID_BL)` and on V1 `(1 - 0.09 * STEROID_BL)` (Zheng 2016 Table 2).",
+      notes              = "85% of the phase IIb cohort were on baseline steroids. Applied as a multiplicative fractional effect on CL `(1 + 0.11 * STEROID)` and on V1 `(1 - 0.09 * STEROID)` (Zheng 2016 Table 2).",
       source_name        = "BSTEROID"
     ),
     DOSE = list(
@@ -61,20 +61,20 @@ Zheng_2016_sifalimumab <- function() {
   ini({
     # Structural parameters - Zheng 2016 Table 2 final-model estimates for a typical patient
     # representing median WT = 64.3 kg, median BGENE21 = 12.04, 600 mg dose (for V1), and
-    # not on baseline steroids (STEROID_BL = 0).
+    # not on baseline steroids (STEROID = 0).
     lcl <- log(0.184); label("Clearance CL for typical patient (L/day)")                     # Zheng 2016 Table 2, theta1
     lvc <- log(2.82);  label("Central volume of distribution V1 for typical patient (L)")    # Zheng 2016 Table 2, theta2
     lvp <- log(1.88);  label("Peripheral volume of distribution V2 (L)")                     # Zheng 2016 Table 2, theta3
     lq  <- log(0.34);  label("Inter-compartmental clearance Q (L/day)")                      # Zheng 2016 Table 2, theta4
 
-    # Covariate effects on CL - power-form on WT and BGENE21, fractional on STEROID_BL.
-    # CL = theta1 * (WT/64.3)^theta5 * (BGENE21/12.04)^theta6 * (1 + theta7 * STEROID_BL)
+    # Covariate effects on CL - power-form on WT and BGENE21, fractional on STEROID.
+    # CL = theta1 * (WT/64.3)^theta5 * (BGENE21/12.04)^theta6 * (1 + theta7 * STEROID)
     e_wt_cl       <- 0.45; label("Power exponent of WT on CL (unitless, reference 64.3 kg)") # Zheng 2016 Table 2, theta5
     e_bgene21_cl  <- 0.09; label("Power exponent of BGENE21 on CL (unitless, reference 12.04)") # Zheng 2016 Table 2, theta6
     e_steroid_cl  <- 0.11; label("Fractional increase in CL for baseline steroid users")      # Zheng 2016 Table 2, theta7
 
-    # Covariate effects on V1 - power-form on WT and DOSE, fractional on STEROID_BL.
-    # V1 = theta2 * (WT/64.3)^theta8 * (DOSE/600)^theta9 * (1 - theta10 * STEROID_BL)
+    # Covariate effects on V1 - power-form on WT and DOSE, fractional on STEROID.
+    # V1 = theta2 * (WT/64.3)^theta8 * (DOSE/600)^theta9 * (1 - theta10 * STEROID)
     e_wt_vc       <- 0.36; label("Power exponent of WT on V1 (unitless, reference 64.3 kg)") # Zheng 2016 Table 2, theta8
     e_dose_vc     <- 0.06; label("Power exponent of DOSE on V1 (unitless, reference 600 mg)") # Zheng 2016 Table 2, theta9
     e_steroid_vc  <- 0.09; label("Fractional decrease in V1 for baseline steroid users")      # Zheng 2016 Table 2, theta10
@@ -97,8 +97,8 @@ Zheng_2016_sifalimumab <- function() {
 
   model({
     # Covariate effects on CL and V1 per Zheng 2016 Equations (final model).
-    cov_cl <- (WT / 64.3)^e_wt_cl * (BGENE21 / 12.04)^e_bgene21_cl * (1 + e_steroid_cl * STEROID_BL)
-    cov_vc <- (WT / 64.3)^e_wt_vc * (DOSE / 600)^e_dose_vc         * (1 - e_steroid_vc * STEROID_BL)
+    cov_cl <- (WT / 64.3)^e_wt_cl * (BGENE21 / 12.04)^e_bgene21_cl * (1 + e_steroid_cl * STEROID)
+    cov_vc <- (WT / 64.3)^e_wt_vc * (DOSE / 600)^e_dose_vc         * (1 - e_steroid_vc * STEROID)
 
     # Individual PK parameters.
     cl <- exp(lcl + etalcl) * cov_cl

--- a/inst/references/covariate-columns.md
+++ b/inst/references/covariate-columns.md
@@ -198,15 +198,16 @@ Covariate column names should be ALL CAPS. Current non-all-caps canonical names 
 - **Notes:** Ratified canonically on 2026-04-19 after cross-model review. Unit varies by paper (g/dL in US-convention papers, g/L in SI-convention papers); the per-model `covariateData[[ALB]]$units` field is load-bearing. Effect-coefficient magnitude is meaningless without the unit.
 
 ### IGG (**canonical for serum immunoglobulin G**)
-- **Description:** Serum total immunoglobulin G concentration (baseline or time-varying).
+- **Description:** Serum total immunoglobulin G concentration (baseline or time-varying). Used in mAb PK analyses as a competition-for-FcRn-recycling covariate on therapeutic-mAb clearance — high endogenous IgG is hypothesized to displace the therapeutic mAb from FcRn salvage and increase its catabolic clearance.
 - **Units:** g/L (typical in SI-convention papers); also reported as mg/dL in US-convention papers — document the unit used in each model via `covariateData[[IGG]]$units`.
 - **Type:** continuous
 - **Scope:** general
-- **Reference category:** n/a — used with power scaling `(IGG / ref)^exponent`.
+- **Reference category:** n/a — used with power scaling `(IGG / ref)^exponent`. Reference values observed: 14.8 g/L (Zhou 2021), 9.65 g/L (Yang 2021).
 - **Source aliases:**
   - `BIGG` (baseline IgG) — used in `Zhou_2021_belimumab.R`.
-- **Example models:** `Zhou_2021_belimumab.R` (g/L, reference 14.8; baseline-only; exponent 0.293 on CL — endogenous IgG competes with the therapeutic mAb for FcRn recycling).
-- **Notes:** Mechanistically meaningful for monoclonal-antibody PK because endogenous IgG competes with the therapeutic mAb for FcRn-mediated recycling. The per-model `covariateData[[IGG]]$units` field is load-bearing (1 g/L ≈ 100 mg/dL). Baseline-vs-time-varying status documented in `covariateData[[IGG]]$notes`.
+  - `IGGBL` (baseline IgG) — used in `Yang_2021_cemiplimab.R`.
+- **Example models:** `Zhou_2021_belimumab.R` (g/L, reference 14.8; baseline-only; exponent 0.293 on CL), `Yang_2021_cemiplimab.R` (g/L, reference 9.65; small positive exponent 0.184 on shared CL/Q).
+- **Notes:** Mechanistically meaningful for monoclonal-antibody PK because endogenous IgG competes with the therapeutic mAb for FcRn-mediated recycling. The per-model `covariateData[[IGG]]$units` field is load-bearing (1 g/L ≈ 100 mg/dL). Baseline-vs-time-varying status documented in `covariateData[[IGG]]$notes`. Distinct from `lIgG0` / IgG-as-a-state in mechanistic FcRn-competition TMDD models (e.g., `Valenzuela_2025_nipocalimab.R`), where IgG is a dynamic state, not a baseline covariate; use `IGG` only when the source paper treats IgG as a static (baseline) covariate column.
 
 ### TBILI (**canonical for total bilirubin**)
 - **Description:** Total serum bilirubin concentration.
@@ -249,17 +250,6 @@ Covariate column names should be ALL CAPS. Current non-all-caps canonical names 
   - `BLDH` (baseline LDH) — used in `Sanghavi_2020_ipilimumab.R`.
 - **Example models:** `Sanghavi_2020_ipilimumab.R` (linear-on-log form on CL with reference 217 U/L; coefficient 0.703).
 - **Notes:** Universal lab marker. Sanghavi 2020 log-transforms LDH because the distribution is heavily right-skewed (range 74-6,245 U/L over a median of 217); other papers may use a simple `(LDH/ref)^exponent` form. Document the functional form in `covariateData[[LDH]]$notes`.
-
-### IGG (**canonical for endogenous serum immunoglobulin G concentration**)
-- **Description:** Endogenous (host-produced) serum immunoglobulin G concentration. Used in oncology / mAb PK analyses as a competition-for-FcRn-recycling covariate on therapeutic-mAb clearance — high endogenous IgG is hypothesized to displace the therapeutic mAb from FcRn salvage and increase its catabolic clearance.
-- **Units:** g/L. Document per-model via `covariateData[[IGG]]$units`.
-- **Type:** continuous
-- **Scope:** general
-- **Reference category:** n/a — used with power scaling `(IGG / ref)^exponent`. Reference values observed: 9.65 g/L (Yang 2021).
-- **Source aliases:**
-  - `IGGBL` (baseline IgG) — used in `Yang_2021_cemiplimab.R`.
-- **Example models:** `Yang_2021_cemiplimab.R` (g/L, reference 9.65; small positive exponent 0.184 on shared CL/Q).
-- **Notes:** Distinct from `lIgG0` / IgG-as-a-state in mechanistic FcRn-competition TMDD models (e.g., `Valenzuela_2025_nipocalimab.R`), where IgG is a dynamic state, not a baseline covariate. Use `IGG` only when the source paper treats IgG as a static (baseline) covariate column. Ratified canonically on 2026-04-25.
 
 ## Hematology
 
@@ -319,15 +309,15 @@ Covariate column names should be ALL CAPS. Current non-all-caps canonical names 
 
 ## Interferon / biomarker panels
 
-### BGENE21
-- **Description:** Baseline type I interferon gene signature computed from the expression of 21 IFN-alpha / type-I-IFN-inducible transcripts in peripheral blood mononuclear cells. Used as a continuous biomarker of type I IFN pathway activation in SLE (and mechanistically-related indications).
-- **Units:** (gene-signature score, unitless)
+### BGENE21 (**canonical for 21-gene type I interferon signature score**)
+- **Description:** Baseline 21-gene type I interferon signature score — a composite transcriptomic score summarising the expression of 21 interferon-regulated genes in whole blood relative to a healthy-donor reference, used as a biomarker of type I IFN pathway activation in SLE and related autoimmune conditions.
+- **Units:** unitless fold-change score (relative to healthy-donor reference).
 - **Type:** continuous
 - **Scope:** specific
-- **Reference category:** n/a — used with power scaling `(BGENE21 / ref)^exponent`. Reference value observed: 32 in Narwal 2013 (study-population median was 33).
+- **Reference category:** n/a — used with power scaling `(BGENE21 / ref)^exponent`. Reference values observed: 32 in Narwal 2013 (study-population median was 33), 12.04 in Zheng 2016 (median of the SLE phase IIb cohort, range 0.32-38.59).
 - **Source aliases:** none.
-- **Example models:** `Narwal_2013_sifalimumab.R` (reference 32, exponent 0.0558 on CL).
-- **Notes:** Specific to studies that report a 21-gene IFN signature (subset / expansion of the "BGENE4" 4-gene signature). If another paper uses the 4-gene signature or a differently-constructed IFN score, register a distinct canonical (`BGENE4`, `IFN_SIG`, ...).
+- **Example models:** `Narwal_2013_sifalimumab.R` (reference 32, exponent 0.0558 on CL), `Zheng_2016_sifalimumab.R` (reference 12.04, power effect on CL with exponent 0.09).
+- **Notes:** Specific to drugs whose mechanism targets the type I IFN pathway (e.g., anti-IFN-alpha antibodies like sifalimumab, anifrolumab). Higher BGENE21 indicates stronger target engagement / disease activity and is associated with increased drug clearance via target-mediated mechanisms. The 21-gene panel composition is tied to the MedImmune/AstraZeneca SLE development programme; a different IFN gene signature (e.g., a 4-gene or 5-gene panel) should be registered under its own canonical name (`BGENE4`, `IFN_SIG`, ...) to avoid conflating panel definitions.
 
 ## Inflammation markers
 
@@ -341,16 +331,6 @@ Covariate column names should be ALL CAPS. Current non-all-caps canonical names 
   - `BEOS` (baseline EOS) — used in `Kotani_2022_astegolimab.R`.
 - **Example models:** `Kotani_2022_astegolimab.R` (reference 180 cells/µL, baseline).
 - **Notes:** Used as a surrogate of inflammatory burden that correlates with protein turnover and therefore mAb clearance. Canonical name drops the `B` prefix to match the `EASI` / `AGE` / `WT` / `ALB` pattern; baseline-vs-time-varying status is documented in `covariateData[[EOS]]$notes`.
-
-### BGENE21 (**canonical for 21-gene type I interferon signature score**)
-- **Description:** Baseline 21-gene type I interferon signature score — a composite transcriptomic score summarising the expression of 21 interferon-regulated genes in whole blood relative to a healthy-donor reference, used as a biomarker of type I IFN pathway activation in SLE and related autoimmune conditions.
-- **Units:** unitless fold-change score (relative to healthy-donor reference).
-- **Type:** continuous
-- **Scope:** specific
-- **Reference category:** n/a — used with power scaling `(BGENE21 / ref)^exponent`. Reference value observed: 12.04 in `Zheng_2016_sifalimumab.R` (median of the SLE phase IIb cohort, range 0.32-38.59).
-- **Source aliases:** none.
-- **Example models:** `Zheng_2016_sifalimumab.R` (power effect on CL with exponent 0.09).
-- **Notes:** Specific to drugs whose mechanism targets the type I IFN pathway (e.g., anti-IFN-alpha antibodies like sifalimumab, anifrolumab). Higher BGENE21 indicates stronger target engagement / disease activity and is associated with increased drug clearance via target-mediated mechanisms. Scope: specific because the 21-gene panel composition is tied to the MedImmune/AstraZeneca SLE development programme; a different IFN gene signature (e.g., a 4-gene or 5-gene panel) should be registered under its own canonical name to avoid conflating panel definitions.
 
 ### BLBCELL (**canonical for baseline CD19+ B cell count**)
 - **Description:** Baseline CD19+ B cell count (cells/µL) measured by fluorescence-activated cell sorting (FACS) prior to first dose. Used as a covariate / scaling biomarker for B-cell-targeted antibody PK-PD models (e.g., anti-CD20 mAbs in multiple sclerosis or B cell malignancies).
@@ -664,16 +644,17 @@ Covariate column names should be ALL CAPS. Current non-all-caps canonical names 
 - **Notes:** Liver metastases are associated with hepatic protein-synthesis impairment and altered IgG catabolism, making `LMET` a commonly tested covariate in oncology mAb population PK analyses. Scope: general so future oncology papers can reuse the canonical column. Time-fixed baseline indicator; if a source paper treats it as time-varying (progression during treatment), document in `covariateData[[LMET]]$notes`.
 
 ### ECOG_GE1 (**canonical for Eastern Cooperative Oncology Group performance-status indicator, >= 1**)
-- **Description:** 1 if baseline Eastern Cooperative Oncology Group (ECOG) performance status is greater than or equal to 1, 0 if ECOG = 0.
+- **Description:** 1 if baseline Eastern Cooperative Oncology Group (ECOG) performance status is greater than or equal to 1, 0 if ECOG = 0. Time-fixed per subject.
 - **Units:** (binary)
 - **Type:** binary
 - **Scope:** general
 - **Reference category:** 0 (ECOG performance status = 0, i.e., fully active / asymptomatic).
 - **Source aliases:**
-  - `PS` / `BPS` — the Bajaj 2017 nivolumab analysis reports "baseline performance status" (BPS) as a binary ECOG-derived indicator. In Bajaj 2017 the one study using Karnofsky Performance Status (KPS) values was mapped to the ECOG scale per Oken 1982 before thresholding.
-  - `ECOG_1` — alternative explicit form; equivalent to `ECOG_GE1` when ECOG only takes values 0, 1, 2 in the analysis dataset (which is the typical oncology case).
-- **Example models:** `Bajaj_2017_nivolumab.R` (exponential effect on CL with coefficient 0.172, reference 0).
-- **Notes:** Oncology papers conventionally report ECOG as an integer (0-5) but binarize at >= 1 because ECOG >= 2 is rare in trial cohorts. When a source paper provides the ordinal ECOG score separately, derive `ECOG_GE1 = as.integer(ECOG >= 1)`. If a future paper needs finer resolution (e.g., separate effects for ECOG 1 vs ECOG 2), add a parallel `ECOG_GE2` canonical rather than overloading this one.
+  - `PS` / `BPS` — used in `Bajaj_2017_nivolumab.R` (BPS = "baseline performance status"; the one study using Karnofsky Performance Status was mapped to ECOG via Oken 1982 before binarization) and `Zhang_2019_nivolumab.R` (paper's binary collapse PS=0 vs. PS>0).
+  - `ECOG_1` — alternative explicit form; equivalent to `ECOG_GE1` when ECOG only takes values 0, 1, 2 in the analysis dataset (the typical oncology case).
+  - `ECOG_PS_GT0` — retired name used in earlier register drafts; semantically identical (`>= 1` equals `> 0` for integer ECOG scores).
+- **Example models:** `Bajaj_2017_nivolumab.R` (exponential effect on CL with coefficient 0.172), `Zhang_2019_nivolumab.R` (exponential effect exp(0.181) on baseline CL; additive effect -0.138 on the time-varying-CL Emax parameter).
+- **Notes:** Oncology papers conventionally report ECOG as an integer (0-5) but binarize at >= 1 because ECOG >= 2 is rare in trial cohorts. When a source paper provides the ordinal ECOG score separately, derive `ECOG_GE1 = as.integer(ECOG >= 1)`. Zhang 2019 uses `ECOG_GE1` on both baseline CL and the time-varying Emax parameter (unlike Bajaj 2017, which uses it on CL only); document the structural role in each model's `covariateData[[ECOG_GE1]]$notes`. If a future paper needs finer resolution (e.g., separate effects for ECOG 1 vs ECOG 2), add a parallel `ECOG_GE2` canonical rather than overloading this one.
 
 ### TUMTP_SCLC (**canonical for small-cell-lung-cancer tumor-type indicator**)
 - **Description:** 1 = small cell lung cancer (SCLC), 0 = other tumor types.
@@ -729,17 +710,6 @@ Covariate column names should be ALL CAPS. Current non-all-caps canonical names 
   - `COMBO` — used in `Sanghavi_2020_ipilimumab.R`. Equivalently derivable from `NIVO_REGIMEN` as `COMBO_NIVO = as.integer(NIVO_REGIMEN != "none")`.
 - **Example models:** `Sanghavi_2020_ipilimumab.R` (additive effect -0.202 on the Emax parameter of the time-varying CL function).
 - **Notes:** Distinct from the per-regimen `NIVO_1Q3W` / `NIVO_3Q2W` indicators on baseline CL: `COMBO_NIVO` aggregates across all nivolumab regimens and acts on the time-varying-CL Emax parameter, whereas the per-regimen indicators act on baseline (time-zero) CL.
-
-### ECOG_PS_GT0 (**canonical for ECOG performance status > 0 indicator**)
-- **Description:** 1 = ECOG (Eastern Cooperative Oncology Group) performance status greater than 0 at baseline (i.e., PS 1, 2, 3, or 4); 0 = ECOG PS 0 (fully active). Time-fixed per subject.
-- **Units:** (binary)
-- **Type:** binary
-- **Scope:** general
-- **Reference category:** 0 (ECOG PS 0; fully active).
-- **Source aliases:**
-  - `PS` — used in `Zhang_2019_nivolumab.R` (paper's binary collapse of the four-level ECOG scale into PS=0 vs. PS>0).
-- **Example models:** `Zhang_2019_nivolumab.R` (multiplicative effect on baseline CL, additive effect on Emax of time-varying CL).
-- **Notes:** Many oncology PopPK papers report a binary-collapsed performance-status indicator rather than the full ECOG scale. The "GT0" suffix preserves the dichotomization explicitly. If a future paper uses a different cut-point (e.g., PS<=1 vs. PS>=2), register it as `ECOG_PS_GT1` rather than reusing this column.
 
 ## Laboratory / disease-activity
 
@@ -906,16 +876,17 @@ Covariate column names should be ALL CAPS. Current non-all-caps canonical names 
 - **Example models:** `Ma_2020_sarilumab_das28crp.R` (multiplicative on DAS28-CRP Kout: `Kout * theta^PRICORT`); `Ma_2020_sarilumab_anc.R` (power-form on Emax: `Emax * 0.819^PRICORT`).
 - **Notes:** Ma 2020 applies it as a multiplicative effect of the form `param * theta^PRICORT` in both DAS28-CRP and ANC PD models. Generally applicable clinical-history indicator.
 
-### STEROID
-- **Description:** 1 = patient on systemic corticosteroid therapy at baseline (typically continued as concomitant medication during the study), 0 = no baseline corticosteroid use.
+### STEROID (**canonical for baseline/concomitant systemic corticosteroid use**)
+- **Description:** 1 = patient on systemic corticosteroid therapy at baseline (typically continued as concomitant medication during the study), 0 = no baseline corticosteroid use. Time-fixed per subject.
 - **Units:** (binary)
 - **Type:** binary
 - **Scope:** general
 - **Reference category:** 0 (no baseline corticosteroid use).
 - **Source aliases:**
-  - `BSTEROID` — used in `Narwal_2013_sifalimumab.R`.
-- **Example models:** `Narwal_2013_sifalimumab.R` (multiplicative on CL: `CL * (1 + 0.195 * STEROID)`).
-- **Notes:** Distinct from `PRICORT`, which is strictly a prior (pre-study) indicator. `STEROID` captures concurrent corticosteroid use at / from study baseline. When a future paper needs the two jointly, both can coexist on the same subject.
+  - `BSTEROID` — used in `Narwal_2013_sifalimumab.R` and `Zheng_2016_sifalimumab.R`.
+- **Example models:** `Narwal_2013_sifalimumab.R` (multiplicative on CL: `CL * (1 + 0.195 * STEROID)`), `Zheng_2016_sifalimumab.R` (multiplicative on CL `(1 + 0.11 * STEROID)` and on V1 `(1 - 0.09 * STEROID)` in the SLE phase IIb cohort, which was ~85% steroid-treated at baseline).
+- **Notes:** Distinct from `PRICORT`, which is strictly a prior (pre-study) indicator. `STEROID` captures concurrent corticosteroid use at / from study baseline in diseases where background steroid use is standard of care (SLE, severe asthma, etc.). When a future paper needs the two jointly, both can coexist on the same subject. The name `STEROID_BL` was used as an alias in earlier register drafts and is retired; use `STEROID` for all future models.
+
 ### COADMIN_IPI_3Q3W (**canonical for nivolumab + ipilimumab 3 mg/kg q3w combination indicator**)
 - **Description:** 1 = subject is receiving nivolumab in combination with ipilimumab 3 mg/kg every 3 weeks (4-dose induction); 0 = otherwise. Encodes the high-intensity ipilimumab combination regimen as a study-design covariate on nivolumab CL.
 - **Units:** (binary)
@@ -959,17 +930,6 @@ Covariate column names should be ALL CAPS. Current non-all-caps canonical names 
   - `IPICO` — used in `Zhang_2019_nivolumab.R`.
 - **Example models:** `Zhang_2019_nivolumab.R` (additive effect on the time-varying-CL Emax parameter: Emax += -0.0668 when COADMIN_IPI_ANY = 1).
 - **Notes:** Logically the union of the regimen-specific indicators (COADMIN_IPI_3Q3W, COADMIN_IPI_1Q6W, plus the unmodeled 1 mg/kg q3wx4 and 1 mg/kg q12w schedules). Zhang 2019 uses it on the *time-varying* Emax (a different structural parameter from baseline CL), which is why it coexists with the regimen-specific indicators on baseline CL rather than substituting for them.
-
-### STEROID_BL (**canonical for baseline/concomitant systemic steroid use**)
-- **Description:** 1 = patient is on systemic corticosteroid treatment at study entry (baseline concomitant use), 0 = not on steroids at baseline. Time-fixed per subject.
-- **Units:** (binary)
-- **Type:** binary
-- **Scope:** general
-- **Reference category:** 0 (not on steroids at baseline).
-- **Source aliases:**
-  - `BSTEROID` — used in `Zheng_2016_sifalimumab.R`.
-- **Example models:** `Zheng_2016_sifalimumab.R` (multiplicative effects on CL `(1 + 0.11 * STEROID_BL)` and on V1 `(1 - 0.09 * STEROID_BL)` in the SLE phase IIb cohort, which was ~85% steroid-treated at baseline).
-- **Notes:** Distinct from `PRICORT`, which captures systemic corticosteroid use *prior* to study entry as a one-time clinical-history indicator. `STEROID_BL` captures ongoing/concomitant steroid therapy at baseline in diseases where background steroid use is standard of care (SLE, severe asthma, etc.). In some studies the prior-vs-baseline distinction is immaterial (patients on steroids at baseline have also taken them prior) but the semantic difference is preserved here so that future models can use the appropriate indicator.
 
 ### STATIN (**canonical for concomitant statin (HMG-CoA reductase inhibitor) therapy**)
 - **Description:** 1 = patient coadministered a statin (HMG-CoA reductase inhibitor) during the study, 0 = no statin coadministration.
@@ -1417,6 +1377,7 @@ Covariate column names should be ALL CAPS. Current non-all-caps canonical names 
 
 ## Change log
 
+- **2026-04-26** — Deduplicated four covariate entries that were registered twice during sequential model-PR merges: (1) merged second `IGG` entry (Yang 2021 cemiplimab) into the first (Zhou 2021 belimumab) — both papers use the same canonical `IGG` column, so the entry now lists both source aliases (`BIGG`, `IGGBL`) and both reference values (14.8 g/L, 9.65 g/L); (2) merged second `BGENE21` entry (Zheng 2016 sifalimumab, misfiled under Inflammation markers) into the first (Narwal 2013 sifalimumab, under Interferon / biomarker panels); (3) merged `STEROID_BL` (Zheng 2016 sifalimumab) into `STEROID` (Narwal 2013 sifalimumab) — both encode the same baseline/concomitant corticosteroid indicator, `STEROID` is the preferred shorter name, `STEROID_BL` retired; `Zheng_2016_sifalimumab.R` updated accordingly; (4) merged `ECOG_PS_GT0` (Zhang 2019 nivolumab) into `ECOG_GE1` (Bajaj 2017 nivolumab) — `>= 1` equals `> 0` for integer ECOG scores, `ECOG_GE1` is the preferred name (consistent with a potential future `ECOG_GE2`), `ECOG_PS_GT0` retired; `Zhang_2019_nivolumab.R` updated accordingly.
 - **2026-04-26** — Added `DIS_DMD` (specific scope) canonical entry while extracting `Wojciechowski_2022_domagrozumab.R`. Source alias `SPOP`; orientation matches the source (1 = DMD pediatric patient, 0 = healthy adult volunteer reference). The covariate enters as a `(1 + theta * DIS_DMD)` multiplicative shift (additive on the linear scale, not exponentiated) rather than the typical `theta^DIS_DMD` form, matching Eqs. 7-8 of the paper.
 - **2026-04-21** — Added `RACE_HISPANIC` (general) and `CLD_PREM` (general) canonical entries while extracting `Robbie_2012_palivizumab.R`. Extended `ADA_TITER` example_models with the Robbie 2012 category-by-titer-bin usage, and added `Robbie_2012_palivizumab.R` to the `WT`, `PAGE`, `RACE_BLACK`, `RACE_ASIAN`, and `RACE_OTHER` example lists. `HISPANIC`, `CLD`, and `BPD` recorded as source aliases.
 - **Initial seed**: Every covariate observed in `inst/modeldb/` as of the audit. Canonical names established: `SEXF`, `ADA_POS`, `RACE_<GROUP>` prefix. Aliases documented but existing model files not modified.

--- a/vignettes/articles/Zhang_2019_nivolumab.Rmd
+++ b/vignettes/articles/Zhang_2019_nivolumab.Rmd
@@ -123,7 +123,7 @@ Equation forms:
 - Q: `Q = Q_REF * (WT/80)^e_wt_cl` (CL exponent reused per Methods).
 - Vp: `Vp = VP_REF * (WT/80)^e_wt_vc` (Vc exponent reused per Methods).
 - Time-varying CL: `CL(t) = CL0 * exp(Emax_i * t^HILL / (T50^HILL + t^HILL))`.
-- Emax_i: additive linear-scale form `Emax_REF + e_ecog_emax * ECOG_PS_GT0 + e_ipico_emax * COADMIN_IPI_ANY + etaEmax`.
+- Emax_i: additive linear-scale form `Emax_REF + e_ecog_emax * ECOG_GE1 + e_ipico_emax * COADMIN_IPI_ANY + etaEmax`.
 
 # Covariate column naming
 
@@ -132,7 +132,7 @@ Equation forms:
 | `BBWT` (kg) | `WT` |
 | `eGFR` (mL/min/1.73 m^2) | `CRCL` |
 | `SEX` (1 = female / 0 = male) | `SEXF` (canonical for sex) |
-| `PS` (binary collapse: PS>0 vs PS=0) | `ECOG_PS_GT0` |
+| `PS` (binary collapse: PS>0 vs PS=0) | `ECOG_GE1` |
 | `RAAA` (1 = African American) | `RACE_BLACK` |
 | `RAAS` (1 = Asian) | `RACE_ASIAN` |
 | `IPI3Q3W` | `COADMIN_IPI_3Q3W` |
@@ -173,7 +173,7 @@ CRCL <- pmin(pmax(rnorm(n_subj, mean = 90, sd = 22), 30), 180)
 SEXF <- rbinom(n_subj, 1, 0.40)
 
 # ECOG PS > 0: Table 1 reports PS 0 in 47.02%, so PS > 0 in ~52.98%.
-ECOG_PS_GT0 <- rbinom(n_subj, 1, 0.5298)
+ECOG_GE1 <- rbinom(n_subj, 1, 0.5298)
 
 # Race indicators: assume the global trial mix has small Asian and Black
 # fractions. Zhang 2019 does not publish per-category percentages in the
@@ -186,7 +186,7 @@ RACE_ASIAN <- pmin(RACE_ASIAN, 1L - RACE_BLACK)
 pop <- data.frame(
   ID = seq_len(n_subj),
   WT, CRCL,
-  SEXF, ECOG_PS_GT0, RACE_BLACK, RACE_ASIAN
+  SEXF, ECOG_GE1, RACE_BLACK, RACE_ASIAN
 )
 ```
 

--- a/vignettes/articles/Zheng_2016_sifalimumab.Rmd
+++ b/vignettes/articles/Zheng_2016_sifalimumab.Rmd
@@ -74,18 +74,18 @@ body holds the `population` list literal).
 | Q                                              | Zheng 2016 Table 2, theta4                    | 0.34 L/day                                                |
 | WT exponent on CL                              | Zheng 2016 Table 2, theta5                    | 0.45 (reference 64.3 kg)                                  |
 | BGENE21 exponent on CL                         | Zheng 2016 Table 2, theta6                    | 0.09 (reference 12.04)                                    |
-| STEROID_BL fractional effect on CL             | Zheng 2016 Table 2, theta7                    | +0.11 (so CL x (1 + 0.11 * STEROID_BL))                   |
+| STEROID fractional effect on CL             | Zheng 2016 Table 2, theta7                    | +0.11 (so CL x (1 + 0.11 * STEROID))                   |
 | WT exponent on V1                              | Zheng 2016 Table 2, theta8                    | 0.36 (reference 64.3 kg)                                  |
 | DOSE exponent on V1                            | Zheng 2016 Table 2, theta9                    | 0.06 (reference 600 mg)                                   |
-| STEROID_BL fractional effect on V1             | Zheng 2016 Table 2, theta10                   | -0.09 (so V1 x (1 - 0.09 * STEROID_BL))                   |
+| STEROID fractional effect on V1             | Zheng 2016 Table 2, theta10                   | -0.09 (so V1 x (1 - 0.09 * STEROID))                   |
 | BSV on CL (log-normal)                         | Zheng 2016 Table 2, BSV (CV %)                | 24% CV (omega^2 = log(CV^2 + 1) = 0.056016)               |
 | BSV on V1 (log-normal)                         | Zheng 2016 Table 2, BSV (CV %)                | 16% CV (omega^2 = 0.025278)                               |
 | IOV on V1 (per-occasion)                       | Zheng 2016 Table 2 / IOV paragraph            | 26% CV, seven infusions; **not implemented** (see below)  |
 | BSV correlations                               | Zheng 2016 Results                            | None significant; IIV treated as diagonal                 |
 | Proportional residual error                    | Zheng 2016 Table 2                            | 7.01% -> propSd = 0.0701 (fraction)                       |
 | Additive residual error                        | Zheng 2016 Table 2                            | 1.14 ug/mL                                                |
-| Covariate equation CL                          | Zheng 2016 Equations (Results)                | CL = theta1 * (WT/64.3)^0.45 * (BGENE21/12.04)^0.09 * (1 + 0.11 * STEROID_BL) |
-| Covariate equation V1                          | Zheng 2016 Equations (Results)                | V1 = theta2 * (WT/64.3)^0.36 * (DOSE/600)^0.06 * (1 - 0.09 * STEROID_BL)       |
+| Covariate equation CL                          | Zheng 2016 Equations (Results)                | CL = theta1 * (WT/64.3)^0.45 * (BGENE21/12.04)^0.09 * (1 + 0.11 * STEROID) |
+| Covariate equation V1                          | Zheng 2016 Equations (Results)                | V1 = theta2 * (WT/64.3)^0.36 * (DOSE/600)^0.06 * (1 - 0.09 * STEROID)       |
 | Dose regimens                                  | Zheng 2016 Table 1 and Methods                | 200, 600, or 1200 mg IV q4w for 52 weeks; loading dose day 15 |
 
 ## Virtual cohort
@@ -119,10 +119,10 @@ pop <- cohorts %>%
                            39), 131.3),
     BGENE21    = pmin(pmax(rlnorm(dplyr::n(), meanlog = log(12.04), sdlog = 0.8),
                            0.32), 38.59),
-    STEROID_BL = as.integer(runif(dplyr::n()) < 0.85),
+    STEROID = as.integer(runif(dplyr::n()) < 0.85),
     DOSE       = dose_mg
   ) %>%
-  select(ID, treatment, dose_mg, WT, BGENE21, STEROID_BL, DOSE)
+  select(ID, treatment, dose_mg, WT, BGENE21, STEROID, DOSE)
 
 pop
 ```
@@ -156,7 +156,7 @@ obs_times <- sort(unique(c(peri_dose, terminal)))
 dose_rows <- pop %>%
   tidyr::crossing(time = dose_days) %>%
   transmute(
-    ID, treatment, WT, BGENE21, STEROID_BL, DOSE,
+    ID, treatment, WT, BGENE21, STEROID, DOSE,
     time,
     amt  = dose_mg,
     evid = 1L,
@@ -166,7 +166,7 @@ dose_rows <- pop %>%
   )
 
 obs_rows <- pop %>%
-  select(ID, treatment, WT, BGENE21, STEROID_BL, DOSE) %>%
+  select(ID, treatment, WT, BGENE21, STEROID, DOSE) %>%
   tidyr::crossing(time = obs_times) %>%
   mutate(
     amt  = NA_real_,
@@ -371,12 +371,12 @@ accounts for < 10% of PK variability.
   first-order elimination from `central`, no explicit depot or
   absorption compartment.
 * **IIV:** diagonal matrix on CL and V1; no BSV on Q or V2.
-* **Covariates:** WT, BGENE21, STEROID_BL on CL; WT, DOSE,
-  STEROID_BL on V1. Collectively these accounted for < 10% of PK
+* **Covariates:** WT, BGENE21, STEROID on CL; WT, DOSE,
+  STEROID on V1. Collectively these accounted for < 10% of PK
   variability in the published final model.
 * **Typical terminal half-life** predicted from the structural
   parameters for a typical 64.3 kg patient with BGENE21 = 12.04,
-  DOSE = 600 mg, STEROID_BL = 0 is approximately 24 days
+  DOSE = 600 mg, STEROID = 0 is approximately 24 days
   (dominated by the central-compartment elimination rate
   CL/V1 = 0.184/2.82 = 0.0652 day^-1 plus the small peripheral
   redistribution term), consistent with the Results narrative.


### PR DESCRIPTION
Four covariate names were registered twice during sequential model-PR merges in merge-all-open-prs-3. This commit collapses each pair into a single canonical entry and updates all affected model/vignette files.

1. IGG — second entry (Yang 2021 cemiplimab) merged into first (Zhou 2021 belimumab). Both source aliases (BIGG, IGGBL) and both reference values (14.8 g/L, 9.65 g/L) now appear in one entry.

2. BGENE21 — second entry (Zheng 2016 sifalimumab, misfiled under Inflammation markers) merged into first (Narwal 2013 sifalimumab, under Interferon / biomarker panels). Both reference values and both papers now in one entry.

3. STEROID_BL → STEROID — STEROID_BL (Zheng 2016) and STEROID (Narwal 2013) encoded the same baseline/concomitant corticosteroid indicator. STEROID is the preferred shorter canonical name; STEROID_BL retired. Zheng_2016_sifalimumab.R and its vignette updated.

4. ECOG_PS_GT0 → ECOG_GE1 — both encode ECOG > 0 at baseline; ≥ 1 equals > 0 for integer ECOG scores. ECOG_GE1 preferred (consistent with a future ECOG_GE2 pattern); ECOG_PS_GT0 retired. Zhang_2019_ nivolumab.R and its vignette updated.