### PR TITLE
extract-literature-model: capture fixed parameters in ini() table

### DIFF
--- a/.claude/skills/extract-literature-model/SKILL.md
+++ b/.claude/skills/extract-literature-model/SKILL.md
@@ -124,8 +124,51 @@ Use `references/model-file-template.md` as the starting skeleton and the two bes
 The file body has this shape:
 
 1. `description`, `reference`, `vignette`, `units`, `covariateData`, `population` — metadata before `ini()`. `vignette` is the basename of the validation vignette in `vignettes/articles/` (e.g., `"Clegg_2024_nirsevimab"`, no path, no extension); `buildModelDb()` extracts it so the list-of-models table can link to the rendered vignette on the pkgdown site.
-2. `ini()` — parameters with `label()` and a trailing **in-file comment pointing to the source location** for every value.
+2. `ini()` — parameters with `label()` and a trailing **in-file comment pointing to the source location** for every value. **Wrap fixed parameters in `fixed()`** — see the "Fixed parameters" subsection below.
 3. `model()` — derived terms → individual parameters → micro-constants → ODEs → bioavailability → observation and error.
+
+### Fixed parameters in `ini()`
+
+When the source paper holds a parameter at a known value rather than estimating it, encode that fact by wrapping the value in `fixed()` in `ini()`. This applies to **every** parameter type — structural THETAs, allometric exponents, IIV variances/covariances, residual-error magnitudes, covariate-effect coefficients — not just IIV. Failing to encode the fixed status loses load-bearing provenance: a downstream user cannot tell whether the value was estimated and reported as a point estimate, or whether the source authors held it constant; re-fitting the model under one assumption vs the other gives different results.
+
+Recognise fixed parameters from any of these signals in the source:
+
+- Explicit prose: "fixed during estimation", "fixed at <value>", "held fixed at the literature value", "not estimated", "set to 1 (fixed)".
+- Allometric exponents reported without uncertainty (no SE / RSE / CI), especially the canonical 0.75 (CL-like) and 1 (V-like) values; if the paper says "allometric scaling with fixed exponents", encode those exponents as `fixed()`.
+- NONMEM `$THETA` lines with a `FIX` flag (`$THETA (0.225 FIX) ; CL`).
+- NONMEM `$OMEGA` / `$SIGMA` lines with a `FIX` flag (`$OMEGA 0.0 FIX` for an off-diagonal that was structurally constrained to zero; `$SIGMA 1.0 FIX` for log-transform-both-sides residual where the variance is absorbed into the additive term).
+- Bioavailability `F1 = 1` / `lfdepot <- log(1)` set as a structural anchor when the paper writes "F was fixed to 1 because absolute bioavailability was not identifiable".
+- Maturation reference values (e.g., reference WT = 70 kg, reference PMA = 40 weeks) — these are model-structural constants and are always fixed; encode them as numeric literals inside `model()` or as `fixed()` parameters in `ini()` if they appear in `label()`-worthy form.
+- Carry-over from upstream: when the current paper inherits a structural-PK model from a prior publication and re-estimates only a subset, the inherited parameters are fixed; wrap them in `fixed()` and put the upstream citation in the trailing comment.
+
+Encoding examples:
+
+```r
+ini({
+  # Estimated structural parameter (paper Table 2)
+  lcl <- log(0.225) ; label("Clearance (L/h)")
+
+  # Fixed allometric exponent (paper Methods: "WT scaling with fixed exponents")
+  e_wt_cl <- fixed(0.75) ; label("Allometric exponent on CL")
+
+  # Fixed bioavailability anchor (paper Methods: "F1 fixed to 1; absolute F not identifiable")
+  lfdepot <- fixed(log(1)) ; label("Bioavailability (depot)")
+
+  # Estimated IIV (paper Table 3, omega_CL = 0.32 reported as variance)
+  etalcl ~ 0.32
+
+  # Fixed IIV (paper Methods: "IIV on V was fixed to the prior published value (Hamberg 2007)")
+  etalvc ~ fixed(0.18)
+
+  # Fixed off-diagonal correlation (NONMEM $OMEGA BLOCK with one element FIX 0)
+  etalcl + etalvc ~ c(0.32, fixed(0), 0.18)
+
+  # Fixed residual error variance (NONMEM $SIGMA 1.0 FIX for LTBS approach)
+  CcaddSd <- fixed(0.10) ; label("Additive residual SD on log-Cc (LTBS)")
+})
+```
+
+When in doubt — for example, a $THETA reported with an RSE of 0% but no FIX flag, or a parameter reported to three decimal places with no uncertainty — sidecar-ask the operator before guessing. Mis-classifying an estimated parameter as fixed (or vice versa) is a real error that downstream users will hit.
 
 Follow `references/naming-conventions.md` strictly:
 

--- a/.claude/skills/extract-literature-model/references/model-file-template.md
+++ b/.claude/skills/extract-literature-model/references/model-file-template.md
@@ -67,24 +67,38 @@ Related references:
     #!   2. A label() with units and a plain-English description.
     #!   3. A trailing in-file comment pointing to the source location the value came from.
     #! Example: lcl <- log(0.0388); label("CL for 70 kg adult (L/day)")  # Clegg 2024 Table 3
+    #!
+    #! Wrap fixed values in fixed(): if the source paper holds the parameter
+    #! constant rather than estimating it, the value belongs in fixed(...).
+    #! See SKILL.md § "Fixed parameters in ini()" for the full source-signal
+    #! checklist (NONMEM FIX flags, "fixed at <value>" prose, allometric
+    #! exponents reported without uncertainty, F1=1 anchors, parameters
+    #! inherited from upstream papers, etc.).
 
     # Structural parameters — reference values for <reference weight / age>
     lka     <- log(<value>); label("<description with units>")  # <source location>
     lcl     <- log(<value>); label("<description with units>")  # <source location>
     lvc     <- log(<value>); label("<description with units>")  # <source location>
     # Add lvp, lq, lfdepot, etc. as applicable
+    # If F1 was fixed to 1: lfdepot <- fixed(log(1)); label("Bioavailability") # <source location>
 
     # Allometric / maturation parameters (if applicable)
+    # Estimated:           allo_cl <- <value>; label("Allometric exponent on CL (unitless)")
+    # Fixed at canonical:  allo_cl <- fixed(0.75); label("Allometric exponent on CL (unitless)")
     allo_cl <- <value>; label("Allometric exponent on CL (unitless)")  # <source location>
 
     # Covariate effects — one per covariate/parameter combination
+    # Wrap in fixed() if the paper held this coefficient constant.
     e_<cov>_<param> <- <value>; label("<Effect of <cov> on <param>>")  # <source location>
 
     # IIV — eta + transformed parameter name. Use a block for correlated IIV.
+    # Use ~ fixed(<var>) for IIVs the paper held constant from a prior publication.
+    # Use fixed(0) inside a c(...) block for off-diagonals NONMEM fixed to zero.
     etalcl + etalvc ~ c(<var_cl>, <cov_cl_vc>, <var_vc>)  # <source location>
     etalka          ~ <var_ka>                              # <source location>
 
     # Residual error
+    # Wrap in fixed() if NONMEM $SIGMA had FIX (LTBS pattern often does this).
     propSd <- <value>; label("Proportional residual error (fraction)")  # <source location>
     # addSd  <- <value>; label("Additive residual error (<units>)")     # uncomment if combined
   })

--- a/.claude/skills/extract-literature-model/references/naming-conventions.md
+++ b/.claude/skills/extract-literature-model/references/naming-conventions.md
@@ -172,13 +172,38 @@ Cc_dar0, Cc_dar1, ... Cc_dar7
 
 Always label every parameter inside `ini()` with units and a short interpretation.
 
+## Fixed parameters
+
+Wrap a parameter value in `fixed()` whenever the source paper holds it constant rather than estimating it. This applies to **every** parameter type: structural THETAs, allometric exponents, IIV variances and covariances, residual-error magnitudes, covariate-effect coefficients, bioavailability anchors. The `fixed()` wrapper is load-bearing provenance — a downstream user must be able to tell which values are estimated point estimates vs structural assumptions.
+
+Source signals that a parameter is fixed:
+
+- Prose: "fixed during estimation", "fixed at <value>", "held fixed at the literature value", "not estimated", "set to 1 (fixed)".
+- Allometric exponents without RSE / SE / CI (canonical 0.75 / 1, especially under "fixed exponents" wording).
+- NONMEM `$THETA` / `$OMEGA` / `$SIGMA` with a `FIX` flag.
+- Bioavailability `F1 = 1` set as structural anchor.
+- Inherited parameters from an upstream publication that the current paper re-uses without re-fitting.
+
+Examples:
+
+```r
+lcl       <- log(0.225)            ; label("Clearance (L/h)")        # estimated
+e_wt_cl   <- fixed(0.75)           ; label("Allometric exp on CL")   # fixed
+lfdepot   <- fixed(log(1))         ; label("Bioavailability")        # fixed anchor
+etalcl    ~ 0.32                                                     # estimated IIV
+etalvc    ~ fixed(0.18)                                              # fixed IIV
+CcaddSd   <- fixed(0.10)           ; label("Additive SD (LTBS)")     # fixed residual
+```
+
+If a parameter is reported without uncertainty but the paper does not explicitly say "fixed", sidecar-ask the operator before guessing. Mis-encoding fixed-vs-estimated is a real downstream error.
+
 ## Inter-individual variability (IIV)
 
 Prefix `eta` + the **transformed** parameter name. Example: IIV on `lcl` is `etalcl`.
 
 - Single IIV: `etalcl ~ 0.09`
 - Correlated IIV (block): `etalcl + etalvc ~ c(var_cl, cov, var_vc)`
-- Fixed: wrap in `fixed()` when the source reports a known value.
+- Fixed: wrap in `fixed()` when the source reports a known value (see "Fixed parameters" above for the broader guidance applying to all parameter types).
 
 Do **not** use `iiv_`, `IIV_`, or `bsv_` prefixes for new models. The two most recent existing models (`Clegg_2024_nirsevimab`, `Hu_2026_clesrovimab`) write `etacl` without the `l`; this skill standardizes on `etalcl` going forward. Existing files are not migrated.
 

--- a/.claude/skills/extract-literature-model/references/verification-checklist.md
+++ b/.claude/skills/extract-literature-model/references/verification-checklist.md
@@ -20,7 +20,7 @@ Do not silently resolve ambiguity. Do not tune parameters to make a validation o
 - [ ] **Log-vs-linear reporting.** NONMEM often reports THETAs on the estimation scale (already log), but tables in the paper usually show the back-transformed value. A `log()` wrapper in `ini()` must match what the paper reports: `lcl <- log(0.0388)` is correct when the paper says "CL = 0.0388 L/day."
 - [ ] **CV% vs. variance.** `omega²` in NONMEM output is the variance on the internal scale. For log-normal parameters, CV% relates via `omega² = log(CV² + 1)`. Do not paste CV% directly into `ini()` as if it were a variance.
 - [ ] **Correlated IIV.** If the paper reports a correlation `r` and individual CV%, the covariance is `cov = r × sqrt(var_1 × var_2)`. Verify the block matrix entries match this formula.
-- [ ] **Fixed parameters** the source holds fixed are wrapped in `fixed(...)` in `ini()`.
+- [ ] **Fixed parameters** the source holds fixed are wrapped in `fixed(...)` in `ini()` — applies to ALL parameter types (THETAs, allometric exponents, IIVs, residual errors, covariate effects, bioavailability anchors), not just IIVs. Source signals: explicit "fixed at <value>" prose, NONMEM `FIX` flags on `$THETA`/`$OMEGA`/`$SIGMA`, allometric exponents reported without uncertainty, bioavailability `F1=1` set as structural anchor, parameters inherited from upstream papers without re-fitting. If a parameter is reported without uncertainty but the paper does not explicitly say "fixed", sidecar-ask before guessing — see `SKILL.md` § "Fixed parameters in `ini()`" for the encoding examples.
 
 ## B. Structural model
 


### PR DESCRIPTION
Promote `fixed()` wrapping from a single bullet under IIV to a dedicated subsection in SKILL.md Phase 3 with concrete encoding examples for THETAs, allometric exponents, IIVs, residual errors, covariate effects, and bioavailability anchors.

Source signals enumerated:
- "fixed during estimation" / "held fixed" / "set to <value>" prose
- NONMEM `$THETA` / `$OMEGA` / `$SIGMA` `FIX` flags
- Allometric exponents reported without RSE/SE/CI
- Bioavailability F1=1 set as structural anchor
- Parameters inherited from upstream papers without re-fitting

Updates:
- SKILL.md Phase 3: new "Fixed parameters in `ini()`" subsection
- references/naming-conventions.md: hoist guidance from IIV-only to a dedicated "Fixed parameters" section applying to all parameter types
- references/model-file-template.md: ini() block now annotates estimated-vs-fixed branches with examples (allometric exponents, F1 anchor, IIV, residual error)
- references/verification-checklist.md: expand the fixed-parameter audit item to enumerate source signals and direct readers to the SKILL.md subsection

Triggered by an operator review observing that fixed-parameter status was not being reliably captured during extraction; downstream users could not tell estimated point estimates from fixed structural assumptions.