### PR TITLE
Prefer rxSolve(keep=) over post-rxSolve left_join in vignettes

### DIFF
--- a/.claude/skills/extract-literature-model/references/pknca-recipes.md
+++ b/.claude/skills/extract-literature-model/references/pknca-recipes.md
@@ -116,7 +116,25 @@ res <- PKNCA::pk.nca(PKNCA::PKNCAdata(conc_obj, dose_obj, intervals = intervals)
 
 PKNCA's `summary()` collapses within the group levels defined by the formula. If
 the source paper reports NCA stratified by an additional covariate (e.g., by
-baseline weight band), join the group metadata after summarizing:
+baseline weight band), the cleanest path is to **carry the stratifier through
+`rxSolve(..., keep = ...)`** so it lands directly in the simulation output and
+in the PKNCA grouping formula — no post-summarise join is needed:
+
+```r
+sim <- rxode2::rxSolve(mod, events = events,
+                       keep = c("treatment", "weight_band"))
+
+conc_obj <- PKNCA::PKNCAconc(
+  data = as.data.frame(sim),
+  formula = Cc ~ time | treatment + weight_band + id,
+  concu = "ug/mL", timeu = "day"
+)
+```
+
+If you cannot route the stratifier through `keep` (e.g. it was derived inside
+the simulation loop and only exists in `cohort`), join it onto the **PKNCA
+result table** (one row per subject per parameter), not onto the per-time-point
+simulation rows — the result table is a 1:1 join by `id` and never fans out:
 
 ```r
 res_tbl <- as.data.frame(res$result)
@@ -187,16 +205,36 @@ Flag any differences > 20% in the narrative; do not tune parameters to match.
   observation for extravascular. Ensure the simulation grid includes `time = 0`.
 - **Duplicate IDs across cohorts** — when `events` is assembled from multiple
   `make_cohort()` calls and `bind_rows`-ed together, confirm
-  `anyDuplicated(sim[, c("id", "time")]) == 0` before handing `sim` to PKNCA.
-  `rxSolve` silently collapses duplicated-ID rows into a single subject;
-  PKNCA then aggregates a single (wrong) subject as if it were the whole
-  group. Use the `id_offset` pattern in the `make_cohort` snippet in
-  `references/vignette-template.md` to keep ID ranges disjoint.
+  `anyDuplicated(events[, c("id", "time", "evid")]) == 0` *before* the
+  `rxSolve` call (and the corresponding check on `sim` after) — by the time
+  you spot wrong NCA values, the silent merge has already happened.
+  `rxSolve` collapses duplicated-ID rows into a single subject that
+  receives the *summed* dose; PKNCA then aggregates one wrong subject as
+  the whole group. Use the `id_offset` pattern in the `make_cohort`
+  snippet in `references/vignette-template.md` to keep ID ranges disjoint.
 - **Carry grouping via `rxSolve(..., keep = ...)`, not a post-hoc
   `left_join`.** `rxSolve` accepts a `keep = c("col1", "col2")` argument
-  that attaches source columns (cohort, treatment, dose group, regimen)
-  directly to the simulation output. This is aligned per row and far
-  cleaner than joining back from `events` — a post-hoc `left_join` will
-  produce multiplied rows if any IDs collide or if rxSolve expanded
-  observation times. Round-trip `treatment` / `cohort` through `keep` and
-  PKNCA's grouping formula picks it up automatically.
+  that attaches source columns (cohort, treatment, dose group, regimen,
+  per-subject covariates) directly to the simulation output, aligned per
+  row. This is the strongly preferred pattern. The post-hoc form
+
+  ```r
+  # AVOID
+  sim <- rxode2::rxSolve(mod, events = events) |>
+    dplyr::left_join(events |> dplyr::select(id, treatment) |>
+                       dplyr::distinct(), by = "id")
+  ```
+
+  fans out every output row across every label an `id` carries. Any
+  refactor that introduces an id collision (e.g. adding a new cohort
+  without `id_offset`) silently re-pools the simulation across panels —
+  this was the root cause of the Clegg 2024 nirsevimab Figure 4 bug, where
+  predictions came out ~3-fold too high. Use `keep = ` instead and the
+  PKNCA formula `Cc ~ time | treatment + id` picks the label up
+  automatically. The footgun-free idiom is:
+
+  ```r
+  sim <- rxode2::rxSolve(mod, events = events,
+                         keep = c("treatment", "cohort", "WT")) |>
+    as.data.frame()
+  ```

--- a/.claude/skills/extract-literature-model/references/vignette-template.md
+++ b/.claude/skills/extract-literature-model/references/vignette-template.md
@@ -240,19 +240,61 @@ match.>
 - `rxode2::zeroRe()` is helpful when the published figure is a typical-value
   prediction rather than a VPC. Simulating with between-subject variability
   always, then plotting percentiles, matches VPC-style figures.
-- **Multi-cohort simulations.** If you build the event table by
-  `bind_rows()`-ing several cohorts (dose groups, regimens, age strata, etc.),
-  each cohort's `id` column must span a disjoint integer range. The
-  `make_cohort(..., id_offset = )` helper in the cohort chunk above shows the
-  pattern. Duplicate IDs across cohorts are silently merged by `rxSolve` into
-  a single subject and are a recurring bug — the `Robbie_2012_palivizumab`
-  vignette has a worked example. Add the assertion
-  `stopifnot(!anyDuplicated(unique(events[, c("id", "time", "evid")])))`
-  after the bind_rows as a cheap regression guard.
-- **Prefer `rxSolve(..., keep = c("col1", "col2"))`** over a post-hoc
-  `left_join` from `events` back into the simulation output. `keep` attaches
-  source columns directly in the rxode2 output, aligned per row. Use it for
-  `cohort`, `treatment`, dose-group labels, and any grouping column the plots
-  or PKNCA formulas need. The column-name is up to you (`"cohort"`,
-  `"treatment"`, `"regimen"` — whatever the paper's figure legends use); the
-  skill does not mandate one.
+- **Multi-cohort simulations — disjoint IDs are mandatory.** If you build
+  the event table by `bind_rows()`-ing several cohorts (dose groups,
+  regimens, age strata, GA strata, trial panels, etc.), each cohort's `id`
+  column must span a **disjoint integer range**. `rxSolve` treats `id` as
+  the subject key; duplicate IDs across cohorts are silently merged into a
+  single "Frankenstein" subject that receives the *summed* dose, producing
+  predictions that can be 2-4× too high (the bug is silent — no warning).
+  The `make_cohort(..., id_offset = )` helper in the cohort chunk above
+  shows the pattern. Worked examples: `Robbie_2012_palivizumab.Rmd`,
+  `Clegg_2024_nirsevimab.Rmd` (Figure 4), `Lin_2024_casirivimab.Rmd`,
+  `Kuchimanchi_2018_evolocumab.Rmd`. Always add the assertion
+
+  ```r
+  stopifnot(!anyDuplicated(unique(events[, c("id", "time", "evid")])))
+  ```
+
+  immediately after the `bind_rows()` as a cheap regression guard.
+
+- **Always carry grouping labels through `rxSolve(..., keep = ...)` —
+  never with a post-hoc `left_join`.** `keep` attaches source columns
+  directly in the rxode2 output aligned per row. The post-hoc pattern
+
+  ```r
+  # AVOID — fans out rows when an id has multiple labels (multi-cohort
+  # bug surface), and even when ids are unique it's a footgun that
+  # silently breaks if a future refactor introduces collisions.
+  sim <- rxode2::rxSolve(mod, events = events) |>
+    dplyr::left_join(events |> dplyr::select(id, treatment) |>
+                       dplyr::distinct(), by = "id")
+  ```
+
+  collapses to wrong group totals the moment any `id` is repeated across
+  cohort labels (e.g. the Clegg 2024 nirsevimab Figure 4 bug, where the
+  `distinct()` step produced four trial-rows per subject and inflated
+  every panel's median ~3-fold). Use `keep` instead:
+
+  ```r
+  # PREFER
+  sim <- rxode2::rxSolve(mod, events = events,
+                         keep = c("treatment", "cohort", "WT")) |>
+    as.data.frame()
+  ```
+
+  Use `keep` for `cohort`, `treatment`, `regimen`, `trial`, dose-group
+  labels, any per-subject covariate the plots or PKNCA formulas need
+  downstream. The column-name is up to you (`"cohort"`, `"treatment"`,
+  `"regimen"`, `"trial"`, etc. — whatever the paper's figure legends use);
+  the skill does not mandate one. Character columns are preserved — they
+  may come back as factor or character but the value is intact.
+
+  The only legitimate post-rxSolve `left_join` use cases are:
+  - joining NCA output (e.g. PKNCA results, one row per id) onto a
+    per-subject summary table — that's not a per-time-point fan-out;
+  - attaching reference values (published Cmax / AUC) by a label that
+    was already carried through `keep`.
+
+  When you see a `left_join(events |> select(id, X) |> distinct())` in
+  any vignette, that's a bug surface to remove, not a pattern to copy.

--- a/vignettes/articles/Budha_2023_tislelizumab.Rmd
+++ b/vignettes/articles/Budha_2023_tislelizumab.Rmd
@@ -114,7 +114,9 @@ pop <- data.frame(
   ID        = seq_len(n_subj),
   WT, AGE, ALB, TUMSZ,
   SEXF, ADA_POS,
-  TUMTP, TUMTP_CHL, TUMTP_GC
+  TUMTP, TUMTP_CHL, TUMTP_GC,
+  # Per-subject grouping label carried through to rxSolve via `keep`
+  treatment = ifelse(ADA_POS == 1, "ADA-positive", "ADA-negative")
 )
 ```
 
@@ -164,7 +166,10 @@ d_sim <- dplyr::bind_rows(d_dose, d_obs) |>
 ```{r simulate}
 mod <- readModelDb("Budha_2023_tislelizumab")
 set.seed(20230331)
-sim <- rxSolve(mod, d_sim, returnType = "data.frame")
+# `keep = "treatment"` carries the ADA grouping label through to the
+# simulation output so the NCA blocks below do not need a post-hoc
+# left_join from `pop`.
+sim <- rxSolve(mod, d_sim, returnType = "data.frame", keep = "treatment")
 ```
 
 ## Concentration-time profile
@@ -226,14 +231,13 @@ half-life is expected to approximate the paper's reported ≈ 23.8 days
 (Budha 2023 Methods) in the ADA-negative arm.
 
 ```{r nca}
-# Per-subject treatment grouping for PKNCA
-pop$treatment <- ifelse(pop$ADA_POS == 1, "ADA-positive", "ADA-negative")
+# `treatment` was carried through rxSolve via `keep = "treatment"` above;
+# no left_join needed here.
 
 # Cycle 1 interval
 conc1 <- sim |>
   dplyr::filter(time >= 0, time <= 21, Cc > 0) |>
   dplyr::rename(ID = id) |>
-  dplyr::left_join(dplyr::select(pop, ID, treatment), by = "ID") |>
   dplyr::transmute(ID, time_rel = time, Cc, treatment, interval = "Cycle 1")
 
 dose1 <- pop |>
@@ -262,10 +266,10 @@ knitr::kable(
 
 ```{r nca-ss}
 # Steady-state-ish interval at cycle 10 (day 189-210)
+# `treatment` already on `sim` via rxSolve's `keep` argument.
 conc_ss <- sim |>
   dplyr::filter(time >= 189, time <= 210, Cc > 0) |>
   dplyr::rename(ID = id) |>
-  dplyr::left_join(dplyr::select(pop, ID, treatment), by = "ID") |>
   dplyr::transmute(ID, time_rel = time - 189, Cc, treatment)
 
 dose_ss <- pop |>

--- a/vignettes/articles/Diao_2016_daclizumab_cd25.Rmd
+++ b/vignettes/articles/Diao_2016_daclizumab_cd25.Rmd
@@ -149,13 +149,16 @@ deterministic typical-value run for figure replication.
 ```{r simulate}
 mod <- readModelDb("Diao_2016_daclizumab_cd25")
 
+# `regimen` is already on every row of `events` (per-id from the cohort
+# left_join above) — carry it through `rxSolve(keep = ...)` so we don't
+# need a fragile post-hoc `left_join` on the simulation output.
 set.seed(2016)
-sim_pop <- rxode2::rxSolve(mod, events, returnType = "data.frame") |>
-  dplyr::left_join(dplyr::select(cohort, id, regimen), by = "id")
+sim_pop <- rxode2::rxSolve(mod, events, returnType = "data.frame",
+                           keep = "regimen")
 
 mod_typ <- rxode2::zeroRe(mod)
-sim_typ <- rxode2::rxSolve(mod_typ, events, returnType = "data.frame") |>
-  dplyr::left_join(dplyr::select(cohort, id, regimen), by = "id")
+sim_typ <- rxode2::rxSolve(mod_typ, events, returnType = "data.frame",
+                           keep = "regimen")
 ```
 
 # Replicate published figures

--- a/vignettes/articles/Jackson_2022_ixekizumab.Rmd
+++ b/vignettes/articles/Jackson_2022_ixekizumab.Rmd
@@ -217,7 +217,12 @@ d_sim <- bind_rows(d_dose, d_obs) |>
 ```{r simulate}
 mod <- readModelDb("Jackson_2022_ixekizumab")
 set.seed(42)
-sim <- rxode2::rxSolve(mod, events = d_sim, returnType = "data.frame")
+# `weight_group` and `WT` are per-subject columns already on every row of
+# `d_sim` (built from `cohort |> tidyr::crossing(...)`). Carrying them
+# through `rxSolve(keep = ...)` removes the need for post-rxSolve
+# left_joins from `cohort` in every downstream chunk.
+sim <- rxode2::rxSolve(mod, events = d_sim, returnType = "data.frame",
+                       keep = c("weight_group", "WT"))
 ```
 
 # Replicate published figures
@@ -232,7 +237,6 @@ concentrations over the same window, stratified by baseline weight group.
 ```{r figure-1, fig.width = 7, fig.height = 4}
 sim_plot <- sim |>
   as.data.frame() |>
-  left_join(cohort |> select(ID, weight_group), by = c("id" = "ID")) |>
   filter(time > 0, time <= 12 * hours_per_week, !is.na(Cc)) |>
   mutate(week = time / hours_per_week)
 
@@ -266,8 +270,7 @@ ggplot(fig1, aes(x = week, y = mean_Cc, colour = weight_group, fill = weight_gro
 wk12_time <- 12 * hours_per_week
 sim_wk12 <- sim |>
   as.data.frame() |>
-  filter(abs(time - wk12_time) < 1e-6) |>
-  left_join(cohort |> select(ID, weight_group, WT), by = c("id" = "ID"))
+  filter(abs(time - wk12_time) < 1e-6)
 
 ggplot(sim_wk12, aes(x = WT, y = Cc, colour = weight_group)) +
   geom_point(alpha = 0.5) +
@@ -295,7 +298,6 @@ trough_times <- trough_weeks * hours_per_week
 trough_tbl <- sim |>
   as.data.frame() |>
   filter(time %in% trough_times) |>
-  left_join(cohort |> select(ID, weight_group), by = c("id" = "ID")) |>
   group_by(weight_group, week = time / hours_per_week) |>
   summarise(
     mean_trough  = mean(Cc, na.rm = TRUE),
@@ -326,7 +328,6 @@ ss_end   <- 12 * hours_per_week
 nca_conc <- sim |>
   as.data.frame() |>
   filter(time >= ss_start, time <= ss_end, Cc > 0) |>
-  left_join(cohort |> select(ID, weight_group), by = c("id" = "ID")) |>
   mutate(time_rel = time - ss_start,
          treatment = paste0("IXE_Q4W_", weight_group)) |>
   rename(ID = id) |>

--- a/vignettes/articles/Koopman_2023_factorix.Rmd
+++ b/vignettes/articles/Koopman_2023_factorix.Rmd
@@ -281,8 +281,7 @@ sim_nca <- sim |>
 
 dose_df <- events |>
   filter(EVID == 1) |>
-  transmute(id = ID, time = TIME, amt = AMT) |>
-  left_join(cohort |> select(id = ID, age_group), by = "id")
+  transmute(id = ID, time = TIME, amt = AMT, age_group)
 
 conc_obj <- PKNCA::PKNCAconc(sim_nca, Cc ~ time | age_group + id,
                              concu = "IU/dL",

--- a/vignettes/articles/Lon_2013_abatacept.Rmd
+++ b/vignettes/articles/Lon_2013_abatacept.Rmd
@@ -196,9 +196,13 @@ across the virtual cohort matches the paper's individual variability.
 mod <- readModelDb("Lon_2013_abatacept")
 
 events_sim <- events |> rename(id = ID)
-sim <- rxSolve(object = mod, events = events_sim, returnType = "data.frame") |>
-  as_tibble() |>
-  left_join(pop |> select(ID, treatment), by = c("id" = "ID"))
+# `treatment` is already on every row of `events_sim` (each per-arm dose
+# builder carries it through, and the obs rows pull it from `pop`). Carry
+# it through rxSolve via `keep = ` rather than a fragile post-hoc
+# left_join from pop.
+sim <- rxSolve(object = mod, events = events_sim, returnType = "data.frame",
+               keep = "treatment") |>
+  as_tibble()
 ```
 
 ## Replicate Figure 2: plasma concentration-time profiles by treatment

--- a/vignettes/articles/Ma_2020_sarilumab_anc.Rmd
+++ b/vignettes/articles/Ma_2020_sarilumab_anc.Rmd
@@ -138,8 +138,14 @@ sim_one <- function(sub, seed_offset = 0L) {
   ev_df$WT      <- sub$WT
   ev_df$SMOKE   <- sub$SMOKE
   ev_df$PRICORT <- sub$PRICORT
+  # Carry per-subject grouping labels into the events table so that
+  # rxSolve(keep = ...) can attach them to the simulation output, avoiding
+  # a fragile post-rxSolve left_join from `pop`.
+  ev_df$regimen <- sub$regimen
+  ev_df$dose_mg <- sub$dose_mg
   set.seed(2020L + sub$id + seed_offset)
-  out <- rxode2::rxSolve(mod, ev_df, returnType = "data.frame")
+  out <- rxode2::rxSolve(mod, ev_df, returnType = "data.frame",
+                         keep = c("regimen", "dose_mg"))
   out$id <- sub$id
   out
 }
@@ -147,10 +153,10 @@ sim_one <- function(sub, seed_offset = 0L) {
 sim <- pop |>
   dplyr::group_split(id) |>
   lapply(sim_one) |>
-  dplyr::bind_rows() |>
-  dplyr::left_join(dplyr::select(pop, id, regimen, dose_mg), by = "id")
+  dplyr::bind_rows()
 
-# Build a single-id event table for later PKNCA dose-mapping.
+# Build a single-id event table for later PKNCA dose-mapping. `regimen` is
+# attached at construction time so it propagates without a post-hoc join.
 events <- pop |>
   dplyr::group_split(id) |>
   lapply(function(sub) {
@@ -162,10 +168,10 @@ events <- pop |>
     ev_df$WT      <- sub$WT
     ev_df$SMOKE   <- sub$SMOKE
     ev_df$PRICORT <- sub$PRICORT
+    ev_df$regimen <- sub$regimen
     ev_df
   }) |>
-  dplyr::bind_rows() |>
-  dplyr::left_join(dplyr::select(pop, id, regimen), by = "id")
+  dplyr::bind_rows()
 
 dim(sim)
 head(sim)

--- a/vignettes/articles/Xu_2011_sirukumab.Rmd
+++ b/vignettes/articles/Xu_2011_sirukumab.Rmd
@@ -134,7 +134,7 @@ infusion_dur <- 15 / (60 * 24)          # 15 min in days
 
 dose_rows <- pop %>%
   transmute(
-    ID, treatment, WT,
+    ID, treatment, dose_mgkg, WT,
     time = 0,
     amt,
     evid = 1L,
@@ -144,7 +144,7 @@ dose_rows <- pop %>%
   )
 
 obs_rows <- pop %>%
-  select(ID, treatment, WT) %>%
+  select(ID, treatment, dose_mgkg, WT) %>%
   tidyr::crossing(time = obs_times) %>%
   mutate(
     amt  = NA_real_,
@@ -167,9 +167,12 @@ virtual cohort matches the paper's individual variability.
 mod <- readModelDb("Xu_2011_sirukumab")
 
 events_sim <- events %>% rename(id = ID)
-sim <- rxSolve(object = mod, events = events_sim, returnType = "data.frame") %>%
-  as_tibble() %>%
-  left_join(pop %>% select(ID, treatment, dose_mgkg), by = c("id" = "ID"))
+# `treatment` and `dose_mgkg` are already on every row of `events_sim`.
+# Carry them through rxSolve via `keep = ...` rather than a fragile
+# post-hoc left_join from `pop`.
+sim <- rxSolve(object = mod, events = events_sim, returnType = "data.frame",
+               keep = c("treatment", "dose_mgkg")) %>%
+  as_tibble()
 ```
 
 ## Replicate Figure 3: concentration-time profiles by dose

--- a/vignettes/articles/Zheng_2016_sifalimumab.Rmd
+++ b/vignettes/articles/Zheng_2016_sifalimumab.Rmd
@@ -189,10 +189,14 @@ virtual cohort matches the paper's reported variability.
 mod <- readModelDb("Zheng_2016_sifalimumab")
 
 events_sim <- events %>% rename(id = ID)
-sim <- rxSolve(object = mod, events = events_sim, returnType = "data.frame") %>%
-  as_tibble() %>%
-  left_join(pop %>% select(ID, treatment, dose_mg),
-            by = c("id" = "ID"))
+# `treatment` is already on every row of `events_sim` (carried from `pop`
+# via the dose_rows / obs_rows construction above). Carry it through
+# rxSolve via `keep = ...` rather than a fragile post-hoc left_join
+# from `pop`. `dose_mg` is taken from `pop` directly when building the
+# PKNCA dose table below, so it does not need to ride through `sim`.
+sim <- rxSolve(object = mod, events = events_sim, returnType = "data.frame",
+               keep = "treatment") %>%
+  as_tibble()
 ```
 
 ## Replicate Figure 2: representative concentration-time profiles


### PR DESCRIPTION
Following the Clegg 2024 nirsevimab Figure 4 bug — where a post-hoc left_join(events |> select(id, trial) |> distinct()) silently fanned out simulation rows when ids collided across cohorts — audit and refactor existing vignettes to carry grouping labels through rxSolve(..., keep = ...) instead of joining them back from `pop` / `cohort` / `events`.

Audit findings (Risk A — actual cohort-ID collision bugs causing wrong simulations):

- Only Clegg 2024 nirsevimab Figure 4 (already fixed on a separate branch). All other multi-cohort vignettes either use disjoint id_offsets, dplyr::row_number() across the unnested pop, or per-iteration rxSolve inside a lapply (each call sees a single cohort's ids) and are not affected.

Refactored 8 vignettes (Risk B — post-rxSolve left_join footgun that works today but breaks silently if a future refactor introduces an id collision):

- Budha_2023_tislelizumab.Rmd  (treatment by ADA status)
- Diao_2016_daclizumab_cd25.Rmd  (regimen)
- Jackson_2022_ixekizumab.Rmd  (weight_group, WT × 4 join sites)
- Koopman_2023_factorix.Rmd  (PKNCA dose-table age_group join)
- Lon_2013_abatacept.Rmd  (treatment)
- Ma_2020_sarilumab_anc.Rmd  (regimen, dose_mg per-subject sim_one loop)
- Xu_2011_sirukumab.Rmd  (treatment, dose_mgkg)
- Zheng_2016_sifalimumab.Rmd  (treatment)

In each case the grouping label is added to (or already present in) the events frame, then carried through with rxSolve(..., keep = c(...)) and the post-rxSolve left_join from pop/cohort is dropped. All eight vignettes render cleanly under timeout 300.

Skill updates so future extractions adopt the safer pattern:

- references/vignette-template.md: Notes section now states the multi-cohort id_offset rule with worked examples (Robbie 2012, Clegg 2024, Lin 2024, Kuchimanchi 2018), shows the "AVOID left_join(distinct())" anti-pattern next to the recommended "PREFER keep = " idiom, and enumerates the legitimate post-hoc left_join cases (NCA-result joins, reference-value tables).
- references/pknca-recipes.md: Recipe 5 (per-subgroup summaries) now leads with the keep = approach for stratifiers; Common pitfalls section spells out the Clegg 2024 root cause and the footgun-free idiom.