### PR TITLE
extract-literature-model: preclinical and in-vitro models are first-class

### DIFF
--- a/.claude/skills/extract-literature-model/SKILL.md
+++ b/.claude/skills/extract-literature-model/SKILL.md
@@ -71,11 +71,14 @@ If a supplement is unobtainable but the lead PDF is on disk, decide based on whe
 
    This catches both "wrong-PMID-in-filename" (e.g. Frey 2010 saved as `PMID_23436260.pdf`) and "wrong-drug-guessed" task-generator errors. Do not proceed with extraction until the mismatch is resolved.
 
-3. **Check the study population species.** Skim the Methods / Subjects section. If every PK dataset contributing to the final model is non-human (rat, mouse, cyno, dog, etc.), stop and sidecar-ask the operator before drafting anything:
+3. **Record the study population species.** Skim the Methods / Subjects section to identify which species the final model was fit to (human, rat, mouse, cyno, dog, beagle, sheep, swine, in-vitro cell line, etc.). Preclinical and in-vitro models are first-class members of nlmixr2lib — extract them the same way you would a human popPK model, with the species recorded explicitly so downstream users can filter by it.
 
-   > This paper reports a preclinical-only (<species>) population PK model. nlmixr2lib is a library of human population-PK models. Should I (A) extract it anyway with clear preclinical metadata, (B) extract only a human-scaled projection if the paper includes one, or (C) skip this paper?
+   - **Required**: set `population$species` to a human-readable label (e.g., `"rat (Sprague-Dawley)"`, `"mouse (HBCx-9 PDX)"`, `"beagle dog"`, `"in vitro (SKBR3)"`, `"human"`). For pooled human+animal cohorts, list each species (e.g., `"human + rat"`).
+   - **Required for non-human**: prepend the species label to `description` (e.g., `description = "Preclinical (rat). Two-compartment popPK ..."` or `description = "In vitro (SKBR3 cell line). Mechanistic HER2 trafficking ..."`) so the species is visible in `modellib()` listings without inspecting `population`.
+   - **Recommended**: if the paper provides a human-scaled projection alongside the preclinical fit (e.g., allometric forward projection for first-in-human dosing), extract the preclinical and the human-scaled projection as **two separate model files** (`Author_Year_drug_<species>.R` and `Author_Year_drug_human.R`) so each is self-contained.
+   - **No sidecar needed for the species choice itself** — extract preclinical models without asking. Sidecar-ask only when the paper has *other* triggers (missing parameters, ambiguous covariate encoding, mixture model, multiple non-hierarchical models, etc.).
 
-   If the paper has both preclinical and human cohorts and the final model is fit to pooled or human-only data, proceed normally — this trigger is specifically for animal-only final models. Record the operator's decision in the PR body.
+   The drug field name should still match the on-disk PDF (per step 2). Animal cohorts often use the same INN as the human drug; in that case, the file is `Author_Year_drug_rat.R` (or similar species suffix) so it doesn't collide with a sibling human extraction.
 
 4. **Prefer trimmed markdown when available.** The preprocessor at `mab_human_consensus/tracking/preprocess_papers.py` writes a `<stem>_trimmed.md` next to each source file (PMC XML, PDF, DOCX, XLSX) containing only the sections the extraction actually needs: Title + Abstract + Methods + Results + Tables + Figure captions. The Introduction, Discussion, Conclusions, References, Acknowledgments, and publisher boilerplate are stripped. If `PMID_<pmid>_pmc_trimmed.md` (or `PMID_<pmid>_trimmed.md` for a PDF, or `<stem>_trimmed.md` for a supplement) exists, read it **instead of** the raw `.xml` / `.pdf` / `.docx` — it's typically 40-95% smaller with no loss of extractable content. Full-text sanity check on the trimmed file: ~15 KB+ (full-text trim) vs < 3 KB (abstract-only trim). Fall back to the raw source only if the `_trimmed.md` doesn't exist, the trim appears to have lost a specific piece of information you need (rare — only when the paper is structurally unusual), or you explicitly need the discarded sections (e.g., to quote a Discussion claim in the vignette narrative).
 
@@ -405,7 +408,7 @@ Don't guess — ask the user when:
 - PKNCA output disagrees with a published NCA table by more than ~20% after careful review.
 - The source is paywalled and the user hasn't supplied the text.
 - An erratum search is inconclusive (e.g., paywalled journal, ambiguous correction notice) — ask the user to confirm whether any corrections apply.
-- The paper's final model was fit to animal-only data (see Phase 1 species-check step).
+- (Removed: animal-only-data sidecar trigger — preclinical and in-vitro models are first-class and extracted without sidecar-asking. Phase 1 step 3 is now a species-labelling step, not a stop-and-ask.)
 - The PMC XML / PDF on disk contains only the paper's abstract (see Phase 1 full-text-check step).
 - The on-disk file's title / first-author / journal / year / drug disagrees with the task's `Paper metadata` block (see Phase 1 paper-identity-check step).
 - The paper depends on an upstream popPK model that is not on disk — either the upstream paper is identifiable (queue dependency) or unidentifiable (operator decision needed). See Phase 1 upstream-popPK detection step.

--- a/.claude/skills/extract-literature-model/references/model-file-template.md
+++ b/.claude/skills/extract-literature-model/references/model-file-template.md
@@ -10,6 +10,13 @@ Related references:
 ```r
 <FirstAuthor>_<Year>_<drug> <- function() {
   description <- "<One-sentence summary, e.g., 'Two-compartment population PK model for <drug> in <population>'>"
+  #! Non-human studies: PREPEND the species to description, e.g.,
+  #!   description <- "Preclinical (rat, Sprague-Dawley). Two-compartment popPK model for ..."
+  #!   description <- "In vitro (SKBR3 cell line). Mechanistic HER2 receptor trafficking model."
+  #! so the species is visible in modellib() listings without inspecting population$species.
+  #! For preclinical/in vitro models: filename should also carry a species suffix
+  #!   <FirstAuthor>_<Year>_<drug>_<species>.R  (e.g., Geldof_2008_fluvoxamine_rat.R)
+  #! to keep human and animal extractions of the same drug as separate, non-colliding files.
   reference   <- "<Full citation with DOI>"
   vignette    <- "<FirstAuthor>_<Year>_<drug>"  #! basename of vignettes/articles/<FirstAuthor>_<Year>_<drug>.Rmd; used by list-of-models to link here
   units       <- list(time = "<day|hour>", dosing = "<mg|mg/kg>", concentration = "<ug/mL|ng/mL>")
@@ -47,6 +54,7 @@ Related references:
     #!   disease_state = "healthy infants at risk for RSV"
     #!   dose_range    = "50-200 mg IM single dose"
     #! Additional keys welcome (ga_range, renal_function, hepatic_function, co_medication, ...).
+    species        = "<required: 'human', 'rat (Sprague-Dawley)', 'mouse (HBCx-9 PDX)', 'beagle dog', 'in vitro (SKBR3 cell line)', 'human + rat', etc.>",
     n_subjects     = <integer>,
     n_studies      = <integer>,
     age_range      = "<adult: '18-75 years' | pediatric: '0-24 months'>",

--- a/.claude/skills/extract-literature-model/references/naming-conventions.md
+++ b/.claude/skills/extract-literature-model/references/naming-conventions.md
@@ -317,6 +317,7 @@ covariateData <- list(
   )
 )
 population <- list(
+  species      = "<required: 'human', 'rat (Sprague-Dawley)', 'mouse (HBCx-9 PDX)', 'beagle dog', 'in vitro (SKBR3 cell line)', etc.; for pooled cohorts list each (e.g., 'human + rat')>",
   n_subjects   = <integer>,
   n_studies    = <integer>,
   age_range    = "<e.g., 0-24 months>",

--- a/.claude/skills/extract-literature-model/references/verification-checklist.md
+++ b/.claude/skills/extract-literature-model/references/verification-checklist.md
@@ -10,6 +10,7 @@ Do not silently resolve ambiguity. Do not tune parameters to make a validation o
 
 - [ ] On-disk PDF / XML title, first author, journal, and year match the task's `Paper metadata` block. Filename PMID matches the actual PMID in the source (catches mislabelled drops like `PMID_23436260.pdf` actually being Frey 2010 / PMID 20097931).
 - [ ] Drug named in the task metadata matches the molecule the paper actually models.
+- [ ] **Species recorded.** `population$species` is set to the species the final model was fit to (e.g., `"human"`, `"rat (Sprague-Dawley)"`, `"beagle dog"`, `"in vitro (SKBR3 cell line)"`, `"human + rat"` for pooled). Non-human models additionally prepend the species to `description` (e.g., `"Preclinical (rat). ..."`). Filename carries a species suffix when the same drug has both human and animal extractions (e.g., `Geldof_2008_fluvoxamine_rat.R`). Preclinical and in-vitro models are first-class and are extracted without sidecar-asking — the species check is a labelling step, not a gating decision. See SKILL.md Phase 1 step 3.
 
 ## A. Parameter values
 


### PR DESCRIPTION
Phase 1 step 3 is no longer a sidecar trigger. Animal-only and in-vitro studies are extracted the same way human popPK studies are, with the species recorded explicitly so downstream users can filter by it.

Operator decision (2026-05-10): "Across the board preclinical models are acceptable and the species should be clearly noted in the model metadata." Skill previously stopped-and-asked before drafting any animal-only model, which (i) burned sidecars cycles for what is now a routine extraction, and (ii) under-served the body of preclinical PK/PD literature in the queue.

Required artefacts in every extraction:

- `population$species` is set to a human-readable label, e.g. "human", "rat (Sprague-Dawley)", "mouse (HBCx-9 PDX)", "beagle dog", "in vitro (SKBR3 cell line)", or "human + rat" for pooled cohorts.
- For non-human models, the species label is prepended to `description` so it shows in `modellib()` listings without inspecting `population` (e.g. "Preclinical (rat). Two-compartment popPK model for ...").
- Filename carries a species suffix when the same drug has both human and animal extractions, e.g. `Geldof_2008_fluvoxamine_rat.R` next to a sibling `Author_Year_fluvoxamine.R` (or `_human.R`) so neither file collides.

Updates:

- SKILL.md Phase 1 step 3: rewrite as a species-labelling step; remove the stop-and-ask sidecar template; document the description-prefix and filename-suffix conventions.
- SKILL.md "Common escalations": remove the animal-only-data trigger with a redirect note.
- references/naming-conventions.md: add `species` as a required key in the `population` schema.
- references/model-file-template.md: add `species` slot to the population list and document the description-prefix + species-suffix-filename rules.
- references/verification-checklist.md (Section H. Source identity): add a "Species recorded" check covering all three artefacts (`population$species`, description prefix, filename suffix).