### PR TITLE
Update test assertion for COMB_EOX -> CONMED_EOX covariate rename

### DIFF
--- a/tests/testthat/test-checkModelConventions.R
+++ b/tests/testthat/test-checkModelConventions.R
@@ -328,7 +328,7 @@ test_that("canonical covariates are parsed from inst/references/covariate-column
   expect_equal(canon$FORM_DP2$scope, "specific")
   expect_equal(canon$TUMTP_CHL$scope, "specific")
   expect_equal(canon$ooc1$scope, "specific")
-  expect_equal(canon$COMB_EOX$scope, "specific")
+  expect_equal(canon$CONMED_EOX$scope, "specific")
   expect_equal(canon$DOSE_70MG$scope, "specific")
   expect_true("Xu_2019_sarilumab" %in% canon$FORM_DP2$example_models)
   expect_true("Cirincione_2017_exenatide" %in% canon$STUDY1$example_models)


### PR DESCRIPTION
The canonical covariate `COMB_EOX` was renamed to `CONMED_EOX` in `inst/references/covariate-columns.md` (the alias source `COMB` from Yamada 2025 was renormalised under the `CONMED_*` concomitant-medication family). The assertion in test-checkModelConventions.R:331 still referenced the old name and so returned NULL$scope.

Fixes the failing R-CMD-check on main:
https://github.com/nlmixr2/nlmixr2lib/actions/runs/25686757684