### PR TITLE
extract-literature-model: tighten stop-and-ask language; forbid best-…

### DIFF
--- a/.claude/skills/extract-literature-model/SKILL.md
+++ b/.claude/skills/extract-literature-model/SKILL.md
@@ -324,10 +324,18 @@ Use this fixed format for ambiguities:
 
 > Ambiguity at [source location]. Two plausible interpretations: (A) …, (B) …. Which applies?
 
-When running interactively, use `AskUserQuestion`. When running under
-`claude_runner`, follow the runner's injected preamble instructions for
-the sidecar stop-and-ask protocol (the runner provides the file paths and
-schema).
+A stop-and-ask trigger is **not advisory**: when one fires, stop work
+on the current task and wait for the operator. Do **not** "document a
+best guess and proceed" — silent best-guesses ship as bugs the
+operator cannot retroactively correct without re-running the whole
+extraction. If you find yourself thinking "I'll just pick the safest
+option and move on," that itself is a stop-and-ask signal.
+
+When running interactively, use `AskUserQuestion` and wait for the
+answer. When running under a task runner, use the runner's
+documented stop-and-ask protocol (the runner is responsible for the
+mechanics — file paths, schema, status transitions, re-dispatch).
+Either way: **stop, ask, wait — do not guess past the trigger.**
 
 ## Refusal handling
 


### PR DESCRIPTION
…guessing

Operator feedback: agents were filing sidecars but then silently best-guessing past the trigger and continuing the extraction. Once a task ships as 'completed', the operator can't retroactively correct it without re-running the whole extraction — defeats the point of the protocol.

Tighten the SKILL.md "Stop-and-ask" guidance:
- A trigger is NOT advisory; agents must stop, ask, wait.
- Best-guessing is explicitly forbidden.
- The runner-mechanics (sidecar JSON, file paths, status transitions) are NOT documented here — they belong in the task runner's own contract. This skill only states the principle: stop, ask, wait.