### PR TITLE
Close 9 gaps in extract-literature-model skill from 100-task drain

### DIFF
--- a/.claude/skills/extract-literature-model/SKILL.md
+++ b/.claude/skills/extract-literature-model/SKILL.md
@@ -25,15 +25,21 @@ Read these on demand; don't load them up front.
 ## Phase 1 — Source acquisition and scoping
 
 1. Confirm the source type (journal article, supplement, poster, regulatory document).
-2. **Check the study population species.** Skim the Methods / Subjects section. If every PK dataset contributing to the final model is non-human (rat, mouse, cyno, dog, etc.), stop and sidecar-ask the operator before drafting anything:
+2. **Verify the on-disk file is the paper the task names.** Open the source file (or its trimmed `.md` companion) and read the title + first-author line + journal + year. Compare against the task's `Paper metadata` block. If any of {first-author, year, journal, drug} disagrees, stop and sidecar-ask:
+
+   > The on-disk file `<filename>` reports `<actual-author> <actual-year>, <actual-journal>: "<actual-title>"` but the task names `<expected-author> <expected-year>, ... <expected-drug>`. Options: (A) the task metadata is wrong and the file is the right paper — please correct the task metadata, (B) the file is mislabelled — please drop the correct PDF, (C) skip this task. Which applies?
+
+   This catches both "wrong-PMID-in-filename" (e.g. Frey 2010 saved as `PMID_23436260.pdf`) and "wrong-drug-guessed" task-generator errors. Do not proceed with extraction until the mismatch is resolved.
+
+3. **Check the study population species.** Skim the Methods / Subjects section. If every PK dataset contributing to the final model is non-human (rat, mouse, cyno, dog, etc.), stop and sidecar-ask the operator before drafting anything:
 
    > This paper reports a preclinical-only (<species>) population PK model. nlmixr2lib is a library of human population-PK models. Should I (A) extract it anyway with clear preclinical metadata, (B) extract only a human-scaled projection if the paper includes one, or (C) skip this paper?
 
    If the paper has both preclinical and human cohorts and the final model is fit to pooled or human-only data, proceed normally — this trigger is specifically for animal-only final models. Record the operator's decision in the PR body.
 
-3. **Prefer trimmed markdown when available.** The preprocessor at `mab_human_consensus/tracking/preprocess_papers.py` writes a `<stem>_trimmed.md` next to each source file (PMC XML, PDF, DOCX, XLSX) containing only the sections the extraction actually needs: Title + Abstract + Methods + Results + Tables + Figure captions. The Introduction, Discussion, Conclusions, References, Acknowledgments, and publisher boilerplate are stripped. If `PMID_<pmid>_pmc_trimmed.md` (or `PMID_<pmid>_trimmed.md` for a PDF, or `<stem>_trimmed.md` for a supplement) exists, read it **instead of** the raw `.xml` / `.pdf` / `.docx` — it's typically 40-95% smaller with no loss of extractable content. Full-text sanity check on the trimmed file: ~15 KB+ (full-text trim) vs < 3 KB (abstract-only trim). Fall back to the raw source only if the `_trimmed.md` doesn't exist, the trim appears to have lost a specific piece of information you need (rare — only when the paper is structurally unusual), or you explicitly need the discarded sections (e.g., to quote a Discussion claim in the vignette narrative).
+4. **Prefer trimmed markdown when available.** The preprocessor at `mab_human_consensus/tracking/preprocess_papers.py` writes a `<stem>_trimmed.md` next to each source file (PMC XML, PDF, DOCX, XLSX) containing only the sections the extraction actually needs: Title + Abstract + Methods + Results + Tables + Figure captions. The Introduction, Discussion, Conclusions, References, Acknowledgments, and publisher boilerplate are stripped. If `PMID_<pmid>_pmc_trimmed.md` (or `PMID_<pmid>_trimmed.md` for a PDF, or `<stem>_trimmed.md` for a supplement) exists, read it **instead of** the raw `.xml` / `.pdf` / `.docx` — it's typically 40-95% smaller with no loss of extractable content. Full-text sanity check on the trimmed file: ~15 KB+ (full-text trim) vs < 3 KB (abstract-only trim). Fall back to the raw source only if the `_trimmed.md` doesn't exist, the trim appears to have lost a specific piece of information you need (rare — only when the paper is structurally unusual), or you explicitly need the discarded sections (e.g., to quote a Discussion claim in the vignette narrative).
 
-4. **Verify the source contains full text, not just the abstract.** Wiley / BJCP and some other publishers serve PMC XML containing only front matter + abstract. Before reading for model structure, run a quick sanity check (against the trimmed file if present, otherwise the raw source):
+5. **Verify the source contains full text, not just the abstract.** Wiley / BJCP and some other publishers serve PMC XML containing only front matter + abstract. Before reading for model structure, run a quick sanity check (against the trimmed file if present, otherwise the raw source):
 
    - Trimmed `.md` file size ≥ ~15 KB, or raw PMC XML ≥ ~40 KB (full-text XML is typically 100 KB+; abstract-only is usually < 20 KB).
    - The file contains a materially-present Methods section (not just a "Methods" heading followed by one abstract paragraph).
@@ -45,13 +51,21 @@ Read these on demand; don't load them up front.
 
    Never attempt extraction from an abstract alone — population-PK parameter values, covariate effects, and equations are not in an abstract.
 
-5. **Always search for supplementary information.** Supplements frequently contain the NONMEM control stream and parameter tables that disambiguate model structure. If the user provided only a main article, ask whether a supplement exists and request it.
-6. **Always search for errata, corrigenda, or author corrections.** Check the journal's landing page for the article, the publisher's "corrections" / "notices" feed, and a search like `"<first author> <year> <drug>" erratum` on PubMed and Google Scholar. Ask the user whether they are aware of any corrections if the source is paywalled or the search is inconclusive. **When an erratum revises a value used in the model (parameter estimate, covariate effect, equation, units), the erratum value takes precedence over the main publication.** If multiple errata exist, the most recent supersedes earlier ones. Record the erratum citation in the model file's `reference` metadata alongside the main paper, and in every in-file source-trace comment whose value comes from the erratum, point to the erratum (not the original table).
-7. **Verify parameters are final estimates, not initial estimates.** Supplement control streams usually list initial values in `$THETA` / `$OMEGA`; final values come from the paper's results table or `$TABLE` output. If only a control stream is available, confirm values against any published point estimates before treating them as final.
-8. **Multiple-model handling.**
-   - Base model + final model → extract only the final.
-   - Any other "multiple model" case (per-subpopulation, per-endpoint, sensitivity analyses) → list the candidates to the user and ask which to extract. Offer "one," "all," or "a subset."
-9. Confirm the target subdirectory under `inst/modeldb/` (usually `specificDrugs/`; endogenous, therapeuticArea, pharmacokinetics, and pharmacodynamics are also valid).
+6. **Detect upstream-popPK dependencies.** Skim Methods for phrases like "PK was described using the popPK model previously developed from <study/phase>", "the structural PK model was fixed from <reference>", "covariate effects were carried over from <author> et al.", or "the PK model from <prior publication> was used as a backbone." If the current paper's PD model fixes its PK parameters from a separate publication that is not on disk:
+
+   1. Try to identify the upstream paper from the references list (PMID, DOI, or full citation).
+   2. If identifiable: sidecar-ask whether the operator wants this task to acquire `depends_on: [<upstream-task>]` and pause until the upstream task completes — versus extracting only the PD layer with the upstream PK parameters reproduced inline.
+   3. If unidentifiable (e.g. "the popPK model from internal Phase 1/2 studies" with no specific citation): sidecar-ask whether to (A) skip the task, (B) proceed with parameters fixed inline as reported in the current paper, with a clear "upstream PK source not located" note in the vignette Errata, or (C) defer pending operator investigation.
+
+   Never silently fabricate upstream PK parameters from training data.
+
+7. **Always search for supplementary information.** Supplements frequently contain the NONMEM control stream and parameter tables that disambiguate model structure. If the user provided only a main article, ask whether a supplement exists and request it.
+8. **Always search for errata, corrigenda, or author corrections.** Check the journal's landing page for the article, the publisher's "corrections" / "notices" feed, and a search like `"<first author> <year> <drug>" erratum` on PubMed and Google Scholar. Ask the user whether they are aware of any corrections if the source is paywalled or the search is inconclusive. **When an erratum revises a value used in the model (parameter estimate, covariate effect, equation, units), the erratum value takes precedence over the main publication.** If multiple errata exist, the most recent supersedes earlier ones. Record the erratum citation in the model file's `reference` metadata alongside the main paper, and in every in-file source-trace comment whose value comes from the erratum, point to the erratum (not the original table).
+9. **Verify parameters are final estimates, not initial estimates.** Supplement control streams usually list initial values in `$THETA` / `$OMEGA`; final values come from the paper's results table or `$TABLE` output. If only a control stream is available, confirm values against any published point estimates before treating them as final.
+10. **Multiple-model handling.**
+    - Base model + final model → extract only the final.
+    - Any other "multiple model" case (per-subpopulation, per-endpoint, sensitivity analyses) → list the candidates to the user and ask which to extract. Offer "one," "all," or "a subset."
+11. Confirm the target subdirectory under `inst/modeldb/` (usually `specificDrugs/`; endogenous, therapeuticArea, pharmacokinetics, and pharmacodynamics are also valid).
 
 ## Phase 2 — Sync with origin/main and branch
 
@@ -69,6 +83,17 @@ will note that a fresh worktree has already been set up — verify with
 `git branch --show-current` and skip the `git fetch` / `git checkout -b`
 in that case. The runner provides the authoritative instructions for its
 own environment.)
+
+**Worktree resumption — handle pre-existing WIP.** Before drafting anything, run `git status -s` in the worktree. If the working tree is **not clean** (uncommitted modifications or untracked files), this worktree is a resumption of a prior task instance that crashed or was interrupted:
+
+1. Read every modified / untracked file under `inst/modeldb/specificDrugs/`, `inst/modeldb/<other-categories>/`, `vignettes/articles/`, `data/`, `inst/`, and `NEWS.md`.
+2. Decide whether the prior WIP is salvageable (sound enough to continue from where it stopped) or unsalvageable (revert to clean state via `git restore .` and `git clean -fd`, then start over).
+3. If salvageable: continue from where the prior run left off and note the resumption in the PR body so the reviewer is aware.
+4. If unsalvageable: clean and restart. No operator approval is required for the cleanup itself; the reset is automatic for an unsalvageable WIP.
+
+If the worktree's branch was **already committed and pushed in a prior run** (i.e. `git log origin/<branch>..HEAD` shows no new commits and the branch exists on origin with task content), that is a different case — the task was already completed previously. Sidecar-ask:
+
+> Worktree branch `<branch>` is already pushed with prior task content. Options: (A) verify the pushed branch and exit cleanly without re-extracting, (B) tear down and re-extract from scratch (operator may have new source files / new skill version). Which applies?
 
 ## Phase 3 — Model file
 
@@ -120,6 +145,30 @@ When any uncertainty remains, ask the user using this format:
 > Ambiguity at [source location]. Two plausible interpretations: (A) …, (B) …. Which applies?
 
 Never silently resolve ambiguity. Never tune parameter values to match a validation target.
+
+**Missing-parameter / author-correspondence pathway.** If a parameter you need to populate the model is **not present anywhere on disk** (not in the main paper, not in any supplement, not in any associated regulatory review), do not substitute a training-data value or a "typical" textbook value. Sidecar-ask:
+
+> Parameter `<name>` (e.g. `kdeg`, `V_DXd`) is required for the <full-TMDD / payload-PK / structural> model but is not reported in any source on disk for <paper>. Options: (A) draft an author-correspondence email and pause this task pending reply (operator handles the email), (B) approximate with <QSS / steady-state / fixed-from-class> and document the approximation in vignette Errata, (C) skip this paper. Which applies?
+
+Operator-followup tracking: unresolved-parameter cases are recorded in `tracking/operator_followups.md` (the `F1`, `F2`, ... numbered register) so the operator can batch-send author emails. When a reply arrives with a numeric value, the operator records it in the followups file; this skill does NOT email authors.
+
+**Non-paper provenance — annotate inline.** When a parameter value did not come from the paper's text or tables — e.g. the operator read it off a graphical figure, an author supplied it via email correspondence, or it was carried from an upstream-task model file — record the provenance as an inline comment on the parameter line so the source-trace is unambiguous:
+
+```r
+ini({
+  # paper-derived (Table 4)
+  lcl <- log(0.225) ; label("Clearance (L/day)")
+
+  # author correspondence (J. Almquist email 2026-04-29);
+  # see tracking/operator_followups.md F12
+  lkdeg <- log(0.0231) ; label("Receptor degradation rate (1/day)")
+
+  # operator-extracted from Figure 2 (digitised); ±10% uncertainty
+  lvdxd <- log(0.038) ; label("DXd payload volume (L/kg) — figure-derived")
+})
+```
+
+This is mandatory for any parameter not from the paper text/tables. The vignette's Assumptions and deviations / Errata section must also list the non-paper provenance (see `references/vignette-template.md`).
 
 ## Phase 5 — Validation vignette
 
@@ -218,6 +267,10 @@ Don't guess — ask the user when:
 - An erratum search is inconclusive (e.g., paywalled journal, ambiguous correction notice) — ask the user to confirm whether any corrections apply.
 - The paper's final model was fit to animal-only data (see Phase 1 species-check step).
 - The PMC XML / PDF on disk contains only the paper's abstract (see Phase 1 full-text-check step).
+- The on-disk file's title / first-author / journal / year / drug disagrees with the task's `Paper metadata` block (see Phase 1 paper-identity-check step).
+- The paper depends on an upstream popPK model that is not on disk — either the upstream paper is identifiable (queue dependency) or unidentifiable (operator decision needed). See Phase 1 upstream-popPK detection step.
+- A required structural-model parameter is absent from every on-disk source (paper + supplements + regulatory review). Use the Phase 4 missing-parameter sidecar template; do not fall back to training data.
+- The worktree at dispatch has a pre-existing pushed branch for this task ID (prior completed run). See Phase 2 worktree-resumption step.
 - `devtools::check()` or vignette rendering produces a C-level segfault — the environment is broken; do not paper over with `--no-build-vignettes` or similar.
 - The `timeout 300 rmarkdown::render()` gate exits 124 — the vignette exceeds 5 minutes; reduce simulation size before committing.
 
@@ -229,6 +282,14 @@ When running interactively, use `AskUserQuestion`. When running under
 `claude_runner`, follow the runner's injected preamble instructions for
 the sidecar stop-and-ask protocol (the runner provides the file paths and
 schema).
+
+## Refusal handling
+
+If at any phase you find yourself producing a content-policy refusal in response to legitimate clinical-trial content (drug + dose + indication + adverse-event language is normal in pharmacometric papers and is not a safety concern), do not silently degrade the extraction. Sidecar-ask:
+
+> Phase <N> step <M> hit a content-policy refusal while reading <paper section / table>. The content is standard published clinical pharmacology (drug + dose + indication + AE language). Options: (A) rephrase the extraction prompt and continue, (B) skip the affected section and document the gap in vignette Errata, (C) defer the task pending operator review.
+
+A refusal is operator-actionable signal, not a fatal error. Treat it the same as any other stop-and-ask trigger.
 
 ## Constraints
 

--- a/.claude/skills/extract-literature-model/references/model-file-template.md
+++ b/.claude/skills/extract-literature-model/references/model-file-template.md
@@ -147,3 +147,48 @@ Related references:
 - Helper functions (e.g., to derive one-hot race indicators from a raw race column) live in `R/` and are exported with roxygen. Name them `<modelname>_<action>()`, e.g., `Clegg_2024_nirsevimab_derive_race_indicators()`. Only add if the covariate encoding is non-trivial.
 
 - Before committing: delete every `#!` instruction comment. Leave the source-location `# <source>` comments — they are the audit trail.
+
+## Documenting non-paper-derived parameter values
+
+When a parameter value did not come from the paper's text or tables — e.g. the
+operator read it off a graphical figure, an author supplied it via email
+correspondence, or it was carried from an upstream-task model file — record the
+provenance inline on the parameter line so the source-trace is unambiguous:
+
+```r
+ini({
+  # paper-derived (Table 4)
+  lcl <- log(0.225) ; label("Clearance (L/day)")
+
+  # author correspondence (J. Almquist email 2026-04-29);
+  # see tracking/operator_followups.md F12
+  lkdeg <- log(0.0231) ; label("Receptor degradation rate (1/day)")
+
+  # operator-extracted from Figure 2 (digitised); ±10% uncertainty
+  lvdxd <- log(0.038) ; label("DXd payload volume (L/kg) — figure-derived")
+})
+```
+
+Mirror the call-out in the vignette's Assumptions and deviations section (see
+`vignette-template.md`).
+
+## `depends_on` lineage in the `reference` field
+
+When a model's PK structure is fixed from another paper already in nlmixr2lib
+(typically a `depends_on` task), record both citations so the dependency is
+visible in `?modellib`, `checkModelConventions()` output, and `readModelDb()`
+metadata — not only in the task YAML:
+
+```r
+reference <- paste(
+  "Iwaki et al. (2021) J Clin Pharmacol 61(11):1488-1499.",
+  "doi:10.1002/jcph.1953.",
+  "PK structure adapted from Yao et al. (2018)",
+  "J Clin Pharmacol 58(11):1488-1497; see",
+  "modellib('Yao_2018_guselkumab').",
+  sep = " "
+)
+```
+
+Use this whenever the task YAML carries a `depends_on:` key referencing an
+upstream nlmixr2lib model.

--- a/.claude/skills/extract-literature-model/references/verification-checklist.md
+++ b/.claude/skills/extract-literature-model/references/verification-checklist.md
@@ -6,9 +6,15 @@ After the first-pass model file is written, re-read the source independently and
 
 Do not silently resolve ambiguity. Do not tune parameters to make a validation output match a target — if the validation disagrees with the paper, investigate the source, not the parameters.
 
+## H. Source identity
+
+- [ ] On-disk PDF / XML title, first author, journal, and year match the task's `Paper metadata` block. Filename PMID matches the actual PMID in the source (catches mislabelled drops like `PMID_23436260.pdf` actually being Frey 2010 / PMID 20097931).
+- [ ] Drug named in the task metadata matches the molecule the paper actually models.
+
 ## A. Parameter values
 
 - [ ] **Errata / corrigenda checked.** Confirmed search for published corrections to the source; any erratum value supersedes the main publication for conflicting values, with the most recent erratum winning when multiple exist. Erratum citation recorded in the model file's `reference` field, and each affected `ini()` comment points to the erratum.
+- [ ] Every parameter line in `ini()` has a clear provenance comment if it did not come from the paper's text/tables (author correspondence, figure-digitisation, upstream-task model file). The comment cites the followup-register entry (`tracking/operator_followups.md F<n>`) when applicable.
 - [ ] Every parameter in `ini()` has an in-file trailing comment pointing to the source location (table, equation, page, or figure). Re-check each comment matches what the source actually says.
 - [ ] Values are **final estimates**, not initial estimates. Supplement NONMEM control streams often list initial values in `$THETA` and `$OMEGA`; the final values come from the `$TABLE` output or the main paper. If the only source is a control stream, confirm the values match any published point estimates.
 - [ ] **Log-vs-linear reporting.** NONMEM often reports THETAs on the estimation scale (already log), but tables in the paper usually show the back-transformed value. A `log()` wrapper in `ini()` must match what the paper reports: `lcl <- log(0.0388)` is correct when the paper says "CL = 0.0388 L/day."
@@ -52,6 +58,7 @@ Do not silently resolve ambiguity. Do not tune parameters to make a validation o
 - [ ] `population` uses the extensible schema documented in `naming-conventions.md`; any paper-specific keys are allowed.
 - [ ] No stray `#!` instruction comments from the template remain.
 - [ ] Vignette path is `vignettes/articles/<...>.Rmd` (not top-level `vignettes/`), matching the pkgdown "articles" convention used by every non-legacy vignette in the package.
+- [ ] If this task `depends_on` an upstream-PK task, the model file's `reference` field cites the upstream model (e.g., `"... PK structure adapted from <Author> <Year>; see modellib('<Upstream>')"`). See `references/model-file-template.md` for the lineage snippet.
 
 ## F. Sanity simulations
 

--- a/.claude/skills/extract-literature-model/references/vignette-template.md
+++ b/.claude/skills/extract-literature-model/references/vignette-template.md
@@ -205,6 +205,18 @@ match.>
 - <Any simplification, e.g., "Time-varying weight held constant at the baseline
   z-score over the follow-up window."
 - <Any parameter the paper did not publish, and what was used instead.>
+- **Non-paper-derived parameter values** — call out any value that came from a
+  source other than the paper's text or tables. Cite the followup-register
+  entry (`tracking/operator_followups.md F<n>`) when applicable. Examples:
+  - "`kdeg = 0.0231 1/day` was supplied by the corresponding author
+    (J. Almquist, email 2026-04-29; see `tracking/operator_followups.md F12`);
+    the paper's Wiley supplement holds the value but is subscription-blocked."
+  - "`V_DXd = 0.038 L/kg` was extracted by the operator from Figure 2 of
+    <Author Year> via on-screen digitisation; ±10% uncertainty estimated from
+    the figure's gridline resolution."
+  - "PK structural parameters (`CL`, `Vc`, `Q`, `Vp`) were carried from the
+    upstream model `<Upstream_Year_drug>` (this paper fixes its PK from that
+    publication and reports only PD parameters)."
 ````
 
 ## Notes

--- a/inst/references/covariate-columns.md
+++ b/inst/references/covariate-columns.md
@@ -425,7 +425,28 @@ Covariate column names should be ALL CAPS. Current non-all-caps canonical names 
 - **Example models:** `Narwal_2013_sifalimumab.R` (reference 32, exponent 0.0558 on CL), `Zheng_2016_sifalimumab.R` (reference 12.04, power effect on CL with exponent 0.09).
 - **Notes:** Specific to drugs whose mechanism targets the type I IFN pathway (e.g., anti-IFN-alpha antibodies like sifalimumab, anifrolumab). Higher BGENE21 indicates stronger target engagement / disease activity and is associated with increased drug clearance via target-mediated mechanisms. The 21-gene panel composition is tied to the MedImmune/AstraZeneca SLE development programme; a different IFN gene signature (e.g., a 4-gene or 5-gene panel) should be registered under its own canonical name (`BGENE4`, `IFN_SIG`, ...) to avoid conflating panel definitions.
 
+### BGENE21_HIGH (**canonical for binary high-vs-low IFN-21-gene indicator**)
+- **Description:** 1 = subject's baseline 21-gene type I IFN signature score is at or above the paper-specified high/low cut-off, 0 = below cut-off.
+- **Units:** (binary)
+- **Type:** binary
+- **Scope:** specific
+- **Reference category:** 0 (low).
+- **Source aliases:** none.
+- **Example models:** `Almquist_2022_anifrolumab.R` (binary high-IFN indicator on CL).
+- **Notes:** Pair with continuous `BGENE21` when the paper reports both. The high/low cut-off is paper-specific (commonly the population median) and must be documented in `covariateData[[BGENE21_HIGH]]$notes` for every model that uses this covariate. Operator decision (2026-04-28): use `BGENE21_HIGH` (not `IFNGS_HIGH`) so the link to the existing `BGENE21` register entry is explicit while the binary nature stays visible in the column name.
+
 ## Inflammation markers
+
+### IL6 (**canonical for serum IL-6 concentration**)
+- **Description:** Baseline serum interleukin-6 concentration.
+- **Units:** pg/mL
+- **Type:** continuous
+- **Scope:** general
+- **Reference category:** n/a — used with power scaling `(IL6 / ref)^exponent`.
+- **Source aliases:**
+  - `bIL6`, `IL6_BASE` (baseline-IL6 column variants).
+- **Example models:** `Frey_2013_tocilizumab.R` (power effect on baseline target receptor).
+- **Notes:** Time-fixed at baseline unless the source paper states otherwise. Time-varying IL-6 in PD models should be the model's predicted state (a `d/dt(IL6)` trajectory) rather than a covariate; use this register entry only for the baseline / observed-covariate role.
 
 ### EOS (**canonical for blood eosinophil count**)
 - **Description:** Blood eosinophil count (baseline or time-varying).
@@ -584,6 +605,16 @@ Covariate column names should be ALL CAPS. Current non-all-caps canonical names 
 - **Source aliases:** `ASIAN_AMIND_MULTI` — used in `Clegg_2024_nirsevimab.R`.
 - **Example models:** `Clegg_2024_nirsevimab.R`.
 - **Notes:** Clegg 2024 applies this covariate to both CL and V2 with different coefficients.
+
+### RACE_ASIAN_OTH (**canonical for Asian-other composite race indicator**)
+- **Description:** 1 = subject self-identifies as Asian-other (Asian heritage outside the locally-dominant Asian subgroup, e.g. non-Chinese in a Chinese-dominant cohort, or "Other Asian" as a study-defined catch-all category). 0 = otherwise. Reference category is the cohort's dominant race grouping (typically Chinese or White, depending on the study).
+- **Units:** (binary)
+- **Type:** binary
+- **Scope:** specific
+- **Reference category:** 0. Document the dominant subgroup explicitly in `covariateData[[RACE_ASIAN_OTH]]$notes` for every model that uses this covariate.
+- **Source aliases:** none.
+- **Example models:** `Frey_2013_tocilizumab.R` (paper's "Other Asian" composite indicator on CL).
+- **Notes:** Distinct from `RACE_ASIAN_AMIND_MULTI` (a 4-way composite of Asian + American Indian + Multiple Races) because the underlying paper's grouping rule is different — `RACE_ASIAN_OTH` is a within-Asian-population sub-indicator, not a multi-race composite. Operator decision (2026-04-28): kept separate from `RACE_ASIAN` because the paper's "Other Asian" category is its own grouping, not an alias of "Asian (any)".
 
 ### RACE_NEAS (**canonical for North East Asian composite race indicator**)
 - **Description:** 1 = North East Asian heritage (worldwide Chinese, Japanese, or Korean), 0 = non-North East Asian. Composite indicator analogous to `RACE_ASIAN` but specifically restricted to the East Asian subgroup most-relevant to ICH E5 ethnic-sensitivity / Asian-region bridging analyses.
@@ -1591,6 +1622,56 @@ Covariate column names should be ALL CAPS. Current non-all-caps canonical names 
   - `Smoking` (case-insensitive) — used in `Ma_2020_sarilumab_anc.R`.
 - **Example models:** `Ma_2020_sarilumab_anc.R` (power-form on baseline ANC: `BASE * 1.15^SMOKE`).
 - **Notes:** Baseline-only indicator; does not track within-study smoking-cessation changes.
+
+### SMOKE_CURRENT
+- **Description:** 1 = subject is a current smoker at baseline, 0 = not. Paired with `SMOKE_NEVER`; both 0 = former smoker. Reference category for the paired pair is "former smoker" so the two indicators capture a 3-level smoking-status covariate without an intercept clash.
+- **Units:** (binary)
+- **Type:** binary
+- **Scope:** general
+- **Reference category:** 0 (not current smoker).
+- **Source aliases:** none known; paper-specific raw forms include `SMOKE = 'CURRENT'` strings or one-hot pivoted columns.
+- **Example models:** (forthcoming).
+- **Notes:** Use this paired-indicator form when the source paper reports a 3-level smoking covariate (current / former / never). When the paper reports only a 2-level current-vs-not covariate, use the simpler binary `SMOKE` instead (already registered above).
+
+### SMOKE_NEVER
+- **Description:** 1 = subject is a never-smoker at baseline, 0 = not. Paired with `SMOKE_CURRENT`; both 0 = former smoker.
+- **Units:** (binary)
+- **Type:** binary
+- **Scope:** general
+- **Reference category:** 0 (not never-smoker).
+- **Source aliases:** none known.
+- **Example models:** (forthcoming).
+- **Notes:** Reference category for the paired pair is "former smoker." See `SMOKE_CURRENT` for the 2-level alternative.
+
+### HSCT_URD_7OF8 (**canonical for unrelated-donor 7/8 HLA-match indicator**)
+- **Description:** 1 = subject's hematopoietic stem-cell transplant donor was unrelated and HLA-matched at 7 of 8 loci (HLA-A, -B, -C, -DRB1), 0 = otherwise. Paired with `HSCT_URD_8OF8`; reference category (both 0) = matched-related donor or autologous transplant.
+- **Units:** (binary)
+- **Type:** binary
+- **Scope:** specific
+- **Reference category:** 0 (matched-related or auto-transplant).
+- **Source aliases:** none known.
+- **Example models:** `Zhong_2026_abatacept.R` (pediatric aGvHD prophylaxis; donor-match covariate on PK).
+- **Notes:** Specific scope because the donor-typing schema is transplant-protocol-dependent (8/8 loci, 10/10 loci, KIR matching, etc.). When a paper uses a different match-resolution definition (e.g. 9/10 vs 10/10), register a new canonical name rather than reusing `HSCT_URD_7OF8`.
+
+### HSCT_URD_8OF8 (**canonical for unrelated-donor 8/8 HLA-match indicator**)
+- **Description:** 1 = subject's hematopoietic stem-cell transplant donor was unrelated and HLA-matched at 8 of 8 loci, 0 = otherwise. Paired with `HSCT_URD_7OF8`.
+- **Units:** (binary)
+- **Type:** binary
+- **Scope:** specific
+- **Reference category:** 0 (matched-related or auto-transplant).
+- **Source aliases:** none known.
+- **Example models:** `Zhong_2026_abatacept.R`.
+- **Notes:** See `HSCT_URD_7OF8` for the paired-pair convention and the rationale for specific-scope.
+
+### PAIN (**canonical for baseline pain score**)
+- **Description:** Baseline patient-reported pain score on a paper-specified scale (NRS 0-10, VAS 0-100, BPI, or paper-specific scale). Document the scale used in `covariateData[[PAIN]]$notes` for every model that uses this covariate.
+- **Units:** (paper-specified — typically dimensionless score)
+- **Type:** continuous
+- **Scope:** specific
+- **Reference category:** n/a — usually used with a linear-deviation form `1 + e * (PAIN - ref)` or a power form `(PAIN / ref)^e`. Document the reference value in `covariateData[[PAIN]]$notes`.
+- **Source aliases:** none known.
+- **Example models:** (forthcoming).
+- **Notes:** Specific scope because the underlying scale varies across papers; if a future paper uses the same scale, extend the Example models list rather than register a new canonical name. If two papers use different scales for the same conceptual covariate, prefer registering a scale-suffixed name (`PAIN_NRS`, `PAIN_VAS`) so a downstream consumer can convert between scales.
 
 ## Formulation / assay / study
 


### PR DESCRIPTION
## Summary

Closes 9 concrete gaps in the `extract-literature-model` skill that were
surfaced (or near-missed) during the recent 100-task extraction drain.
Each gap is grounded in a specific failure pattern. Plus 8 new canonical
covariate entries downstream models will use.

### SKILL.md additions

- **Phase 1 paper-identity check** — catches mislabelled PDFs (the
  motivating case: `PMID_23436260.pdf` was actually Frey 2010 /
  PMID 20097931, ran for several Phase-1 cycles before being caught).
- **Phase 1 upstream-popPK detection** — surfaces queue dependencies
  when a paper fixes its PK from a separate publication (Iwaki 2021
  ↦ Yao 2018; Sidbury 2022 ↦ unidentified upstream).
- **Phase 4 missing-parameter sidecar** — author-correspondence
  pathway routed through `tracking/operator_followups.md` F-register
  (Almquist 2022 `kdeg`, Lu 2022 `V_DXd`); never falls back to
  training-data values.
- **Phase 4 non-paper-provenance comments** — inline annotation for
  any value not from the paper text/tables (author email,
  figure-digitisation, upstream-task carryover).
- **Phase 2 worktree-resumption** — explicit handling of crashed /
  interrupted runs whose worktree carries WIP at dispatch.
- **Refusal handling** — sidecar route for content-policy refusals on
  legitimate clinical-trial content; previously such refusals
  silently degraded extractions.

### References updates

- `model-file-template.md` — non-paper-provenance comment pattern;
  `depends_on` lineage citation in the `reference` field (visible via
  `modellib()` and `checkModelConventions()` output).
- `verification-checklist.md` — new **§ H. Source identity** section;
  parameter-provenance checkbox in § A; `depends_on` citation
  checkbox in § E.
- `vignette-template.md` — Assumptions and deviations explicitly
  lists non-paper-derived parameter values (with worked examples for
  `kdeg`, `V_DXd`, upstream PK carryover).

### `inst/references/covariate-columns.md` additions

8 new canonical entries:

- `BGENE21_HIGH` — binary high-vs-low IFN-21-gene indicator (paired
  with continuous `BGENE21`); used by `Almquist_2022_anifrolumab`.
- `IL6` — baseline serum IL-6 (used by `Frey_2013_tocilizumab`).
- `RACE_ASIAN_OTH` — within-Asian-population sub-indicator (distinct
  from the existing `RACE_ASIAN_AMIND_MULTI` 4-way composite); used
  by `Frey_2013_tocilizumab`.
- `SMOKE_CURRENT` / `SMOKE_NEVER` — paired-indicator form for 3-level
  smoking covariates (complements existing 2-level binary `SMOKE`).
- `HSCT_URD_7OF8` / `HSCT_URD_8OF8` — paired-indicator form for
  unrelated-donor HLA-match status; used by
  `Zhong_2026_abatacept`.
- `PAIN` — baseline patient-reported pain score (paper-specific
  scale).

`checkModelConventions()` will pick these up automatically once
downstream model files reference them.

## Test plan

- [ ] Diff review: confirm Edits A–O each landed exactly once in the
      expected file (5 files total).
- [ ] `lintr::lint_dir(".claude")` clean — done locally, no lints.
- [ ] Phase 1 numbering on SKILL.md is sequential 1–11 — done.
- [ ] Sidecar-trigger smoke tests against re-dispatched tasks once a
      future drain begins (paper-identity, upstream-popPK,
      missing-parameter, worktree-resumption).
- [ ] `checkModelConventions()` picks up the 8 new covariate entries
      cleanly when a downstream model uses one.