### PR TITLE
Parallelize pkgdown article rendering in GitHub Actions

### DIFF
--- a/.github/scripts/pkgdown-parallel-build.R
+++ b/.github/scripts/pkgdown-parallel-build.R
@@ -81,7 +81,8 @@ abort_with <- function(failed_name, err) {
 }
 
 while (length(running) < ncores && length(pending) > 0) {
-  nm <- pending[1]; pending <- pending[-1]
+  nm <- pending[1]
+  pending <- pending[-1]
   job <- launch_one(nm)
   log_line("START ", nm, "  (pid ", job$pid, ")")
   running[[nm]] <- job
@@ -106,7 +107,8 @@ while (length(running) > 0) {
     log_line("DONE  ", article_name, "  (", sprintf("%.1fs", r$secs), ")")
   }
   while (length(running) < ncores && length(pending) > 0) {
-    nm <- pending[1]; pending <- pending[-1]
+    nm <- pending[1]
+    pending <- pending[-1]
     job <- launch_one(nm)
     log_line("START ", nm, "  (pid ", job$pid, ")")
     running[[nm]] <- job

--- a/.github/scripts/pkgdown-parallel-build.R
+++ b/.github/scripts/pkgdown-parallel-build.R
@@ -45,6 +45,27 @@ t0 <- Sys.time()
 # Spawn a forked worker rendering one article. Returns the mcparallel job.
 launch_one <- function(name) {
   parallel::mcparallel({
+    # Per-fork rmarkdown tempfile prefix.
+    #
+    # rmarkdown::render() writes pandoc include files (header / before-body /
+    # after-body) via as_tmpfile() into tempdir() using the package-global
+    # prefix `tmpfile_pattern` ("rmarkdown-str"), and after each render
+    # calls clean_tmpfiles() which unlinks every file in tempdir() matching
+    # ^rmarkdown-str[0-9a-f]+\.html$.
+    #
+    # All forks inherit the parent's tempdir() path AND the same default
+    # prefix, so worker B's clean_tmpfiles() can wipe worker A's include
+    # files mid-pandoc -- surfaces as
+    #   "pandoc: /tmp/RtmpXXX/rmarkdown-strYYY.html: withBinaryFile: does not exist"
+    # Giving each fork a pid-scoped prefix scopes both the writes and the
+    # cleanup to that fork, eliminating the race. The cleanup regex still
+    # matches because the suffix is still [0-9a-f]+\.html.
+    try(assignInNamespace(
+      "tmpfile_pattern",
+      paste0("rmarkdown-str-", Sys.getpid(), "-"),
+      ns = "rmarkdown"
+    ), silent = TRUE)
+
     t_start <- Sys.time()
     tryCatch({
       pkgdown::build_article(name = name, pkg = pkg,

--- a/.github/scripts/pkgdown-parallel-build.R
+++ b/.github/scripts/pkgdown-parallel-build.R
@@ -1,0 +1,131 @@
+#!/usr/bin/env Rscript
+# Parallel pkgdown site build for nlmixr2lib's GitHub Actions workflow.
+#
+# Temporary workaround until pkgdown gains native worker support upstream.
+# When that PR lands and is released, this script can be deleted and the
+# pkgdown.yaml workflow reverted to a single build_site_github_pages() call.
+#
+# Strategy: render every vignette in parallel via a hand-rolled scheduler over
+# parallel::mcparallel + mccollect (Linux fork), with FAIL-FAST cancellation
+# on the first vignette failure (sends SIGTERM to all in-flight siblings).
+# After the parallel pass, call pkgdown::build_site_github_pages(lazy = TRUE,
+# clean = FALSE) so pkgdown handles the non-article sections (reference, news,
+# search, ...) and skips already-rendered articles via its mtime lazy check.
+#
+# The PKGDOWN_WORKERS env var is the single managed knob. Blank => use
+# parallel::detectCores(); a positive integer overrides (e.g. to cap memory).
+
+env <- Sys.getenv("PKGDOWN_WORKERS", "")
+ncores <- if (nzchar(env)) as.integer(env) else parallel::detectCores()
+stopifnot(is.finite(ncores), ncores >= 1L)
+Sys.setenv(PKGDOWN_WORKERS = ncores)
+
+# Single-syscall logger; writes < PIPE_BUF (4 KB) are atomic on Linux, so
+# concurrent workers will not interleave mid-line.
+log_line <- function(...) {
+  cat(sprintf("[%s] %s\n",
+              format(Sys.time(), "%H:%M:%S"),
+              paste0(...)),
+      file = stderr())
+}
+
+log_line("PKGDOWN_WORKERS = ", ncores,
+         "  (detectCores() = ", parallel::detectCores(), ")")
+
+pkg <- pkgdown::as_pkgdown(".")
+
+# init_site() copies assets/CSS into docs/. Required because the wrap-up
+# build_site_github_pages(lazy = TRUE) call skips init_site when lazy.
+pkgdown::init_site(pkg)
+
+articles <- pkg$vignettes$name[pkg$vignettes$type == "rmd"]
+log_line("Rendering ", length(articles), " articles in parallel...")
+t0 <- Sys.time()
+
+# Spawn a forked worker rendering one article. Returns the mcparallel job.
+launch_one <- function(name) {
+  parallel::mcparallel({
+    t_start <- Sys.time()
+    tryCatch({
+      pkgdown::build_article(name = name, pkg = pkg,
+                             new_process = FALSE, quiet = TRUE)
+      list(ok = TRUE, name = name,
+           secs = as.numeric(difftime(Sys.time(), t_start, units = "secs")))
+    }, error = function(e) {
+      out <- pkg$vignettes$file_out[match(name, pkg$vignettes$name)]
+      try(unlink(file.path(pkg$dst_path, out)), silent = TRUE)
+      list(ok = FALSE, name = name, err = conditionMessage(e))
+    })
+  }, name = name)
+}
+
+pending <- articles
+# running: vignette name -> mcparallel job descriptor.
+# Keyed by vignette name because mccollect() returns its result list keyed by
+# the job's 'name' argument (which we set to the vignette name); keying running
+# the same way lets us simply do `running[[result_name]] <- NULL` to deregister
+# a finished worker.
+running <- list()
+
+# Kill all in-flight workers and stop the script with a clear error.
+abort_with <- function(failed_name, err) {
+  if (length(running) > 0) {
+    log_line("Killing ", length(running), " in-flight worker(s) and aborting")
+    for (other_name in names(running)) {
+      try(tools::pskill(running[[other_name]]$pid, tools::SIGTERM),
+          silent = TRUE)
+    }
+    try(parallel::mccollect(unname(running), wait = TRUE), silent = TRUE)
+  }
+  stop("Vignette build failed: ", failed_name, " -- ", err, call. = FALSE)
+}
+
+while (length(running) < ncores && length(pending) > 0) {
+  nm <- pending[1]; pending <- pending[-1]
+  job <- launch_one(nm)
+  log_line("START ", nm, "  (pid ", job$pid, ")")
+  running[[nm]] <- job
+}
+
+while (length(running) > 0) {
+  res <- parallel::mccollect(unname(running), wait = FALSE, timeout = 0.5)
+  if (is.null(res)) next
+  for (article_name in names(res)) {
+    r <- res[[article_name]]
+    running[[article_name]] <- NULL
+    failed <- is.null(r) ||
+              inherits(r, "try-error") ||
+              (is.list(r) && isFALSE(r$ok))
+    if (failed) {
+      err <- if (inherits(r, "try-error")) attr(r, "condition")$message
+             else if (is.list(r) && !is.null(r$err)) r$err
+             else "(silent crash)"
+      log_line("FAIL  ", article_name, "  -- ", err)
+      abort_with(article_name, err)
+    }
+    log_line("DONE  ", article_name, "  (", sprintf("%.1fs", r$secs), ")")
+  }
+  while (length(running) < ncores && length(pending) > 0) {
+    nm <- pending[1]; pending <- pending[-1]
+    job <- launch_one(nm)
+    log_line("START ", nm, "  (pid ", job$pid, ")")
+    running[[nm]] <- job
+  }
+}
+
+log_line("Parallel article render finished in ", format(Sys.time() - t0))
+
+# Build remaining sections (reference, home, news, sitemap, search, navbar,
+# GitHub-pages metadata). lazy = TRUE makes build_articles() short-circuit on
+# articles whose HTML is newer than their Rmd; clean = FALSE preserves the
+# articles we just rendered.
+log_line("Building non-article sections (reference, news, sitemap, ...)")
+t1 <- Sys.time()
+pkgdown::build_site_github_pages(
+  new_process = FALSE,
+  install     = FALSE,
+  clean       = FALSE,
+  lazy        = TRUE
+)
+log_line("Wrap-up build finished in ", format(Sys.time() - t1))
+log_line("Total pkgdown build time: ", format(Sys.time() - t0))

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -20,6 +20,11 @@ jobs:
       group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      # Parallel article rendering knob, consumed by
+      # .github/scripts/pkgdown-parallel-build.R. Leave blank to use
+      # parallel::detectCores(); set to a positive integer to override
+      # (e.g. "16" to cap memory on a 32-core larger runner).
+      PKGDOWN_WORKERS: ""
     permissions:
       contents: write
     steps:
@@ -34,9 +39,8 @@ jobs:
           extra-packages: any::pkgdown, local::.
           needs: website
 
-      - name: Build site
-        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
-        shell: Rscript {0}
+      - name: Build site (parallel articles)
+        run: Rscript .github/scripts/pkgdown-parallel-build.R
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
## Summary

- Replaces the serial `pkgdown::build_site_github_pages()` call in `.github/workflows/pkgdown.yaml` with a fail-fast parallel scheduler driven by a new `.github/scripts/pkgdown-parallel-build.R`. With 400 vignettes (6 main + 394 drug-specific articles), each doing an `rxode2::rxSolve()` simulation + PKNCA analysis, the serial CI build was ~3 h on `ubuntu-latest`; this should bring it down ~4× on the current 4-vCPU runner and scale further if `runs-on:` is upgraded.
- Adds a single `PKGDOWN_WORKERS` env knob to the workflow's `env:` block — blank ⇒ auto-detect via `parallel::detectCores()`; set to a positive integer (e.g. `"16"`) to cap memory on a larger runner. No new R-package dependencies.
- **Temporary by design**: a parallelization PR is pending upstream in `r-lib/pkgdown`. Once that lands and is released, this workflow reverts to a single `build_site_github_pages(..., workers = ...)` call and `.github/scripts/pkgdown-parallel-build.R` can be deleted.

## How it works

1. `pkgdown::init_site()` lays down `docs/` assets.
2. A hand-rolled scheduler over `parallel::mcparallel` + `mccollect` (Linux fork, copy-on-write so each worker doesn't re-load `nlmixr2`/`rxode2`) keeps `PKGDOWN_WORKERS` forks in flight at a time, polling every 0.5 s.
3. On the **first** vignette failure, `tools::pskill(pid, SIGTERM)` every other in-flight sibling and `stop()` with the failing vignette name — no waiting for slow siblings, no wasted compute.
4. `pkgdown::build_site_github_pages(lazy = TRUE, clean = FALSE)` handles the remaining sections (reference, news, sitemap, search, navbar, GitHub-pages metadata); `lazy = TRUE` makes `build_article()` skip the already-rendered HTML via its mtime check, `clean = FALSE` preserves the just-rendered articles.

Every worker emits timestamped lines so a CI failure traces directly to one vignette:

```
[HH:MM:SS] PKGDOWN_WORKERS = 4  (detectCores() = 4)
[HH:MM:SS] Rendering 400 articles in parallel...
[HH:MM:SS] START articles/Xu_2019_sarilumab  (pid 12345)
[HH:MM:SS] DONE  articles/Xu_2019_sarilumab  (27.3s)
[HH:MM:SS] FAIL  articles/SomeBrokenVignette  -- ...error message...
```

## Test plan

- [ ] CI: open the PR's pkgdown job log and confirm
  - the opening `PKGDOWN_WORKERS = N (detectCores() = M)` line shows
  - interleaved `START`/`DONE` lines name every vignette
  - total runtime is materially shorter than the most recent `main`-branch run
- [ ] Inspect the deployed `gh-pages` preview (post-merge on main): spot-check `docs/articles/Xu_2019_sarilumab.html` and `docs/articles/index.html` look right
- [ ] Failure-tracing rehearsal (optional, manual): temporarily `stop()` in one vignette on a throwaway branch, push, confirm the CI log surfaces the offending name via `grep FAIL` and the step turns red within ~0.5 s of the failure

## Roll-back

Delete `.github/scripts/pkgdown-parallel-build.R` and revert the two yaml edits — one revert commit.