### PR TITLE
Fix pkgdown copy_article_images fixed-path race between workers

### DIFF
--- a/.github/scripts/pkgdown-parallel-build.R
+++ b/.github/scripts/pkgdown-parallel-build.R
@@ -66,6 +66,43 @@ launch_one <- function(name) {
       ns = "rmarkdown"
     ), silent = TRUE)
 
+    # Per-fork pkgdown:::copy_article_images.
+    #
+    # pkgdown:::copy_article_images writes a fixed-name tempfile at
+    #   <path_dir(input_path)>/--find-assets.html
+    # (it has to live next to the Rmd so rmarkdown::find_external_resources
+    # can resolve the HTML's relative paths -- tempdir() wouldn't work),
+    # then calls find_external_resources on it, then unlinks it via
+    # withr::defer. The filename is hard-coded, so two forks rendering
+    # articles in the same source directory (vignettes/articles/) collide
+    # on creation/deletion -- surfaces as
+    #   "[EEXIST] Failed to copy ... to .../vignettes/articles/--find-assets.html"
+    #   "[ENOENT] Failed to remove .../vignettes/articles/--find-assets.html"
+    # Patch the function in this fork's pkgdown namespace copy to use a
+    # pid-scoped filename. Same logic as the rmarkdown patch above.
+    try(assignInNamespace(
+      "copy_article_images",
+      function(built_path, input_path, output_path) {
+        ext_src <- rmarkdown::find_external_resources(input_path)
+        tempfile <- fs::path(
+          fs::path_dir(input_path),
+          paste0("--find-assets-", Sys.getpid(), ".html")
+        )
+        withr::defer(try(fs::file_delete(tempfile), silent = TRUE))
+        fs::file_copy(built_path, tempfile)
+        ext_post <- rmarkdown::find_external_resources(tempfile)
+        ext <- rbind(ext_src, ext_post)
+        ext <- ext[!duplicated(ext$path), ]
+        is_child <- fs::path_has_parent(ext$path, ".")
+        ext_path <- ext$path[(ext$web | ext$explicit) & is_child]
+        src <- fs::path(fs::path_dir(input_path), ext_path)
+        dst <- fs::path(fs::path_dir(output_path), ext_path)
+        fs::dir_create(unique(fs::path_dir(dst)))
+        fs::file_copy(src, dst, overwrite = TRUE)
+      },
+      ns = "pkgdown"
+    ), silent = TRUE)
+
     t_start <- Sys.time()
     tryCatch({
       pkgdown::build_article(name = name, pkg = pkg,


### PR DESCRIPTION
## Summary

Closes the second concurrency race in the parallel pkgdown build, exposed by experiment PR #427 (PKGDOWN_WORKERS=6) and distinct from the rmarkdown `tmpfile_pattern` race fixed in f2a18624. Failure mode:

```
FAIL articles/Bruno_2005_trastuzumab -- [EEXIST] Failed to copy
  '<root>/docs/articles/Bruno_2005_trastuzumab.html'
  to '<root>/vignettes/articles/--find-assets.html': file already exists
```

## Root cause

`pkgdown:::copy_article_images` writes a fixed-name probe file at `<path_dir(input_path)>/--find-assets.html` to feed `rmarkdown::find_external_resources()`, then unlinks it via `withr::defer`. The filename is hard-coded — and has to live next to the Rmd so the HTML's relative paths resolve correctly (`tempdir()` would not work), so two forks rendering articles in the same source directory (here `vignettes/articles/`, where all 394 article Rmds live) collide on creation/deletion of that file.

The 4-worker default in the merged work got lucky; the 6-worker experiment widened the race window enough that it triggered after ~80 vignettes. **The race is theoretically possible at any worker count ≥ 2**; this fix removes it entirely.

## Fix

Each forked worker overrides `pkgdown:::copy_article_images` via `assignInNamespace` with a pid-scoped probe name `--find-assets-<pid>.html`, so concurrent workers in the same source directory don't collide. The mutation is fork-local (post-fork namespace copy) and the only caller of `copy_article_images` (`build_rmarkdown_article`) resolves the function via namespace lookup at runtime, so the override takes effect.

Same technique as the rmarkdown `tmpfile_pattern` patch already in `pkgdown-parallel-build.R`.

## Test plan

- [ ] CI: the pkgdown job on this PR completes successfully with the default PKGDOWN_WORKERS=4 (same as the merged main-branch build, just exercising the new override path).
- [ ] (Optional) On a follow-up throwaway branch, re-run the PKGDOWN_WORKERS=6 experiment to confirm the race no longer reproduces.