### PR TITLE
[experiment] Try PKGDOWN_WORKERS=10 post-races-fixed

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -24,7 +24,14 @@ jobs:
       # .github/scripts/pkgdown-parallel-build.R. Leave blank to use
       # parallel::detectCores(); set to a positive integer to override
       # (e.g. "16" to cap memory on a 32-core larger runner).
-      PKGDOWN_WORKERS: ""
+      #
+      # EXPERIMENT: post-races-fixed re-run with 10 workers (2.5x the 4
+      # vCPUs on ubuntu-latest). Memory risk on 16 GB runner -- if it OOMs
+      # we'll learn the ceiling. Compares end-to-end throughput against
+      # the 4-, 6-, and 8-worker runs now that both the rmarkdown
+      # tmpfile_pattern race and the pkgdown --find-assets.html race are
+      # fixed on main.
+      PKGDOWN_WORKERS: "10"
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
Re-run of the workers experiment with 10 workers (2.5x the 4 vCPUs on ubuntu-latest). Both concurrency races now fixed on main:
  - rmarkdown tmpfile_pattern (commit f2a18624 / PR #426)
  - pkgdown --find-assets.html (commit 60521cf4 / PR #428)

Compare end-to-end runtime against the 4-, 6-, and 8-worker runs. Memory budget is the main concern: 10 workers x ~1.5 GB resident = ~15 GB, very close to the 16 GB ubuntu-latest ceiling. If this OOMs we'll have located the practical ceiling on this runner.