### PR TITLE
skill: tighten canonical-naming stop-and-ask rule for params + compartments

### DIFF
--- a/.claude/skills/extract-literature-model/SKILL.md
+++ b/.claude/skills/extract-literature-model/SKILL.md
@@ -212,6 +212,13 @@ Follow `references/compartment-names.md` and `references/parameter-names.md` str
 - Residual error: `propSd`, `addSd`, `expSd`. Multi-output: `propSd_<output>`, `addSd_<output>`, etc.
 - Compartments: `depot`, `central`, `peripheral1`, `peripheral2`, `effect`, `target`, `complex`, `csf`, `isf`, etc. Observation: `Cc`.
 
+**Stop-and-ask before introducing any new canonical parameter or compartment name.** The authoritative lists live in `references/parameter-names.md` (~263 lines covering structural PK params, transform prefixes, IIV/eta names, residual error, covariate-effect parameters, file-level metadata) and `references/compartment-names.md` (~71 lines covering canonical compartments and drug-suffix patterns). Treat these the same way as `inst/references/covariate-columns.md`:
+
+- If the paper's local name is just notation for an existing canonical (e.g., paper uses `Kel`, canonical is `kel`; paper uses `V1/V2/V3`, canonical is `vc/vp/vp2`), translate to canonical and proceed — no sidecar needed for trivial casing or notation differences explicitly covered by the references.
+- If the paper introduces a structural concept that ISN'T in the references at all (e.g., a new clearance component suffix, a new compartment role, a new transform prefix), **sidecar-ask before writing the model file**. Propose the new canonical name with: its role (one sentence), its source-paper local name(s) it would replace, why it isn't an alias of an existing canonical, and any cross-precedent in the existing registered models (cite filenames). Wait for operator approval before committing the model file and the new entry to `parameter-names.md` / `compartment-names.md`.
+- Do NOT pick a "seems obvious" extension silently (e.g., choosing `kel_distinct_<suffix>` when nothing in the registry uses that pattern, or registering `compartment_NN` numbered names instead of role-based names). Even when the new name looks like a natural extension of an existing one, file the sidecar so the operator can decide whether it's actually a new canonical or a synonym of something that already exists.
+- After the operator approves, the new entry is committed alongside the model file in the same PR (same convention as `covariate-columns.md`). Append the new name to the appropriate H2 section in the reference file with a one-paragraph description and a `Founding example: <Author_Year_drug.R>` citation. Do not add a change-log or history section — `git log` is the record.
+
 Covariate columns come from `inst/references/covariate-columns.md`. Before writing any covariate into the file:
 
 - If the canonical name exists, use it and record the source column name in `covariateData[[name]]$source_name`.

--- a/.claude/skills/extract-literature-model/references/compartment-names.md
+++ b/.claude/skills/extract-literature-model/references/compartment-names.md
@@ -2,6 +2,8 @@
 
 Authoritative source: `vignettes/create-model-library.Rmd` and `R/conventions.R`. When in doubt, prefer this file; if this file conflicts with `create-model-library.Rmd`, raise the conflict with the user.
 
+**Stop-and-ask gate (Phase 1 pre-flight + Phase 3 drafting):** If the model you are extracting needs a compartment role that is NOT in this document, file a sidecar BEFORE writing the model file. Propose the canonical role-based name, its source-paper local name(s), and any cross-precedent in existing registered models. Wait for operator approval. Never introduce numbered placeholders like `cmt1` / `compartment_3` / `c1` silently — those are red flags that the role hasn't been canonicalised. Trivial casing differences (the paper's `Central` → canonical `central`) translate silently and do NOT need a sidecar.
+
 ## Compartments
 
 Lower case. Snake case only when combining concepts.

--- a/.claude/skills/extract-literature-model/references/parameter-names.md
+++ b/.claude/skills/extract-literature-model/references/parameter-names.md
@@ -2,6 +2,8 @@
 
 Authoritative source: `vignettes/create-model-library.Rmd` and `R/conventions.R`. Covers structural PK parameters, transform prefixes, fixed parameters, IIV, covariate-effect parameters, endogenous / mechanistic parameters, residual error, and file-level metadata.
 
+**Stop-and-ask gate (Phase 1 pre-flight + Phase 3 drafting):** If the model you are extracting needs a parameter name that is NOT in this document, file a sidecar BEFORE writing the model file. Propose: the canonical name (with `l` prefix if log-transformed), its role (one sentence), source paper's local name(s) it would replace, why it isn't an alias of an existing canonical (e.g., why this isn't just `cl_ss` / `cl_time` / `cl_renal` / `cl_nonren` under a different label), and any cross-precedent in existing registered model files. Wait for operator approval before committing. Trivial notation differences (case-only, NONMEM `V1`/`V2`/`V3` → `vc`/`vp`/`vp2`, paper's `Kel` → canonical `kel`) translate silently and do NOT need a sidecar.
+
 ## Structural PK parameters
 
 Log-transform any parameter that must be positive. Prefix `l` (lower-case L).

--- a/.claude/skills/extract-literature-model/references/pre-flight-checklist.md
+++ b/.claude/skills/extract-literature-model/references/pre-flight-checklist.md
@@ -17,7 +17,8 @@ Read this once at dispatch, before starting the 6-phase workflow. Every trigger 
 - **Covariate encoding ambiguous.** Reference category, units, transformation not fully specified.
 - **Source column name not in `inst/references/covariate-columns.md`.** Propose a new entry and confirm before adding.
 - **Source column is an alias of an existing canonical name with value inversion or reference-category flip.** Confirm sign and reference-category implications.
-- **Parameter name deviates from nlmixr2lib standard.** Propose canonical name and confirm.
+- **Parameter name not in `references/parameter-names.md`.** Trivial notation differences (case, NONMEM `V1`/`V2`/`V3` → `vc`/`vp`/`vp2`, paper's `Kel` → canonical `kel`, etc.) translate silently. Any *new structural concept* (new clearance-component suffix like `cl_renal_intermittent`, new transform prefix, new endogenous-system parameter family, etc.) requires a sidecar BEFORE drafting the model. Propose: canonical name, role (one sentence), source paper's local name(s) it replaces, and any cross-precedent in existing registered models. Do not invent a "seems obvious" name silently.
+- **Compartment name not in `references/compartment-names.md`.** Trivial casing differences translate silently. Any *new compartment role* (new endogenous-state compartment, new drug-suffix pattern beyond the registered list, new effect-compartment variant) requires a sidecar BEFORE drafting. Never introduce numbered `cmt1` / `cmt2` / `compartment_3` placeholders silently — propose a canonical role-based name and confirm. Same applies to drug-specific suffix patterns: don't extend `_tfvdp` → `_newdrugX` without operator sign-off on the suffix.
 
 ## Worktree state (Phase 2)
 


### PR DESCRIPTION
## Summary

Extends the existing "sidecar-ask before adding a new canonical entry"
rule (which previously covered only `inst/references/covariate-columns.md`)
to also cover `parameter-names.md` and `compartment-names.md`. Closes
a gap where dispatched extraction agents would invent new canonical
parameter/compartment names silently (numbered placeholders like
`cmt1`/`cmt2`, drug-suffix extensions, or "seems obvious" extensions
to existing clearance/volume suffixes) without operator sign-off.

## Changes

- **`SKILL.md`** — new block after the canonical-name lists explicitly
  requiring a sidecar BEFORE writing the model file when introducing
  any name not in the references. Trivial notation (case-only, NONMEM
  `V1`/`V2`/`V3` → `vc`/`vp`/`vp2`, `Kel` → `kel`) still translates
  silently; only NEW structural concepts trigger the sidecar.
- **`references/pre-flight-checklist.md`** — replaced the single vague
  "Parameter name deviates from nlmixr2lib standard" trigger with two
  explicit triggers (parameter + compartment) that name the proposal
  fields and call out red-flag patterns.
- **`references/parameter-names.md`** + **`references/compartment-names.md`** —
  added a "Stop-and-ask gate" preamble at the top of each file so the
  rule is visible at the point of consultation.

## Test plan

- [ ] Next dispatched extraction that hits a non-canonical name fires
      a sidecar instead of silently extending the registry.
- [ ] Trivial-rename cases (e.g., `V1` → `vc`) proceed without sidecar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)