### PR TITLE
extract-literature-model: in-task OA self-acquisition + log-fixed exa…

### DIFF
--- a/.claude/skills/extract-literature-model/SKILL.md
+++ b/.claude/skills/extract-literature-model/SKILL.md
@@ -24,6 +24,46 @@ Read these on demand; don't load them up front.
 
 ## Phase 1 — Source acquisition and scoping
 
+### Step 0 — Source-file presence and self-acquisition
+
+Before any of the numbered steps below, confirm every source file the task references is on disk and is a valid PDF. The task block includes `Lead PDF`, `Supplements`, `Model files`, and `Source dir` paths; check each path that is set.
+
+For each missing or invalid file (file does not exist, is < 10 KB, or whose first 4 bytes are not `%PDF`), attempt OA acquisition before giving up. The task agent has `Bash` and `WebFetch` tools — use them. Try sources in this order, stopping at the first that yields a valid `%PDF`-headed download of ≥ 10 KB:
+
+1. **CrossRef link array.** `curl -sS "https://api.crossref.org/works/<DOI>" -A "literature-acquisition (mailto:wdenney@humanpredictions.com)"` → inspect the `message.link[]` array; download any URL whose `content-type` contains `pdf` or whose URL ends in `.pdf`.
+2. **Unpaywall.** `curl -sS "https://api.unpaywall.org/v2/<DOI>?email=wdenney@humanpredictions.com"` → if `best_oa_location.url_for_pdf` is set, download it.
+3. **Europe PMC.** `curl -sS "https://www.ebi.ac.uk/europepmc/webservices/rest/search?query=DOI:<DOI>&format=json"` → if any result has a `pmcid` field, download `https://europepmc.org/articles/<PMCID>?pdf=render`. Most effective for Wiley, Elsevier, and Springer papers in PMC after embargo.
+4. **NCBI PMC ID converter.** `curl -sS "https://www.ncbi.nlm.nih.gov/pmc/utils/idconv/v1.0/?ids=<DOI>&format=json&tool=literature-acquisition&email=wdenney@humanpredictions.com"` → download `https://www.ncbi.nlm.nih.gov/pmc/articles/<PMCID>/pdf/`.
+5. **Publisher-specific patterns** (only for known-OA outlets):
+   - BMC: `https://<journal>.biomedcentral.com/track/pdf/<DOI>`
+   - Frontiers: `https://www.frontiersin.org/articles/<DOI>/pdf`
+   - Nature OA / Springer Nature OA: `https://www.nature.com/articles/<id>.pdf` (where `<id>` is the trailing segment of the DOI)
+   - Hindawi: `https://onlinelibrary.wiley.com/doi/pdf/<DOI>` (post-Wiley acquisition)
+   - Dovepress: `https://www.dovepress.com/getfile.php?fileID=<file_id>`
+   - Static Springer Nature media (for Nature Comm SI files): `https://static-content.springer.com/esm/art%3A<doi-percent-encoded>/MediaObjects/<id>_MOESM1_ESM.pdf`
+
+**Validation after each download:** confirm size ≥ 10 KB AND the first 4 bytes equal `%PDF`. Wiley/Elsevier non-OA endpoints typically return ~5 KB HTML challenge pages — these MUST be rejected (delete and try the next source). Do NOT extract from a file whose head bytes are not `%PDF`.
+
+**Title-content sanity check** for the lead PDF: after a successful download, `pdftotext -l 1 <file> -` and confirm the title / first-author line approximately matches what the task block expects. CrossRef DOIs occasionally point to a different paper than the task's metadata claims (publishers' DOI sequence is not always continuous, e.g. `10.1038/aps.2014.120` was a Zhang ROR review when the task expected Lu 2015 tacrolimus). If the downloaded PDF's title disagrees with the task expectation, don't extract from it — sidecar-ask the operator with the actual-vs-expected metadata.
+
+**When to give up and sidecar.** If all 5 source paths above have been tried and none produced a valid PDF whose title matches the task expectation, write a sidecar request describing what was attempted:
+
+> Lead PDF for <paper> not on disk and OA acquisition failed. Tried: CrossRef link array (n URLs), Unpaywall (oa_status=<status>, pdf_url=<url-or-none>), Europe PMC (PMCID=<id-or-not-found>), NCBI PMC (PMCID=<id-or-not-found>), publisher landing (<list-of-tried-URLs>). Each returned <reason: HTML challenge page / 404 / not-PDF / title-mismatch>. Options: (A) operator drops the PDF on disk and re-dispatches, (B) operator emails corresponding author, (C) skip this task. Which applies?
+
+The same ladder applies to **supplements** and **errata**:
+
+- For Wiley supplements: try `https://onlinelibrary.wiley.com/action/downloadSupplement?doi=<DOI>&file=<filename>`. Filenames often follow the pattern `<journal-prefix><articleid>-sup-<NNNN>-<descriptor>.pdf`; if the exact filename isn't known, fetch the article landing page and grep for `downloadSupplement` URLs.
+- For Springer Nature SI: `https://static-content.springer.com/esm/art%3A<doi-percent-encoded>/MediaObjects/<id>_MOESM1_ESM.pdf`. Increment `MOESM2_ESM`, `MOESM3_ESM`, etc. for additional supplements.
+- For BMC: PMC mirror often has supplements at `https://www.ncbi.nlm.nih.gov/pmc/articles/<PMCID>/bin/<filename>`.
+- For Frontiers: typically inline at the article landing page; fetch the page and grep for `Image_*.pdf` / `Table_*.docx` / `Presentation_*.pdf` in the HTML.
+- For errata: search PubMed (`https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&term=<title>+AND+erratum&retmode=json`) for the original PMID + erratum link; download the erratum PDF via the same OA ladder.
+
+If a supplement is unobtainable but the lead PDF is on disk, decide based on whether the missing supplement contains parameter values you need: if it does, sidecar-ask before extracting (see Phase 4 missing-parameter pathway); if it does not, document the gap in the vignette Errata and proceed.
+
+**Reasonable-attempts cap.** Don't loop forever. The 5-source ladder above with one retry per source is the cap; after that, sidecar. If a source returns a 5xx error, retry once after 5 seconds; otherwise treat as failed and move on.
+
+### Numbered steps
+
 1. Confirm the source type (journal article, supplement, poster, regulatory document).
 2. **Verify the on-disk file is the paper the task names.** Open the source file (or its trimmed `.md` companion) and read the title + first-author line + journal + year. Compare against the task's `Paper metadata` block. If any of {first-author, year, journal, drug} disagrees, stop and sidecar-ask:
 
@@ -147,6 +187,10 @@ Encoding examples:
 ini({
   # Estimated structural parameter (paper Table 2)
   lcl <- log(0.225) ; label("Clearance (L/h)")
+
+  # Fixed log-transformed structural parameter (paper inherits CL = 2 L/h from upstream)
+  # log() goes INSIDE fixed(); never fixed() inside log().
+  lcl <- fixed(log(2)) ; label("Clearance (L/h)")
 
   # Fixed allometric exponent (paper Methods: "WT scaling with fixed exponents")
   e_wt_cl <- fixed(0.75) ; label("Allometric exponent on CL")

--- a/.claude/skills/extract-literature-model/references/naming-conventions.md
+++ b/.claude/skills/extract-literature-model/references/naming-conventions.md
@@ -188,12 +188,15 @@ Examples:
 
 ```r
 lcl       <- log(0.225)            ; label("Clearance (L/h)")        # estimated
+lcl       <- fixed(log(2))         ; label("Clearance (L/h)")        # fixed log-transformed value: log() goes inside fixed()
 e_wt_cl   <- fixed(0.75)           ; label("Allometric exp on CL")   # fixed
-lfdepot   <- fixed(log(1))         ; label("Bioavailability")        # fixed anchor
+lfdepot   <- fixed(log(1))         ; label("Bioavailability")        # fixed anchor (log of 1 = 0)
 etalcl    ~ 0.32                                                     # estimated IIV
 etalvc    ~ fixed(0.18)                                              # fixed IIV
 CcaddSd   <- fixed(0.10)           ; label("Additive SD (LTBS)")     # fixed residual
 ```
+
+Note the `fixed(log(2))` form: when a log-transformed structural parameter is fixed (e.g. `lcl` for a paper that holds CL constant at 2 L/h from an upstream publication), the `log()` goes **inside** `fixed()`, not the other way around. `lcl <- log(fixed(2))` is wrong — it would fix the linear-scale `2` and then take its log, which is not what `fixed()` is meant to mark. Always: `<lparam> <- fixed(log(<linear_value>))`.
 
 If a parameter is reported without uncertainty but the paper does not explicitly say "fixed", sidecar-ask the operator before guessing. Mis-encoding fixed-vs-estimated is a real downstream error.
 


### PR DESCRIPTION
…mple

Two operator follow-ups on top of the prior fixed-parameters commit:

1. SKILL.md Phase 1 gains a "Step 0 — Source-file presence and self-acquisition" preamble that instructs the agent to attempt OA acquisition (CrossRef link array → Unpaywall → Europe PMC → NCBI PMC → publisher landing) for any missing or invalid lead PDF, supplement, or erratum BEFORE sidecaring. The same ladder applies to supplements (Wiley downloadSupplement, Springer Nature MOESM media, BMC PMC bin, Frontiers article-page grep) and errata (PubMed search). Reasonable- attempts cap: 5 sources × 1 retry on 5xx; then sidecar with what was tried and why each failed. Validation on each download requires `%PDF` head bytes + ≥10 KB size, plus a title-content sanity check to catch DOI-mismatch downloads (Wiley/Springer occasionally serve a different paper than the DOI's CrossRef metadata claims).

2. naming-conventions.md and SKILL.md "Fixed parameters" subsection now show `lcl <- fixed(log(2))` explicitly with the rationale that `log()` goes INSIDE `fixed()` — never `log(fixed(2))`. Caught in review of the prior commit; the encoding ambiguity was noted but not exemplified.