### PR TITLE
Skill: wire author-name CamelCase normalization as hard default in extract-literature-model

### DIFF
--- a/.claude/skills/extract-literature-model/SKILL.md
+++ b/.claude/skills/extract-literature-model/SKILL.md
@@ -108,6 +108,37 @@ Whole-body PBPK, semi-mechanistic PBPK, quantitative systems pharmacology (QSP),
   - The model is suitable for simulating study-level summary outcomes (per-arm mean response) but NOT individual-level concentrations.
   - Document the simulation scope prominently in `description` and in the vignette's Assumptions and deviations section.
 
+### Step 3b — Target file naming (author-surname normalization)
+
+Apply the normalization rule below **silently — no sidecar** when choosing the target filename, function name, vignette basename, and worktree branch name. CamelCase across separators is the **default**; do not stop to ask the operator whether to use `Lohy_Das_...` or `LohyDas_...` (the convention is `LohyDas_...`), nor whether to write `Ait-Oudhia_...` or `AitOudhia_...` (the convention is `AitOudhia_...`).
+
+Transformations applied to the first-author surname BEFORE choosing the filename:
+
+| Source author surname | File basename stem | Notes |
+|---|---|---|
+| `Lohy Das`     | `LohyDas`       | Drop spaces, CamelCase across the drop |
+| `Ait-Oudhia`   | `AitOudhia`     | Drop hyphens, CamelCase across the drop |
+| `O'Brien`      | `OBrien`        | Drop apostrophes, CamelCase across the drop |
+| `Câmara`       | `Camara`        | Transliterate accents |
+| `Müller`       | `Muller`        | Transliterate accents |
+| `Łukasz`       | `Lukasz`        | Transliterate accented Latin extensions |
+| `van Rongen`   | `vanRongen`     | Lowercase particle preserved when author publishes that way |
+| `de Winter`    | `deWinter`      | Lowercase particle preserved |
+| `Von Bonin`    | `VonBonin`      | Capitalised particle preserved when author publishes that way |
+| `Mac Donald`   | `MacDonald`     | Drop space, CamelCase |
+| `Câmara De Souza` | `CamaraDeSouza` | Combination: transliterate accent AND drop space AND preserve published particle case |
+
+Rules:
+
+- **Hyphens, spaces, apostrophes**: drop, CamelCase across the drop.
+- **Accents and other diacritics**: transliterate to plain ASCII (`Câmara` → `Camara`, `Müller` → `Muller`, `Łukasz` → `Lukasz`). The filename must be ASCII-only so the function name (= filename minus `.R`) is a valid R identifier without quoting.
+- **Lowercase particles** ("van", "de", "von", "ten", "le", "du", "la", "del", "el", etc.): preserve the lowercase first letter when the author publishes that way (`van Rongen` → `vanRongen`, `de Kock` → `deKock`).
+- **Capitalised particles**: follow the published author form (`Von Bonin` → `VonBonin`, `De Kock` → `DeKock`).
+
+The same normalised stem is used for: the model filename (`<Stem>_<Year>_<drug>.R`), the function name (which `buildModelDb()` enforces must equal the filename minus `.R`), the `vignette <- "..."` field, the vignette basename under `vignettes/articles/`, the worktree branch name in Phase 2, and the PR title.
+
+Year-letter collision suffixes (`Author_2019a_drug.R`, `Author_2019b_drug.R`) for genuinely-same-author/year/drug pairs are handled separately — see Phase 3 and `references/parameter-names.md` § "File naming".
+
 4. **Prefer trimmed markdown when available.** The preprocessor at `mab_human_consensus/tracking/preprocess_papers.py` writes a `<stem>_trimmed.md` next to each source file (PMC XML, PDF, DOCX, XLSX) containing only the sections the extraction actually needs: Title + Abstract + Methods + Results + Tables + Figure captions. The Introduction, Discussion, Conclusions, References, Acknowledgments, and publisher boilerplate are stripped. If `PMID_<pmid>_pmc_trimmed.md` (or `PMID_<pmid>_trimmed.md` for a PDF, or `<stem>_trimmed.md` for a supplement) exists, read it **instead of** the raw `.xml` / `.pdf` / `.docx` — it's typically 40-95% smaller with no loss of extractable content. Full-text sanity check on the trimmed file: ~15 KB+ (full-text trim) vs < 3 KB (abstract-only trim). Fall back to the raw source only if the `_trimmed.md` doesn't exist, the trim appears to have lost a specific piece of information you need (rare — only when the paper is structurally unusual), or you explicitly need the discarded sections (e.g., to quote a Discussion claim in the vignette narrative).
 
 5. **Verify the source contains full text, not just the abstract.** Wiley / BJCP and some other publishers serve PMC XML containing only front matter + abstract. Before reading for model structure, run a quick sanity check (against the trimmed file if present, otherwise the raw source):
@@ -174,6 +205,8 @@ git fetch origin
 git checkout -b <firstauthor>-<year>-<drug> origin/main
 ```
 
+`<firstauthor>` here is the **normalised** surname stem from Phase 1 Step 3b (CamelCase across hyphens/spaces/apostrophes, accents transliterated, lowercase particles preserved per the published form). Use the same stem the model file and vignette use, just in the lowercase form typical for branch names (e.g. `lohydas-2018-mefloquine`, `vanrongen-2017-midazolam`).
+
 Local `main` may be stale. The regenerated `data/modeldb.rda` / `inst/modeldb.qs2` must reflect current origin/main or they will clobber models added upstream. Never push directly to `main`; always open a PR.
 
 (When this skill runs as a task under `claude_runner`, the runner's preamble
@@ -195,7 +228,7 @@ If the worktree's branch was **already committed and pushed in a prior run** (i.
 
 ## Phase 3 — Model file
 
-File path: `inst/modeldb/<category>/<FirstAuthor>_<Year>_<drug>.R`.
+File path: `inst/modeldb/<category>/<FirstAuthor>_<Year>_<drug>.R`. `<FirstAuthor>` is the **normalised** surname stem — apply the Phase 1 Step 3b table (hyphens/spaces/apostrophes dropped with CamelCase, accents transliterated, lowercase particles preserved per the published form). Do not stop to ask the operator to confirm the normalised form; the policy is a hard default.
 
 If the chosen `<FirstAuthor>_<Year>_<drug>` name collides with an existing file (rare — e.g., two same-author/year/drug entries with different scenarios), append a lowercase letter to the year: `Author_2019a_drug.R`, `Author_2019b_drug.R`. Use the same year-letter for both files in the pair so the chronological ordering is preserved.
 

--- a/.claude/skills/extract-literature-model/references/parameter-names.md
+++ b/.claude/skills/extract-literature-model/references/parameter-names.md
@@ -414,5 +414,35 @@ After this metadata block come `ini()` and `model()`.
 
 - Path: `inst/modeldb/<category>/<FirstAuthor>_<Year>_<drug>.R`.
 - Function name **must** equal the filename minus `.R`. Enforced by `buildModelDb()`.
-- Use the paper's first-author surname (no accents or spaces), four-digit year, and drug INN in lowercase.
-- **Year-letter collision suffix.** When two extractions resolve to the same `<FirstAuthor>_<Year>_<drug>` name (e.g., two same-author/year/drug entries with different scenarios), append a lowercase letter to the year — `Author_2019a_drug.R`, `Author_2019b_drug.R`. Allocate letters in chronological model-development order when known. Never overwrite an existing file silently.
+- `<FirstAuthor>` is the paper's first-author surname, normalised to plain ASCII CamelCase per the rules below. `<Year>` is the four-digit publication year. `<drug>` is the drug INN in lowercase (with a species or mechanism-class suffix when applicable — see SKILL.md Phase 1 steps 3 and 3a).
+
+### Author-surname normalization (hard default — no sidecar)
+
+CamelCase across separators is the **default behaviour**. Apply silently — do NOT raise a stop-and-ask sidecar to confirm the filename form.
+
+| Source author surname | File basename stem | Notes |
+|---|---|---|
+| `Lohy Das`     | `LohyDas`       | Drop spaces, CamelCase across the drop |
+| `Ait-Oudhia`   | `AitOudhia`     | Drop hyphens, CamelCase across the drop |
+| `O'Brien`      | `OBrien`        | Drop apostrophes, CamelCase across the drop |
+| `Câmara`       | `Camara`        | Transliterate accents |
+| `Müller`       | `Muller`        | Transliterate accents |
+| `Łukasz`       | `Lukasz`        | Transliterate accented Latin extensions |
+| `van Rongen`   | `vanRongen`     | Lowercase particle preserved when author publishes that way |
+| `de Winter`    | `deWinter`      | Lowercase particle preserved |
+| `Von Bonin`    | `VonBonin`      | Capitalised particle preserved when author publishes that way |
+| `Mac Donald`   | `MacDonald`     | Drop space, CamelCase |
+| `Câmara De Souza` | `CamaraDeSouza` | Combination: transliterate accent AND drop space AND preserve published particle case |
+
+Rules:
+
+- **Hyphens, spaces, apostrophes**: drop, CamelCase across the drop.
+- **Accents and other diacritics**: transliterate to plain ASCII. The filename must be ASCII-only so the function name (= filename minus `.R`) is a valid R identifier without quoting.
+- **Lowercase particles** ("van", "de", "von", "ten", "le", "du", "la", "del", "el", etc.): preserve the lowercase first letter when the author publishes that way (`van Rongen` → `vanRongen`, `de Kock` → `deKock`).
+- **Capitalised particles**: follow the published author form (`Von Bonin` → `VonBonin`, `De Kock` → `DeKock`).
+
+Precedents in `inst/modeldb/specificDrugs/`: `AitOudhia_2012_canakinumab.R`. The same normalised stem is used for the vignette basename, the `vignette <- "..."` field, the worktree branch name in Phase 2, and the PR title.
+
+### Year-letter collision suffix
+
+When two extractions resolve to the same `<FirstAuthor>_<Year>_<drug>` name (e.g., two same-author/year/drug entries with different scenarios), append a lowercase letter to the year — `Author_2019a_drug.R`, `Author_2019b_drug.R`. Allocate letters in chronological model-development order when known. Never overwrite an existing file silently.

--- a/.claude/skills/extract-literature-model/references/pre-flight-checklist.md
+++ b/.claude/skills/extract-literature-model/references/pre-flight-checklist.md
@@ -20,6 +20,24 @@ Only sidecar when one of these two narrow conditions holds (these are the only m
 
 See `references/replicate-author-structure.md` for worked examples (de Vries Schultink 2018 → 2 `.R` files + 1 vignette; Yoshida 2021 ipatasertib → 1 `.R` file + 1 vignette).
 
+## Standing default — author-surname normalization
+
+**CamelCase across hyphens, spaces, apostrophes, and accents is the default — do NOT sidecar to confirm the filename form.** When the first author's surname contains a hyphen, space, apostrophe, or accent, apply the normalization rules from SKILL.md Phase 1 Step 3b silently when choosing the filename, function name, vignette basename, branch name, and PR title. There is no stop-and-ask trigger for this choice.
+
+Quick reference:
+
+- `Lohy Das` → `LohyDas` (drop spaces, CamelCase across the drop)
+- `Ait-Oudhia` → `AitOudhia` (drop hyphens, CamelCase across the drop)
+- `O'Brien` → `OBrien` (drop apostrophes, CamelCase across the drop)
+- `Câmara` → `Camara` (transliterate accents)
+- `Müller` → `Muller` (transliterate accents)
+- `van Rongen` → `vanRongen` (lowercase particle preserved per published form)
+- `Von Bonin` → `VonBonin` (capitalised particle preserved per published form)
+
+See SKILL.md Phase 1 Step 3b for the full table and rules, and `references/parameter-names.md` § "File naming" for the canonical statement.
+
+If a *different* naming ambiguity arises (e.g., genuinely ambiguous corporate-author convention, or a transliteration that has multiple accepted forms in the literature), that is not covered by this default — sidecar in the normal format and let the operator decide.
+
 ## Source acquisition (Phase 1)
 
 - **Lead PDF missing and OA acquisition failed.** All 5 ladder sources tried, no valid PDF whose title matches the task expectation. Sidecar with the structured attempts log from `scripts/acquire-paper.R` (`acquire-log.json`).


### PR DESCRIPTION
## Summary

- Make CamelCase across hyphens, spaces, apostrophes, and accents the **hard default**
  for the first-author surname stem used in model filenames, function names, vignette
  basenames, branch names, and PR titles. Operators no longer see a stop-and-ask
  sidecar for `Lohy_Das` vs `LohyDas`, `Ait-Oudhia` vs `AitOudhia`, `Schütte` vs
  `Schutte`, `Câmara` vs `Camara`, `van Rongen` vs `VanRongen`, etc.
- Adds an authoritative transformation table in three load-bearing places (SKILL.md
  Phase 1 Step 3b, pre-flight-checklist.md as a "Standing default", and
  parameter-names.md § File naming) so a reader entering at any of those surfaces
  sees the same rule.
- Particle-case rule: preserve the published form. `van Rongen` → `vanRongen`,
  `Von Bonin` → `VonBonin`. Filename must be plain ASCII so the function name is a
  valid R identifier without quoting.

## What changed

- `.claude/skills/extract-literature-model/SKILL.md` — new Phase 1 Step 3b, plus
  Phase 2/Phase 3 cross-references to the normalized stem.
- `.claude/skills/extract-literature-model/references/pre-flight-checklist.md` — new
  "Standing default — author-surname normalization" section, parallel to the
  existing "replicate the author's modeling structure" default.
- `.claude/skills/extract-literature-model/references/parameter-names.md` —
  authoritative table in § "File naming"; existing year-letter collision rule preserved.

## Test plan

- [ ] Skim each of the three updated files for internal consistency (same table,
      same particle rule).
- [ ] Spot-check by mentally walking a Lohy Das / Ait-Oudhia / van Rongen / Schütte
      extraction through Phase 1 → Phase 3 and confirming no sidecar prompt
      remains.
- [ ] Confirm no existing model file in `inst/modeldb/specificDrugs/` is in
      conflict (e.g., `AitOudhia_2012_canakinumab.R` is the named precedent).

## Coordination note

A sibling skill update — "Wire 'build as authors built' policy into
extract-literature-model skill" (PR #442, already merged to main) — touched the same
SKILL.md and the same pre-flight-checklist.md for a different policy. This PR is
based on `origin/main` AFTER that merge landed, so there is no conflict. The
"Standing default — author-surname normalization" section is structured as a
parallel sibling to the existing "Standing default — replicate the author's
modeling structure" section, matching the pattern that merge established.

🤖 Generated with [Claude Code](https://claude.com/claude-code)