### PR TITLE
[experiment] Try PKGDOWN_WORKERS=6 on 4-vCPU runner

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -24,7 +24,14 @@ jobs:
       # .github/scripts/pkgdown-parallel-build.R. Leave blank to use
       # parallel::detectCores(); set to a positive integer to override
       # (e.g. "16" to cap memory on a 32-core larger runner).
-      PKGDOWN_WORKERS: ""
+      #
+      # EXPERIMENT: oversubscribing 4-vCPU ubuntu-latest with 6 workers to
+      # see whether non-CPU-bound stretches (rxode2 compile I/O, pandoc
+      # subprocess waits, knitr lazy-load reads) make extra workers
+      # productive despite the CPU contention. Compare run time against the
+      # main-branch baseline (PKGDOWN_WORKERS = "" => detectCores() = 4).
+      # Revert to "" if no benefit or if memory pressure shows up.
+      PKGDOWN_WORKERS: "6"
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary

Experiment branch — testing whether bumping `PKGDOWN_WORKERS` from the implicit `parallel::detectCores() = 4` to an explicit `6` on the standard `ubuntu-latest` (4 vCPU) runner produces any speedup, or whether the work is CPU-bound enough that oversubscription is a net loss.

Sole change: `PKGDOWN_WORKERS: ""` → `PKGDOWN_WORKERS: "6"` in `.github/workflows/pkgdown.yaml`'s `env:` block.

## Hypothesis being tested

If the rendering work has meaningful non-CPU stretches (`rxode2` compile I/O, pandoc subprocess waits, lazy-load reads, GC pauses), extra workers can fill those gaps. If it's purely CPU-bound (knitr → pandoc → ODE solving), oversubscribing 4 vCPUs with 6 workers will just thrash.

## Comparison

- Baseline: most recent `pkgdown.yaml` run on `main` after the parallel-build merge.
- Experiment: this branch's `pkgdown.yaml` run.

## Decision rule

- ≥ 10 % faster → bump the default in a follow-up PR, possibly try 8 next.
- Within ±5 % → revert; the 2× speedup we already observe is the ceiling on this runner shape.
- Slower → revert and confirm the analysis (CPU-bound, vCPUs already saturated).

If the experiment doesn't pay off, the real lever for further speedup is `runs-on: ubuntu-latest-16-core` (more vCPUs + RAM), not more workers.