### PR TITLE
Fix Robbie 2012 palivizumab population metadata after revisit

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 # development version
 
+* Fix Robbie 2012 palivizumab population metadata after revisit against the full-text PDF: pediatric `n` corrected from 1,767 (derived) to 1,684 (paper PK dataset), `sex_female_pct` denominator from 1,660 to 1,684, and added a vignette note clarifying that the 2012 erratum's equation 10 correction (6,900 → 16,900) is a NONMEM `$PRIOR` variance for adult Vp, not a final-model parameter. All `ini()` parameter values continue to match Table 2 exactly.
 * Fix Clegg 2024 nirsevimab vignette Figure 4: pass disjoint `id_offset` per cohort and carry `trial` via `rxSolve(keep = )` so the four panels no longer collapse into a single Frankenstein-subject simulation (predictions had been ~3× too high).
 * Add Cheng 2026 immunoglobulin ([doi:10.1002/bcp.70420](https://doi.org/10.1002/bcp.70420)) — children with primary immunodeficiency or secondary antibody deficiency receiving intravenous immunoglobulin replacement therapy.
 * Add Frey 2010 tocilizumab ([doi:10.1177/0091270009350623](https://doi.org/10.1177/0091270009350623)) — adults with moderate-to-severe rheumatoid arthritis.

--- a/inst/modeldb/specificDrugs/Robbie_2012_palivizumab.R
+++ b/inst/modeldb/specificDrugs/Robbie_2012_palivizumab.R
@@ -72,21 +72,21 @@ Robbie_2012_palivizumab <- function() {
   )
 
   population <- list(
-    n_subjects     = 1883,
+    n_subjects     = 1800,
     n_studies      = 22,
     n_adults       = 116,
-    n_pediatric    = 1767,
+    n_pediatric    = 1684,
     age_range      = "Pediatric PAGE 6.89 to 34.7 months; adult 19.3 to 58.9 years.",
     age_median     = "Pediatric PAGE median 12.6 months; adult mean 32.8 years.",
     weight_range   = "Pediatric 0.92 to 16.3 kg; adult 48.9 to 104.3 kg.",
     weight_median  = "Pediatric median 5.64 kg; adult mean 72.5 kg.",
     ga_range       = "Pediatric gestational age 22 to 41 weeks (median 30 weeks); 62% preterm, 38% term.",
-    sex_female_pct = "Pediatric 45.3% female (752 girls / 1660 reported); adult 65.5% female (76/116).",
+    sex_female_pct = "Pediatric 44.7% female (752 girls / 1,684); adult 65.5% female (76 / 116).",
     race_ethnicity = "Pediatric 54% White, 20% Black / African American, 18% Hispanic / Latino, 2% Asian, 6% Other.",
     disease_state  = "Pediatric cohort at high risk of RSV lower respiratory tract disease (preterm, bronchopulmonary dysplasia / chronic lung disease of prematurity, congenital heart disease); 36% had chronic lung disease of prematurity. Adult cohort: 7 healthy-volunteer studies and 2 hematopoietic / solid-organ transplant studies.",
     dose_range     = "3 to 30 mg/kg; label regimen 15 mg/kg IM monthly (up to 5 doses per RSV season).",
     regions        = "North America and Europe (22 pooled MedImmune studies).",
-    notes          = "Baseline demographics taken from Robbie 2012 Table 1. Adult cohort dosed by a mix of IM and IV routes across 9 studies; pediatric cohort dosed exclusively IM. 1,661 adult PK samples and 4,095 pediatric PK samples."
+    notes          = "Counts are PK-analysis dataset (subjects with palivizumab serum concentrations); Table 1 reports 1,883 enrolled across the 22 studies. Adult cohort dosed by a mix of IM and IV routes across 9 studies (7 healthy-volunteer + 2 transplant); pediatric cohort dosed exclusively IM across 13 studies. 1,661 adult PK samples and 4,095 pediatric PK samples."
   )
 
   ini({

--- a/vignettes/articles/Robbie_2012_palivizumab.Rmd
+++ b/vignettes/articles/Robbie_2012_palivizumab.Rmd
@@ -51,13 +51,14 @@ Baseline demographics reproduced from Robbie 2012 Table 1:
 
 | Cohort | N | Key covariates | PK samples |
 |---|---|---|---|
-| Adults | 116 | age 19.3-58.9 y (mean 32.8); weight 48.9-104.3 kg (mean 72.5); 65.5% female | 1,661 |
-| Pediatric | 1,767 | PAGE 6.89-34.7 mo (median 12.6); weight 0.92-16.3 kg (median 5.64); gestational age 22-41 wk (median 30; 62% preterm); 36% CLD of prematurity; 54% White, 20% Black, 18% Hispanic, 2% Asian, 6% Other | 4,095 |
+| Adults | 116 | age 19.3-58.9 y (mean 32.8); weight 48.9-104.3 kg (mean 72.5); 65.5% female (76/116) | 1,661 |
+| Pediatric | 1,684 | PAGE 6.89-34.7 mo (median 12.6); weight 0.92-16.3 kg (median 5.64); gestational age 22-41 wk (median 30; 62% preterm); 36% CLD of prematurity; 932 boys + 752 girls (44.7% female); 54% White, 20% Black, 18% Hispanic, 2% Asian, 6% Other | 4,095 |
 
-The pooled dataset spans 22 clinical studies (9 adult: 7 healthy-volunteer + 2
-transplant; 13 pediatric). Adult cohort was dosed IV or IM across studies;
-pediatric cohort was dosed IM. Dose range 3-30 mg/kg; label regimen is 5
-monthly doses of 15 mg/kg IM.
+PK-analysis dataset totals 1,800 subjects across 22 clinical studies (9 adult:
+7 healthy-volunteer + 2 transplant; 13 pediatric); Table 1 reports 1,883
+enrolled. Adult cohort was dosed IV or IM across studies; pediatric cohort
+was dosed IM. Dose range 3-30 mg/kg; label regimen is 5 monthly doses of 15
+mg/kg IM.
 
 ## Source trace
 
@@ -77,7 +78,6 @@ monthly doses of 15 mg/kg IM.
 | Pediatric reference scaling (4.5 kg, 12.3-month PAGE) | Robbie 2012, Table 3. |
 | Figure 3 (corrected per erratum): 3- vs 5-dose profiles | Robbie 2012, Figure 3 (PDF page 7); erratum replaces the original panel. |
 | Figure 5 (corrected per erratum): profiles stratified by postnatal age cohort | Robbie 2012, Figure 5 (PDF page 9); erratum updates legend. |
-| Equation 10 on page 4931, left column: 16,900 | Robbie 2012 erratum; corrects original "6,900" value. |
 
 ## WHO weight-for-age growth curve helper
 
@@ -406,6 +406,19 @@ cited in the paper's discussion.
 
 ## Assumptions and deviations
 
+- **Erratum eq. 10 numerical correction (6,900 -> 16,900).** The 2012
+  erratum corrects "6,900" to "16,900" in equation 10. Equation 10 is the
+  NONMEM `$PRIOR` matrix from the adult fit used to inform the pediatric
+  fit (THETA prior means and the diagonal of the OMEGA prior covariance);
+  16,900 is the prior variance for adult Vp (consistent with the adult
+  fit's reported %RSE of 5.39% on Vp = 2,410 mL: SE = 130 mL,
+  SE^2 = 16,900). The model file uses the post-fit final parameter
+  estimates from Table 2, not the priors from equation 10, so the
+  erratum's numerical correction does not propagate to any `ini()` value.
+  The other erratum corrections (renaming equation 4 to "1a", adding
+  Anderson/Allegaert/Holford 2006 as reference 1a, the Figure 3
+  replacement, the Figure 5 legend rewording) are all reflected in the
+  model file's `reference` field and the source trace above.
 - **Maturation parameterization.** The paper's eq. 4 / 1a reads
   `TVCL = theta_CL * (1 - beta * exp(...))` but the reported beta = 0.411
   and TCL = 62.3 months only reproduce the pediatric Table 3 reference
@@ -433,6 +446,14 @@ cited in the paper's discussion.
   Robbie 2012 Table 1 pediatric proportions (54/20/18/2/6 White/Black/
   Hispanic/Asian/Other); weight uses WHO combined-sex LMS with each
   infant's z-score held constant.
+- **Population metadata corrected at revisit.** The original extraction
+  ran from a PMC abstract stub that did not contain the Methods text. The
+  pediatric `n_pediatric` count of 1,767 (derived as Table 1 enrolled total
+  1,883 minus 116 adults) was replaced with the paper's PK-analysis
+  dataset count of 1,684 ("932 boys and 752 girls"); `n_subjects` was
+  realigned from 1,883 enrolled to 1,800 in the PK dataset; and
+  `sex_female_pct` denominator was corrected from 1,660 to 1,684 (giving
+  44.7% rather than 45.3% female).
 - **Original observed data not available.** All figures show simulated
   prediction intervals only.
 


### PR DESCRIPTION
The original task-017 extraction ran from a PMC abstract stub before the abstract-only Phase 1 trigger landed in the extract-literature-model skill, so any field not in the abstract was guessed. With the full-text PDF now on disk, all 19 ini() parameter values were verified against Robbie 2012 Table 2 and reproduce Tables 2 and 3 reference values to within rounding -- no model parameter changes needed. Three population- metadata fabrications were corrected:

- n_pediatric 1767 -> 1684 (paper PK dataset: 932 boys + 752 girls)
- n_subjects 1883 -> 1800 (PK-dataset alignment; Table 1 reports 1,883 enrolled, the model was fit to 1,800 with PK data)
- sex_female_pct denominator 1660 -> 1684 (44.7% rather than 45.3% female)

Added a vignette Errata bullet clarifying that the 2012 erratum's equation 10 numerical correction (6,900 -> 16,900) is a NONMEM \$PRIOR variance for adult Vp from the prior matrix used to inform the pediatric fit, not a final model parameter -- the model file uses the post-fit Table 2 estimates, so the correction does not propagate to any ini() value.