### PR TITLE
[experiment] Try PKGDOWN_WORKERS=8 post-races-fixed

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -24,7 +24,12 @@ jobs:
       # .github/scripts/pkgdown-parallel-build.R. Leave blank to use
       # parallel::detectCores(); set to a positive integer to override
       # (e.g. "16" to cap memory on a 32-core larger runner).
-      PKGDOWN_WORKERS: ""
+      #
+      # EXPERIMENT: post-races-fixed re-run with 8 workers (2x the 4 vCPUs
+      # on ubuntu-latest). Compares end-to-end throughput against the
+      # 4-worker baseline now that both the rmarkdown tmpfile_pattern race
+      # and the pkgdown --find-assets.html race are fixed on main.
+      PKGDOWN_WORKERS: "8"
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
Re-run of the workers experiment with 8 workers (2x the 4 vCPUs on ubuntu-latest). Both concurrency races now fixed on main:
  - rmarkdown tmpfile_pattern (commit f2a18624 / PR #426)
  - pkgdown --find-assets.html (commit 60521cf4 / PR #428)

Compare end-to-end runtime against the 4-worker baseline of ~71 min total (run 26220347152) and the experiment-workers-6 branch from the same baseline.

Memory budget on the 16 GB ubuntu-latest runner: 8 workers x ~1.5 GB resident = ~12 GB. Tight but not over the cliff.