### PR TITLE
Fix Clegg 2024 nirsevimab vignette Figure 4 cohort-ID collision

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 # development version
 
+* Fix Clegg 2024 nirsevimab vignette Figure 4: pass disjoint `id_offset` per cohort and carry `trial` via `rxSolve(keep = )` so the four panels no longer collapse into a single Frankenstein-subject simulation (predictions had been ~3× too high).
 * Add Cheng 2026 immunoglobulin ([doi:10.1002/bcp.70420](https://doi.org/10.1002/bcp.70420)) — children with primary immunodeficiency or secondary antibody deficiency receiving intravenous immunoglobulin replacement therapy.
 * Add Frey 2010 tocilizumab ([doi:10.1177/0091270009350623](https://doi.org/10.1177/0091270009350623)) — adults with moderate-to-severe rheumatoid arthritis.
 * Add Hayashi 2007 omalizumab ([doi:10.1111/j.1365-2125.2006.02803.x](https://doi.org/10.1111/j.1365-2125.2006.02803.x)) — Japanese adults with atopic asthma or seasonal allergic rhinitis.

--- a/vignettes/articles/Clegg_2024_nirsevimab.Rmd
+++ b/vignettes/articles/Clegg_2024_nirsevimab.Rmd
@@ -77,10 +77,16 @@ Builds dose + observation records for a virtual cohort of `n` infants.
 `max_day`: follow-up duration in days.
 `season2`: TRUE for Season 2 (200 mg flat dose, Season 2 CL effect applied).
 `obs_days`: observation time points in days.
+`id_offset`: integer added to `seq_len(n)` so multiple cohorts can be
+`bind_rows()`-ed without colliding on `ID`. `rxSolve` treats `ID` as the
+subject key; duplicate IDs across cohorts silently collapse into a single
+"Frankenstein" subject that receives the summed dose, so a non-zero
+offset is mandatory for any multi-cohort simulation (see Figure 4).
 
 ```{r make-cohort}
 make_cohort <- function(n, ga_range, pna0_range, max_day,
-                        season2 = FALSE, obs_days = seq(0, max_day, by = 7)) {
+                        season2 = FALSE, obs_days = seq(0, max_day, by = 7),
+                        id_offset = 0L) {
   GA <- runif(n, ga_range[1], ga_range[2]) # weeks
   PNA_0 <- runif(n, pna0_range[1], pna0_range[2]) # months at dosing
   wt_z <- pmax(-2, pmin(2, rnorm(n, 0, 1)))
@@ -88,7 +94,7 @@ make_cohort <- function(n, ga_range, pna0_range, max_day,
   AMT <- if (season2) rep(200, n) else ifelse(WT_0 < 5, 50, 100)
 
   pop <- data.frame(
-    ID = seq_len(n), GA, PNA_0, wt_z, WT_0, AMT,
+    ID = id_offset + seq_len(n), GA, PNA_0, wt_z, WT_0, AMT,
     SEASON2 = as.integer(season2),
     ADA_POS = 0L,
     # All White/Nat.Haw reference race for simplicity
@@ -147,21 +153,31 @@ data are not publicly available).
 ```{r fig4-sim, message=FALSE}
 set.seed(8897) # MEDI8897 = nirsevimab development code
 
-d_p2b <- make_cohort(200, c(29, 35), c(0, 3), 400) |> mutate(trial = "Phase 2b\n(healthy infants, 29 to <35 wGA)")
-d_melody <- make_cohort(200, c(35, 42), c(0, 3), 500) |> mutate(trial = "MELODY\n(healthy infants, \u226535 wGA)")
-d_med_s1 <- make_cohort(200, c(24, 35), c(0, 3), 400) |>
+# `id_offset` per cohort is mandatory: rxSolve uses ID as the subject key,
+# so duplicate IDs across cohorts silently merge into a single subject that
+# receives the summed dose. Without offsets, Figure 4's predictions came out
+# ~3-fold too high because IDs 1..100 appeared in all four cohorts and were
+# collapsed into Frankenstein subjects with ~400 mg in depot at TIME = 0.
+d_p2b <- make_cohort(200, c(29, 35), c(0, 3), 400, id_offset =   0L) |>
+  mutate(trial = "Phase 2b\n(healthy infants, 29 to <35 wGA)")
+d_melody <- make_cohort(200, c(35, 42), c(0, 3), 500, id_offset = 200L) |>
+  mutate(trial = "MELODY\n(healthy infants, \u226535 wGA)")
+d_med_s1 <- make_cohort(200, c(24, 35), c(0, 3), 400, id_offset = 400L) |>
   mutate(trial = "MEDLEY Season 1\n(infants \u226435 wGA, CHD/CLD)")
 d_med_s2 <- make_cohort(100, c(35, 42), c(12, 24), 400,
-  season2 = TRUE) |> mutate(trial = "MEDLEY Season 2\n(children with CHD/CLD)")
+  season2 = TRUE, id_offset = 600L) |>
+  mutate(trial = "MEDLEY Season 2\n(children with CHD/CLD)")
 
 sim_f4 <- bind_rows(d_p2b, d_melody, d_med_s1, d_med_s2)
+# Cheap regression guard: every (ID, TIME, EVID) triple must be unique.
+stopifnot(!anyDuplicated(unique(sim_f4[, c("ID", "TIME", "EVID")])))
 
-out_f4 <- rxode2::rxSolve(mod, events = sim_f4) |>
-  as.data.frame() |>
-  left_join(
-    sim_f4 |> select(ID, trial) |> distinct(),
-    by = c("id" = "ID")
-  )
+# Carry `trial` through rxSolve via `keep =` rather than a post-hoc left_join.
+# A `left_join(distinct(ID, trial))` fans out every row when an ID happens to
+# repeat across trials, silently re-pooling cohorts; `keep = "trial"` aligns
+# the trial label per output row.
+out_f4 <- rxode2::rxSolve(mod, events = sim_f4, keep = "trial") |>
+  as.data.frame()
 ```
 
 ```{r fig4-summarise}


### PR DESCRIPTION
Root cause: the four cohorts in Figure 4 were built with make_cohort()'s default ID = seq_len(n), producing IDs 1..100 in all four cohorts simultaneously. After bind_rows(), rxSolve saw subject 1 with four doses at TIME = 0 and silently merged the cohorts into a single "Frankenstein" subject receiving the summed dose (~400 mg). The follow-up left_join() to (ID, trial) distinct() then fanned out each output row across all four trials, so every panel plotted the same merged simulation. Net effect: Figure 4 predictions were ~3x too high and the four panels were indistinguishable. Figure 5 was unaffected because it uses a single cohort.

Fix follows the Phase 9 / Robbie 2012 multi-cohort pattern:

- make_cohort() now takes id_offset = 0L; the four Figure 4 cohorts pass disjoint offsets (0, 200, 400, 600).
- A stopifnot(!anyDuplicated(...)) guard catches future regressions before rxSolve.
- rxSolve(events = sim_f4, keep = "trial") carries the trial label through directly; the post-hoc left_join is removed.

Verified: vignette renders cleanly (timeout 300, exit 0); the four-panel medians are now in the published ballpark (MELODY Cmax ~106 ug/mL, MEDLEY Season 2 ~158 ug/mL with 200 mg flat dose properly differentiated from the other 50/100 mg panels).