### PR TITLE
Bender 2014 T-DM1: rename lqd2/lqd3 to canonical lq/lq2

### DIFF
--- a/inst/modeldb/specificDrugs/Bender_2014_trastuzumabEmtansine_mechanistic.R
+++ b/inst/modeldb/specificDrugs/Bender_2014_trastuzumabEmtansine_mechanistic.R
@@ -74,9 +74,9 @@ Bender_2014_trastuzumabEmtansine_mechanistic <- function() {
     lcl      <- log(0.0174);  label("Total trastuzumab clearance (CL_TT, L/day)")           # Bender 2014 Table II, cyno: 17.4 mL/day
     lkplasma <- log(0.0939);  label("Plasma antibody degradation rate constant (k_plasma, 1/day)") # Bender 2014 Table II, cyno: 0.0939 /day
     lvc      <- log(0.148);   label("Central volume shared by all DAR species (V1, L)")      # Bender 2014 Table II, cyno: 148 mL
-    lqd2     <- log(0.0255);  label("Distributional clearance to peripheral1 (CLd2, L/day)") # Bender 2014 Table II, cyno: 25.5 mL/day
+    lq     <- log(0.0255);  label("Distributional clearance to peripheral1 (CLd2, L/day)") # Bender 2014 Table II, cyno: 25.5 mL/day
     lvp      <- log(0.0572);  label("Peripheral volume 1 shared by all DAR species (V2, L)") # Bender 2014 Table II, cyno: 57.2 mL
-    lqd3     <- log(0.0812);  label("Distributional clearance to peripheral2 (CLd3, L/day)") # Bender 2014 Table II, cyno: 81.2 mL/day
+    lq2     <- log(0.0812);  label("Distributional clearance to peripheral2 (CLd3, L/day)") # Bender 2014 Table II, cyno: 81.2 mL/day
     lvp2     <- log(0.127);   label("Peripheral volume 2 shared by all DAR species (V3, L)") # Bender 2014 Table II, cyno: 127 mL
     lkhi     <- log(0.341);   label("Shared upper-chain deconjugation rate k_7->6 = k_6->5 = k_5->4 = k_4->3 = k_3->2 (1/day)") # Bender 2014 Table II, cyno: 0.341 /day
     lk21     <- log(0.255);   label("DAR2 deconjugation rate constant k_2->1 (1/day)")       # Bender 2014 Table II, cyno: 0.255 /day
@@ -97,9 +97,9 @@ Bender_2014_trastuzumabEmtansine_mechanistic <- function() {
     cl      <- exp(lcl + etalcl)
     kplasma <- exp(lkplasma)
     vc      <- exp(lvc + etalvc)
-    qd2     <- exp(lqd2)
+    q     <- exp(lq)
     vp      <- exp(lvp + etalvp)
-    qd3     <- exp(lqd3)
+    q2     <- exp(lq2)
     vp2     <- exp(lvp2)
     khi     <- exp(lkhi)
     k21     <- exp(lk21)
@@ -113,10 +113,10 @@ Bender_2014_trastuzumabEmtansine_mechanistic <- function() {
     kel        <- cl / vc
 
     # Three-compartment distribution parameters, shared across all DAR species
-    k12 <- qd2 / vc
-    k21d <- qd2 / vp
-    k13 <- qd3 / vc
-    k31d <- qd3 / vp2
+    k12 <- q / vc
+    k21d <- q / vp
+    k13 <- q2 / vc
+    k31d <- q2 / vp2
 
     # DAR7: no incoming deconjugation (no DAR8)
     d/dt(dar7_central)     <- -kel * dar7_central - khi * dar7_central -

--- a/inst/modeldb/specificDrugs/Bender_2014_trastuzumabEmtansine_reduced.R
+++ b/inst/modeldb/specificDrugs/Bender_2014_trastuzumabEmtansine_reduced.R
@@ -57,9 +57,9 @@ Bender_2014_trastuzumabEmtansine_reduced <- function() {
     # Cc = central / vc directly in mg/L = ug/mL.
     lcl    <- log(0.0199);  label("Total trastuzumab clearance (CL_TT, L/day)")             # Bender 2014 Table III, cyno: 19.9 mL/day
     lvc    <- log(0.154);   label("Central volume shared by T-DM1 and DAR0 (V1, L)")         # Bender 2014 Table III, cyno: 154 mL
-    lqd2   <- log(0.0568);  label("Distributional clearance to peripheral1 (CLd2, L/day)")   # Bender 2014 Table III, cyno: 56.8 mL/day
+    lq   <- log(0.0568);  label("Distributional clearance to peripheral1 (CLd2, L/day)")   # Bender 2014 Table III, cyno: 56.8 mL/day
     lvp    <- log(0.0500);  label("Peripheral volume 1 shared by T-DM1 and DAR0 (V2, L)")    # Bender 2014 Table III, cyno: 50.0 mL
-    lqd3   <- log(0.0604);  label("Distributional clearance to peripheral2 (CLd3, L/day)")   # Bender 2014 Table III, cyno: 60.4 mL/day
+    lq2   <- log(0.0604);  label("Distributional clearance to peripheral2 (CLd3, L/day)")   # Bender 2014 Table III, cyno: 60.4 mL/day
     lvp2   <- log(0.0847);  label("Peripheral volume 2 shared by T-DM1 and DAR0 (V3, L)")    # Bender 2014 Table III, cyno: 84.7 mL
     lcldec <- log(0.0220);  label("Deconjugation clearance from T-DM1 to DAR0 (CL_DEC, L/day)") # Bender 2014 Table III, cyno: 22.0 mL/day
 
@@ -78,9 +78,9 @@ Bender_2014_trastuzumabEmtansine_reduced <- function() {
   model({
     cl     <- exp(lcl + etalcl)
     vc     <- exp(lvc + etalvc)
-    qd2    <- exp(lqd2)
+    q    <- exp(lq)
     vp     <- exp(lvp)
-    qd3    <- exp(lqd3)
+    q2    <- exp(lq2)
     vp2    <- exp(lvp2 + etalvp2)
     cldec  <- exp(lcldec + etalcldec)
 
@@ -89,16 +89,16 @@ Bender_2014_trastuzumabEmtansine_reduced <- function() {
     # DAR0 inherits the same V1/V2/V3 and distributional clearances and is
     # fed by the deconjugation flux out of the T-DM1 central compartment.
     d/dt(central)           <- -(cl + cldec) / vc * central -
-                                qd2 / vc * central + qd2 / vp  * peripheral1 -
-                                qd3 / vc * central + qd3 / vp2 * peripheral2
-    d/dt(peripheral1)       <-  qd2 / vc * central - qd2 / vp  * peripheral1
-    d/dt(peripheral2)       <-  qd3 / vc * central - qd3 / vp2 * peripheral2
+                                q / vc * central + q / vp  * peripheral1 -
+                                q2 / vc * central + q2 / vp2 * peripheral2
+    d/dt(peripheral1)       <-  q / vc * central - q / vp  * peripheral1
+    d/dt(peripheral2)       <-  q2 / vc * central - q2 / vp2 * peripheral2
 
     d/dt(dar0_central)      <-  cldec / vc * central - cl / vc * dar0_central -
-                                qd2 / vc * dar0_central + qd2 / vp  * dar0_peripheral1 -
-                                qd3 / vc * dar0_central + qd3 / vp2 * dar0_peripheral2
-    d/dt(dar0_peripheral1)  <-  qd2 / vc * dar0_central - qd2 / vp  * dar0_peripheral1
-    d/dt(dar0_peripheral2)  <-  qd3 / vc * dar0_central - qd3 / vp2 * dar0_peripheral2
+                                q / vc * dar0_central + q / vp  * dar0_peripheral1 -
+                                q2 / vc * dar0_central + q2 / vp2 * dar0_peripheral2
+    d/dt(dar0_peripheral1)  <-  q / vc * dar0_central - q / vp  * dar0_peripheral1
+    d/dt(dar0_peripheral2)  <-  q2 / vc * dar0_central - q2 / vp2 * dar0_peripheral2
 
     # Observations: T-DM1 = conjugated ADC central concentration;
     # total trastuzumab (TT) = T-DM1 + DAR0 central concentration

--- a/vignettes/articles/Bender_2014_trastuzumabEmtansine_reduced.Rmd
+++ b/vignettes/articles/Bender_2014_trastuzumabEmtansine_reduced.Rmd
@@ -113,9 +113,9 @@ mod_rat <- mod |>
   ini(
     lcl    = log(0.00237),
     lvc    = log(0.0107),
-    lqd2   = log(0.0597),
+    lq     = log(0.0597),
     lvp    = log(0.00252),
-    lqd3   = log(0.0139),
+    lq2    = log(0.0139),
     lvp2   = log(0.0155),
     lcldec = log(0.00224),
     propSd   = 0.109,


### PR DESCRIPTION
The Bender 2014 trastuzumab emtansine mechanistic and reduced model files labelled their three-compartment distributional clearances as lqd2 (central to peripheral1) and lqd3 (central to peripheral2).  Both files already use the canonical lvc/lvp/lvp2 triple, so the natural distributional-flow pairing is lq (paired with lvp) and lq2 (paired with lvp2).

This is a pure identifier rename - the model semantics are unchanged.  All internal references in the model() block (k12 = qd2/vc, k21d = qd2/vp, k13 = qd3/vc, k31d = qd3/vp2 in mechanistic; the parallel ODE expressions in reduced) follow the rename.  The labels still describe each parameter as Bender's CLd2/CLd3 so the connection to Table II/III of the paper is preserved.

Effect for downstream users: drugs reported with this model will now classify under the canonical Q / Q2 concept and pair with the existing Vc / Vp / Vp2 distribution volumes for cross-drug comparison.