### PR TITLE
[experiment] Try PKGDOWN_WORKERS=6 post-races-fixed

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -24,7 +24,13 @@ jobs:
       # .github/scripts/pkgdown-parallel-build.R. Leave blank to use
       # parallel::detectCores(); set to a positive integer to override
       # (e.g. "16" to cap memory on a 32-core larger runner).
-      PKGDOWN_WORKERS: ""
+      #
+      # EXPERIMENT: post-races-fixed re-run with 6 workers (oversubscribes
+      # the 4-vCPU ubuntu-latest runner). Compares end-to-end throughput
+      # against the 4-worker baseline now that both the rmarkdown
+      # tmpfile_pattern race and the pkgdown --find-assets.html race are
+      # fixed on main.
+      PKGDOWN_WORKERS: "6"
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
Re-run of the 6-worker experiment now that both concurrency races are fixed on main:
  - rmarkdown tmpfile_pattern (commit f2a18624 / PR #426)
  - pkgdown --find-assets.html (commit 60521cf4 / PR #428)

Compare end-to-end runtime against the 4-worker baseline of ~71 min total (run 26220347152): 68.6 min parallel render + 2.9 min wrap-up.

Partial 6-worker throughput from the earlier failed run (#427) was ~10.4 articles/min vs 6.13 for 4 workers (~1.7x), but the run died after 50/421 vignettes. This run completes end-to-end and gives a real number.