### PR TITLE
Standardise CL / Vc parameter naming across mAb popPK models

### DIFF
--- a/inst/modeldb/specificDrugs/Hood_2021_medi7836.R
+++ b/inst/modeldb/specificDrugs/Hood_2021_medi7836.R
@@ -47,7 +47,7 @@ Hood_2021_medi7836 <- function() {
     # Structural PD parameters (IL13 turnover, complex distribution, assay fraction).
     lkin   <- log(0.0173);  label("IL13 production rate Kin (nM/day; paper labels nmol/d but the steady-state baseline 0.096 pM = Kin/Kout requires nM/day)") # Hood 2021 Table 2: Kin = 0.0173 [0.0136-0.0227]
     lkout  <- log(180);     label("IL13 elimination rate constant Kout (1/day; estimated, not constrained to MEDI7836 kel)") # Hood 2021 Table 2: Kout = 180 [143-227]
-    lvcx   <- log(13.6);    label("Apparent central volume of IL13:MEDI7836 complex Vcx/F (L)")           # Hood 2021 Table 2: Vcx/F = 13.6 [10.5-16.7]
+    lvc_complex   <- log(13.6);    label("Apparent central volume of IL13:MEDI7836 complex Vcx/F (L)")           # Hood 2021 Table 2: Vcx/F = 13.6 [10.5-16.7]
     lcxfr  <- log(0.0429);  label("Fraction of total IL13:MEDI7836 complex captured by the bioanalytical PD assay (unitless)") # Hood 2021 Table 2: Cx fraction = 4.29% [2.98-5.96%]
 
     # Fixed in-vitro binding constants from Biacore T100 molecule characterization.
@@ -101,7 +101,7 @@ Hood_2021_medi7836 <- function() {
     # Individual PD parameters (no IIV on Kin or Vcx per Hood 2021 Table 2).
     kin  <- exp(lkin)
     kout <- exp(lkout + etalkout)
-    vcx  <- exp(lvcx)
+    vc_complex  <- exp(lvc_complex)
     cxfr <- exp(lcxfr + etalcxfr)
 
     # Micro-rate constants for the linear distribution / elimination kinetics.
@@ -110,8 +110,8 @@ Hood_2021_medi7836 <- function() {
     kel    <- cl / vc
     k12    <- q  / vc
     k21    <- q  / vp
-    kel_cx <- cl / vcx
-    k12_cx <- q  / vcx
+    kel_cx <- cl / vc_complex
+    k12_cx <- q  / vc_complex
     k21_cx <- q  / vp
 
     # Drug mass balance (compartments in mg of MEDI7836).
@@ -151,7 +151,7 @@ Hood_2021_medi7836 <- function() {
     # central complex concentration; the paper's interpretation is that the
     # supposedly-free IL13 immunoassay also captures ~4% of the bound drug-target
     # complex, biasing the apparent free signal upward when drug is present.
-    pdIL13 <- log(target + cxfr * complex / vcx)
+    pdIL13 <- log(target + cxfr * complex / vc_complex)
     pdIL13 ~ prop(propSd_pdIL13)
   })
 }

--- a/inst/modeldb/specificDrugs/Lu_2019_polatuzumab.R
+++ b/inst/modeldb/specificDrugs/Lu_2019_polatuzumab.R
@@ -86,7 +86,7 @@ Lu_2019_polatuzumab <- function() {
       units              = "(binary)",
       type               = "binary",
       reference_category = 0,
-      notes              = "Time-fixed. Lu 2019 NONMEM defines RTX = 1 if COMBO == 1, GA101 = 1 if COMBO == 2, and applies effects as theta^(RTX+GA101); since RTX and GA101 are mutually exclusive, RTX+GA101 takes values 0 or 1 and the effect collapses to a single anti-CD20-combination indicator. Multiplicative effects on CL_SS (e_combo_rg_cl_ss = 0.844, lower CL_SS on combo), kdes (e_combo_rg_kdes = 0.932), and FRAC_NS (e_combo_rg_frac_mmae = 0.709). The paper distinguishes rituximab and obinutuzumab combos in Table S1 but the final model fits a single combined effect (i.e., does not detect a meaningful difference between the two).",
+      notes              = "Time-fixed. Lu 2019 NONMEM defines RTX = 1 if COMBO == 1, GA101 = 1 if COMBO == 2, and applies effects as theta^(RTX+GA101); since RTX and GA101 are mutually exclusive, RTX+GA101 takes values 0 or 1 and the effect collapses to a single anti-CD20-combination indicator. Multiplicative effects on CL_SS (e_combo_rg_cl = 0.844, lower CL_SS on combo), kdes (e_combo_rg_kdes = 0.932), and FRAC_NS (e_combo_rg_frac_mmae = 0.709). The paper distinguishes rituximab and obinutuzumab combos in Table S1 but the final model fits a single combined effect (i.e., does not detect a meaningful difference between the two).",
       source_name        = "COMBO"
     )
   )
@@ -113,7 +113,7 @@ Lu_2019_polatuzumab <- function() {
     # male, R/R, non-Asian, normal hepatic function, ECOG >= 1, single-agent.
     lkdes      <- log(0.0046);  label("Rate constant of CL_TIME exponential decay (kdes, 1/hour)")     # Lu 2019 Table 1, theta1
     lcl_time   <- log(0.00623); label("Initial CL_TIME at time 0 for the reference subject (CL_TIME, L/hour)") # Lu 2019 Table 1, theta2
-    lcl_ss     <- log(0.0344);  label("acMMAE nonspecific linear clearance after repeated dosing (CL_SS, L/hour)") # Lu 2019 Table 1, theta3
+    lcl     <- log(0.0344);  label("acMMAE nonspecific linear clearance after repeated dosing (CL_SS, L/hour)") # Lu 2019 Table 1, theta3
     lvc        <- log(3.15);    label("acMMAE central volume (Vc, L)")                                 # Lu 2019 Table 1, theta4
     lvp        <- log(3.98);    label("acMMAE peripheral volume (Vp, L)")                              # Lu 2019 Table 1, theta5
     lq         <- log(0.0145);  label("acMMAE intercompartmental clearance (Q, L/hour)")               # Lu 2019 Table 1, theta6
@@ -141,7 +141,7 @@ Lu_2019_polatuzumab <- function() {
     # ----- Covariate effects on acMMAE parameters (Lu 2019 Table 2, theta22-theta37) -----
     # WT enters all acMMAE clearance and volume parameters as power effects
     # normalized to 75 kg.
-    e_wt_cl_ss      <-  0.73;   label("Power exponent of WT on CL_SS (unitless)")                      # Lu 2019 Table 2, theta22
+    e_wt_cl      <-  0.73;   label("Power exponent of WT on CL_SS (unitless)")                      # Lu 2019 Table 2, theta22
     e_wt_vc         <-  0.50;   label("Shared power exponent of WT on Vc, Vp, Q (unitless)")           # Lu 2019 Table 2, theta23
 
     # SEXF coding inverts vs. the source's male-indicator: paper theta24 = 1.20
@@ -151,11 +151,11 @@ Lu_2019_polatuzumab <- function() {
     e_sexf_vc       <-  1 / 1.20;  label("Multiplicative effect of female sex on Vc (ratio female:male, unitless)")     # Lu 2019 Table 2, theta24 inverted (paper reports 1.20 as male:female; SEXF stores 1/1.20)
     e_asian_vc      <-  0.929;     label("Multiplicative effect of Asian race on Vc (unitless)")                        # Lu 2019 Table 2, theta25
     e_line1l_vc     <-  1.20;      label("Multiplicative effect of treatment-naive (first-line) status on Vc (unitless)") # Lu 2019 Table 2, theta26
-    e_sexf_cl_ss    <-  1 / 1.10;  label("Multiplicative effect of female sex on CL_SS (ratio female:male, unitless)")  # Lu 2019 Table 2, theta27 inverted
-    e_alb_cl_ss     <- -0.247;     label("Power exponent of ALB on CL_SS (unitless; reference 35 g/L)")                 # Lu 2019 Table 2, theta28
-    e_combo_rg_cl_ss <- 0.844;     label("Multiplicative effect of anti-CD20 (rituximab or obinutuzumab) combination on CL_SS (unitless)") # Lu 2019 Table 2, theta29
-    e_blbcell_cl_ss <-  0.0212;    label("Power exponent of max(1, BLBCELL) on CL_SS (unitless; B-cell count in cells/uL floored at 1)") # Lu 2019 Table 2, theta30
-    e_tumsz_cl_ss   <-  0.0521;    label("Linear coefficient of (TUMSZ/5000 - 1) on CL_SS (unitless; effect = 1 + theta * (TUMSZ/5000 - 1), reference 5000 mm^2 SPD)") # Lu 2019 Table 2, theta31
+    e_sexf_cl    <-  1 / 1.10;  label("Multiplicative effect of female sex on CL_SS (ratio female:male, unitless)")  # Lu 2019 Table 2, theta27 inverted
+    e_alb_cl     <- -0.247;     label("Power exponent of ALB on CL_SS (unitless; reference 35 g/L)")                 # Lu 2019 Table 2, theta28
+    e_combo_rg_cl <- 0.844;     label("Multiplicative effect of anti-CD20 (rituximab or obinutuzumab) combination on CL_SS (unitless)") # Lu 2019 Table 2, theta29
+    e_blbcell_cl <-  0.0212;    label("Power exponent of max(1, BLBCELL) on CL_SS (unitless; B-cell count in cells/uL floored at 1)") # Lu 2019 Table 2, theta30
+    e_tumsz_cl   <-  0.0521;    label("Linear coefficient of (TUMSZ/5000 - 1) on CL_SS (unitless; effect = 1 + theta * (TUMSZ/5000 - 1), reference 5000 mm^2 SPD)") # Lu 2019 Table 2, theta31
     e_line1l_kdes   <-  3.38;      label("Multiplicative effect of treatment-naive status on kdes (unitless)")          # Lu 2019 Table 2, theta32
     e_combo_rg_kdes <-  0.932;     label("Multiplicative effect of anti-CD20 combination on kdes (unitless)")           # Lu 2019 Table 2, theta33
     e_line1l_cl_time <- 3.53;      label("Multiplicative effect of treatment-naive status on CL_TIME (unitless)")        # Lu 2019 Table 2, theta34
@@ -185,7 +185,7 @@ Lu_2019_polatuzumab <- function() {
     # Stored as variances on the log scale exactly as the paper reports them
     # (the paper labels these omega^2; the per-row %CV column matches sqrt(exp(omega^2) - 1)).
     etalcl_time ~ 1.89                       # Lu 2019 Table S3, Omega11 (CV 138%)
-    etalcl_ss  ~ 0.0376                      # Lu 2019 Table S3, Omega22 (CV 19.5%)
+    etalcl  ~ 0.0376                      # Lu 2019 Table S3, Omega22 (CV 19.5%)
     etalvc     ~ 0.0151                      # Lu 2019 Table S3, Omega33 (CV 12.3%)
     etalvp     ~ 0.107                       # Lu 2019 Table S3, Omega44 (CV 32.7%)
     etalq      ~ 0.0538                      # Lu 2019 Table S3, Omega55 (CV 23.2%)
@@ -212,7 +212,7 @@ Lu_2019_polatuzumab <- function() {
     # (used in the CL_SS covariate). max(1, x) preserves the NONMEM
     # IF(BBCC.GT.thresh) BCEL=BBCC/thresh; ELSE BCEL=1 logic.
     bcel_cl_time <- max(1, BLBCELL / bcell_thr_cl_time)  # Lu 2019 supplement: BCEL  for CL_TIME
-    bcel_cl_ss   <- max(1, BLBCELL)                      # Lu 2019 supplement: BCEL1 for CL_SS
+    bcel_cl   <- max(1, BLBCELL)                      # Lu 2019 supplement: BCEL1 for CL_SS
 
     # Aggregate covariate multipliers (Lu 2019 supplement, COVV1, COVCLINF,
     # COVKDES, COVCLT, COVMMAE expressions), with reference categories at 75 kg
@@ -223,12 +223,12 @@ Lu_2019_polatuzumab <- function() {
               e_asian_vc^RACE_ASIAN *
               e_line1l_vc^LINE_1L
 
-    cov_cl_ss <- (WT / 75)^e_wt_cl_ss *
-                 e_sexf_cl_ss^SEXF *
-                 (ALB / 35)^e_alb_cl_ss *
-                 e_combo_rg_cl_ss^COMBO_RG *
-                 bcel_cl_ss^e_blbcell_cl_ss *
-                 (1 + e_tumsz_cl_ss * (TUMSZ / 5000 - 1))
+    cov_cl <- (WT / 75)^e_wt_cl *
+                 e_sexf_cl^SEXF *
+                 (ALB / 35)^e_alb_cl *
+                 e_combo_rg_cl^COMBO_RG *
+                 bcel_cl^e_blbcell_cl *
+                 (1 + e_tumsz_cl * (TUMSZ / 5000 - 1))
 
     cov_kdes <- e_line1l_kdes^LINE_1L *
                 e_combo_rg_kdes^COMBO_RG
@@ -249,7 +249,7 @@ Lu_2019_polatuzumab <- function() {
     # acMMAE side
     kdes        <- exp(lkdes) * cov_kdes                      # 1/hour
     cl_time_init <- exp(lcl_time + etalcl_time) * cov_cl_time # CL_TIME initial value at t = 0 (L/hour)
-    cl_ss       <- exp(lcl_ss + etalcl_ss) * cov_cl_ss        # L/hour
+    cl       <- exp(lcl + etalcl) * cov_cl        # L/hour
     vc          <- exp(lvc + etalvc) * cov_vc                 # L
     vp          <- exp(lvp + etalvp) * (WT / 75)^e_wt_vc      # L
     q           <- exp(lq + etalq) * (WT / 75)^e_wt_vc        # L/hour
@@ -274,7 +274,7 @@ Lu_2019_polatuzumab <- function() {
     # Hill function for CL_NS(t) (Lu 2019 Eq. 1). At t = 0, CL_NS = CL_SS *
     # (1 + CLSSEMAX); as t -> infinity, CL_NS -> CL_SS.
     tgam <- time^gamma_ns
-    cl_ns <- cl_ss * (1 + clss_emax * t50gam / (t50gam + tgam))
+    cl_ns <- cl * (1 + clss_emax * t50gam / (t50gam + tgam))
 
     # Exponential decay of CL_TIME (Lu 2019 supplement Notations: CLT = CLT0 * exp(-kdes*t)).
     cl_t <- cl_time_init * exp(-kdes * time)

--- a/inst/modeldb/specificDrugs/Wu_2024_inotuzumab.R
+++ b/inst/modeldb/specificDrugs/Wu_2024_inotuzumab.R
@@ -78,7 +78,7 @@ Wu_2024_inotuzumab <- function() {
     # exp(-kdes * time). Mapping to nlmixr2lib conventions: CL1 -> CL_SS
     # (the steady-state, non-decaying arm) and CL2 -> CL_TIME (the
     # time-varying decay arm).
-    lcl_ss <- log(0.130);  label("Linear (steady-state) clearance for an NHL adult (CL_SS, L/h)")               # Wu 2024 Table 3 (CL1)
+    lcl <- log(0.130);  label("Linear (steady-state) clearance for an NHL adult (CL_SS, L/h)")               # Wu 2024 Table 3 (CL1)
     lvc    <- log(6.49);   label("Central volume of distribution for an NHL adult (Vc, L)")                     # Wu 2024 Table 3 (V1)
     lcl_time <- log(0.569); label("Initial value of time-dependent clearance for an NHL adult (CL_TIME, L/h)")  # Wu 2024 Table 3 (CL2)
     lkdes  <- log(0.0577); label("Decay coefficient of time-dependent clearance for an NHL adult (kdes, 1/h)")  # Wu 2024 Table 3
@@ -88,15 +88,15 @@ Wu_2024_inotuzumab <- function() {
     # Covariate-effect parameters (Wu 2024 Table 3). Continuous covariates enter
     # as power models centered on the reference value; categorical effects enter
     # as additive fractional-change dummy variables of the form (1 + theta * I).
-    e_lbm_cl_ss   <-  1.05;    label("Power exponent of LBM on CL_SS (unitless)")                            # Wu 2024 Table 3
+    e_lbm_cl   <-  1.05;    label("Power exponent of LBM on CL_SS (unitless)")                            # Wu 2024 Table 3
     e_lbm_vc      <-  0.977;   label("Power exponent of LBM on Vc (unitless)")                               # Wu 2024 Table 3
     e_lbm_cl_time <-  0.687;   label("Power exponent of LBM on CL_TIME (unitless)")                          # Wu 2024 Table 3
-    e_all_cl_ss   <- -0.767;   label("Fractional change in CL_SS for BCP-ALL (vs NHL, unitless)")            # Wu 2024 Table 3
+    e_all_cl   <- -0.767;   label("Fractional change in CL_SS for BCP-ALL (vs NHL, unitless)")            # Wu 2024 Table 3
     e_all_cl_time <- -0.362;   label("Fractional change in CL_TIME for BCP-ALL (vs NHL, unitless)")          # Wu 2024 Table 3
     e_all_kdes    <- -0.924;   label("Fractional change in kdes for BCP-ALL (vs NHL, unitless)")             # Wu 2024 Table 3
     e_blstabl_kdes <- -0.0484; label("Power exponent of BLSTABL on kdes for BCP-ALL only (unitless)")        # Wu 2024 Table 3
     e_age_kdes    <- -0.296;   label("Power exponent of AGE on kdes for BCP-ALL only (unitless)")            # Wu 2024 Table 3
-    e_ritux_cl_ss <- -0.132;   label("Fractional change in CL_SS for concomitant rituximab (unitless)")      # Wu 2024 Table 3
+    e_ritux_cl <- -0.132;   label("Fractional change in CL_SS for concomitant rituximab (unitless)")      # Wu 2024 Table 3
 
     # Inter-individual variability. Wu 2024 Table 3 reports CV% for IIV with
     # the convention CV = sqrt(omega^2) (i.e., the OMEGA variance equals the
@@ -104,7 +104,7 @@ Wu_2024_inotuzumab <- function() {
     # from the off-diagonal covariances (e.g., 0.136 / sqrt(0.16 * 0.1608)
     # = 0.847 = 84.7% as in Table 3 'CL1 - V1; correlations'). CL_SS, Vc,
     # CL_TIME are reported as a 3x3 correlated block; kdes is independent.
-    etalcl_ss + etalvc + etalcl_time ~ c(0.16,
+    etalcl + etalvc + etalcl_time ~ c(0.16,
                                          0.136, 0.16080,
                                          0.194, 0.204, 0.54317)  # Wu 2024 Table 3 (CV%: CL_SS 40.0, Vc 40.1, CL_TIME 73.7; covariances 0.136 / 0.194 / 0.204)
     etalkdes ~ 0.35641  # Wu 2024 Table 3 (CV% kdes 59.7)
@@ -130,10 +130,10 @@ Wu_2024_inotuzumab <- function() {
     #   kdes_ALL = 0.0577 * (1 - 0.924) * (BLSTABL/0.352)^-0.0484 * (AGE/60)^-0.296
     #   Q     = 0.0437
     #   Vp    = 4.74
-    cl_ss <- exp(lcl_ss + etalcl_ss) *
-      (1 + e_all_cl_ss   * DIS_BCPALL) *
-      (LBM / 52.7)^e_lbm_cl_ss *
-      (1 + e_ritux_cl_ss * CONMED_RITUX)
+    cl <- exp(lcl + etalcl) *
+      (1 + e_all_cl   * DIS_BCPALL) *
+      (LBM / 52.7)^e_lbm_cl *
+      (1 + e_ritux_cl * CONMED_RITUX)
 
     vc <- exp(lvc + etalvc) * (LBM / 52.7)^e_lbm_vc
 
@@ -160,7 +160,7 @@ Wu_2024_inotuzumab <- function() {
     # `time` is the internal integration time in hours, which corresponds to
     # time from the first dose for the event datasets this model expects.
     cl_t   <- cl_time * exp(-kdes * time)
-    cl_tot <- cl_ss + cl_t
+    cl_tot <- cl + cl_t
 
     # Two-compartment model with IV input (no depot; doses are administered
     # directly into the central compartment as 60-minute IV infusions, see

--- a/inst/modeldb/specificDrugs/Yamada_2025_zolbetuximab.R
+++ b/inst/modeldb/specificDrugs/Yamada_2025_zolbetuximab.R
@@ -84,7 +84,7 @@ Yamada_2025_zolbetuximab <- function() {
     # in L/h; we use time in days here to align with Kdecay (1/day), so L/h is
     # multiplied by 24 to give L/day. Values are from Yamada 2025 Table 1
     # (final TDC model; footnote a identifies it as the final model).
-    lcl_ss   <- log(0.0117 * 24); label("Steady-state clearance component (CLss, L/day)")    # Yamada 2025 Table 1 (0.0117 L/h * 24)
+    lcl   <- log(0.0117 * 24); label("Steady-state clearance component (CLss, L/day)")    # Yamada 2025 Table 1 (0.0117 L/h * 24)
     lcl_time <- log(0.0159 * 24); label("Time-decaying clearance component (CLT, L/day)")    # Yamada 2025 Table 1 (0.0159 L/h * 24)
     lkdecay  <- log(0.0209);      label("First-order decay rate of CLT (Kdecay, 1/day)")     # Yamada 2025 Table 1
     lvc      <- log(3.04);        label("Central volume of distribution (V1, L)")            # Yamada 2025 Table 1
@@ -98,20 +98,20 @@ Yamada_2025_zolbetuximab <- function() {
     # (param = typical * (1 + theta * I)).
     e_bsa_cl                <-  1.06;   label("Power exponent of BSA on CLss, CLT, Q (unitless; shared CL exponent)")  # Yamada 2025 Table 1
     e_bsa_vc_vp             <-  0.968;  label("Power exponent of BSA on V1, V2 (unitless; shared volume exponent)")    # Yamada 2025 Table 1
-    e_alb_cl_ss             <- -0.535;  label("Power exponent of albumin on CLss (unitless)")                          # Yamada 2025 Table 1
+    e_alb_cl             <- -0.535;  label("Power exponent of albumin on CLss (unitless)")                          # Yamada 2025 Table 1
     e_alb_kdecay            <-  1.48;   label("Power exponent of albumin on Kdecay (unitless)")                        # Yamada 2025 Table 1
     e_hgb_vc                <- -0.374;  label("Power exponent of hemoglobin on V1 (unitless)")                         # Yamada 2025 Table 1
     e_tbili_vc              <-  0.0347; label("Power exponent of total bilirubin on V1 (unitless)")                    # Yamada 2025 Table 1
-    e_prior_gast_cl_ss      <- -0.182;  label("Fractional change in CLss for prior gastrectomy (unitless)")            # Yamada 2025 Table 1
+    e_prior_gast_cl      <- -0.182;  label("Fractional change in CLss for prior gastrectomy (unitless)")            # Yamada 2025 Table 1
     e_prior_gast_cl_time    <- -0.495;  label("Fractional change in CLT for prior gastrectomy (unitless)")             # Yamada 2025 Table 1
     e_prior_gast_vc         <-  0.103;  label("Fractional change in V1 for prior gastrectomy (unitless)")              # Yamada 2025 Table 1
-    e_sexf_cl_ss            <- -0.195;  label("Fractional change in CLss for females (unitless)")                      # Yamada 2025 Table 1
+    e_sexf_cl            <- -0.195;  label("Fractional change in CLss for females (unitless)")                      # Yamada 2025 Table 1
     e_sexf_vc               <- -0.108;  label("Fractional change in V1 for females (unitless)")                        # Yamada 2025 Table 1
     e_comb_eox_vc           <-  0.466;  label("Fractional change in V1 for EOX chemotherapy backbone (unitless)")      # Yamada 2025 Table 1
 
     # Inter-individual variability. The paper reports %CV on log-normal
     # parameters; the stored variance follows omega^2 = log(CV^2 + 1).
-    etalcl_ss   ~ 0.0669  # 26.3% CV; Yamada 2025 Table 1
+    etalcl   ~ 0.0669  # 26.3% CV; Yamada 2025 Table 1
     etalcl_time ~ 0.4569  # 76.1% CV; Yamada 2025 Table 1
     etalkdecay  ~ 0.4685  # 77.3% CV; Yamada 2025 Table 1
     etalvc      ~ 0.0396  # 20.1% CV; Yamada 2025 Table 1
@@ -131,11 +131,11 @@ Yamada_2025_zolbetuximab <- function() {
     # Individual PK parameters. Reference subject (Yamada 2025 Figure 1):
     # BSA = 1.70 m^2, ALB = 39.1 g/L, HGB = 118 g/L, TBILI = 0.38 mg/dL, male,
     # no prior gastrectomy, non-EOX chemotherapy backbone.
-    cl_ss <- exp(lcl_ss + etalcl_ss) *
+    cl <- exp(lcl + etalcl) *
       (BSA / 1.70)^e_bsa_cl *
-      (ALB / 39.1)^e_alb_cl_ss *
-      (1 + e_prior_gast_cl_ss * PRIOR_GAST) *
-      (1 + e_sexf_cl_ss * SEXF)
+      (ALB / 39.1)^e_alb_cl *
+      (1 + e_prior_gast_cl * PRIOR_GAST) *
+      (1 + e_sexf_cl * SEXF)
 
     cl_time <- exp(lcl_time + etalcl_time) *
       (BSA / 1.70)^e_bsa_cl *
@@ -162,11 +162,11 @@ Yamada_2025_zolbetuximab <- function() {
     #   CL(t) = CLss + CLT * exp(-Kdecay * t)
     # `time` is the internal integration time in days, which corresponds to
     # time from the first dose for the event datasets this model expects.
-    cl <- cl_ss + cl_time * exp(-kdecay * time)
+    cl_tot <- cl + cl_time * exp(-kdecay * time)
 
     # Two-compartment model with zero-order IV input (infusion rate supplied
     # via the `rate` column on dose events).
-    kel <- cl / vc
+    kel <- cl_tot / vc
     k12 <- q  / vc
     k21 <- q  / vp
 

--- a/vignettes/articles/Lu_2019_polatuzumab.Rmd
+++ b/vignettes/articles/Lu_2019_polatuzumab.Rmd
@@ -109,7 +109,7 @@ Table S3. The table below collates them.
 |------------------------|----------------------------|-----------------|------------------|
 | `lkdes`                | kdes                       | 0.0046 1/hour   | Table 1, theta1  |
 | `lcl_time`             | CL_TIME (initial)          | 0.00623 L/hour  | Table 1, theta2  |
-| `lcl_ss`               | CL_SS                      | 0.0344 L/hour   | Table 1, theta3  |
+| `lcl`               | CL_SS                      | 0.0344 L/hour   | Table 1, theta3  |
 | `lvc`                  | V1                         | 3.15 L          | Table 1, theta4  |
 | `lvp`                  | V2                         | 3.98 L          | Table 1, theta5  |
 | `lq`                   | Q                          | 0.0145 L/hour   | Table 1, theta6  |
@@ -128,16 +128,16 @@ Table S3. The table below collates them.
 | `lfrac_mm`             | FRAC_MM                    | 2.72            | Table 1, theta19 |
 | `lalph_mo`             | alpha (1/month)            | 0.167 1/month   | Table 1, theta20 |
 | `frac_t`               | FRAC_T                     | 0.139           | Table 1, theta21 |
-| `e_wt_cl_ss`           | WT on CL_SS                | 0.73            | Table 2, theta22 |
+| `e_wt_cl`           | WT on CL_SS                | 0.73            | Table 2, theta22 |
 | `e_wt_vc`              | WT on Vc, Vp, Q (shared)   | 0.50            | Table 2, theta23 |
 | `e_sexf_vc`            | sex on Vc (1/1.20)         | 0.8333          | Table 2, theta24 (inverted) |
 | `e_asian_vc`           | Asian on Vc                | 0.929           | Table 2, theta25 |
 | `e_line1l_vc`          | Treatment-naive on Vc      | 1.20            | Table 2, theta26 |
-| `e_sexf_cl_ss`         | sex on CL_SS (1/1.10)      | 0.9091          | Table 2, theta27 (inverted) |
-| `e_alb_cl_ss`          | ALB on CL_SS (power)       | -0.247          | Table 2, theta28 |
-| `e_combo_rg_cl_ss`     | R/G combo on CL_SS         | 0.844           | Table 2, theta29 |
-| `e_blbcell_cl_ss`      | B-cell on CL_SS (power)    | 0.0212          | Table 2, theta30 |
-| `e_tumsz_cl_ss`        | TUMSZ on CL_SS (linear)    | 0.0521          | Table 2, theta31 |
+| `e_sexf_cl`         | sex on CL_SS (1/1.10)      | 0.9091          | Table 2, theta27 (inverted) |
+| `e_alb_cl`          | ALB on CL_SS (power)       | -0.247          | Table 2, theta28 |
+| `e_combo_rg_cl`     | R/G combo on CL_SS         | 0.844           | Table 2, theta29 |
+| `e_blbcell_cl`      | B-cell on CL_SS (power)    | 0.0212          | Table 2, theta30 |
+| `e_tumsz_cl`        | TUMSZ on CL_SS (linear)    | 0.0521          | Table 2, theta31 |
 | `e_line1l_kdes`        | Treatment-naive on kdes    | 3.38            | Table 2, theta32 |
 | `e_combo_rg_kdes`      | R/G combo on kdes          | 0.932           | Table 2, theta33 |
 | `e_line1l_cl_time`     | Treatment-naive on CL_TIME | 3.53            | Table 2, theta34 |
@@ -588,7 +588,7 @@ expected to be reproduced.
   canonical SEXF reverses the value coding (`SEXF = 1 - source_SEX`).
   Multiplicative-ratio effects therefore invert: the paper's `theta24 =
   1.20` (V1 male:female) becomes `e_sexf_vc = 1/1.20 = 0.8333`;
-  `theta27 = 1.10` becomes `e_sexf_cl_ss = 1/1.10 = 0.9091`; `theta39 =
+  `theta27 = 1.10` becomes `e_sexf_cl = 1/1.10 = 0.9091`; `theta39 =
   0.911` becomes `e_sexf_frac_mmae = 1/0.911 = 1.0977`. Effect magnitude
   and reference subject (male, SEXF = 0) are preserved.
 


### PR DESCRIPTION
Rename steady-state-CL and complex-Vc parameters to canonical lcl / lvc identifiers so they pair with the standard PK concept set used everywhere else in the modeldb (CL, Q, Q2, Vc, Vp, Vp2).  Pure identifier renames - model semantics are unchanged.

- Lu_2019_polatuzumab: lcl_ss -> lcl (and the corresponding cl_ss / etalcl_ss / e_*_cl_ss / bcel_cl_ss / cov_cl_ss locals in model({})).  The total time-varying CL is already cl_ns (not cl), so there is no naming collision.
- Wu_2024_inotuzumab: lcl_ss -> lcl as above.  Total clearance was already cl_tot, no collision.
- Yamada_2025_zolbetuximab: lcl_ss -> lcl as above.  The total time-varying clearance was previously stored in a local cl, which would have collided with the renamed steady-state CL; renamed that local to cl_tot to match the Wu 2024 convention.
- Hood_2021_medi7836: lvcx -> lvc_complex (the apparent central volume of the IL13:MEDI7836 complex compartment).

Vignettes:
- vignettes/articles/Lu_2019_polatuzumab.Rmd: code-side and inline-backtick references to the renamed identifiers updated.  Paper-style notation ("CL_SS", "Vcx", etc.) is preserved in prose / table headers as-is.
- The Wu, Yamada, and Hood vignettes had no lowercase code-side references to the renamed identifiers and are unchanged.