### PR TITLE
Shrink virtual cohorts in 5 slow vignettes to build under 5 minutes

### DIFF
--- a/vignettes/articles/Billard_1995_methoxsalen.Rmd
+++ b/vignettes/articles/Billard_1995_methoxsalen.Rmd
@@ -124,7 +124,7 @@ make_cohort <- function(spec, n, id_offset = 0L) {
   dplyr::bind_rows(lapply(seq_len(n), per_id))
 }
 
-n_per_cohort <- 200L
+n_per_cohort <- 80L   # virtual subjects per dose group (VPC-band cohort)
 
 events <- dplyr::bind_rows(
   make_cohort(cohort_specs[1, ], n_per_cohort, id_offset =   0L),
@@ -208,7 +208,7 @@ sim_plasma_vpc |>
   ggplot2::labs(x = "Time from start of infusion (min)",
                 y = "Plasma 8-MOP (ng/mL, log scale)",
                 title = "Plasma VPC: 5th / 50th / 95th percentiles",
-                caption = "Includes published IIV from Billard 1995 Table 5 (plasma fit). 200 simulated subjects per dose group.")
+                caption = "Includes published IIV from Billard 1995 Table 5 (plasma fit). 80 simulated subjects per dose group.")
 ```
 
 # PKNCA validation against Tables 3 and 4

--- a/vignettes/articles/Frymoyer_2013_mycophenolic_acid.Rmd
+++ b/vignettes/articles/Frymoyer_2013_mycophenolic_acid.Rmd
@@ -154,7 +154,7 @@ make_cohort <- function(n,
   do.call(rbind, lapply(seq_len(nrow(cov)), function(i) build_one(cov[i, ])))
 }
 
-n_per <- 200L
+n_per <- 80L   # virtual subjects per route (oral / iv) for the simulation cohort
 events <- dplyr::bind_rows(
   make_cohort(n_per, route = "oral", mmf_mg = 1000, ii_h = 12,
               id_offset = 0L),

--- a/vignettes/articles/Iida_2008_nicorandil.Rmd
+++ b/vignettes/articles/Iida_2008_nicorandil.Rmd
@@ -103,7 +103,7 @@ bolus (for comparison with paper Figure 2 left upper panel).
 ```{r cohort}
 set.seed(20260613L)
 
-n_ahf <- 200L
+n_ahf <- 80L       # virtual subjects per regimen arm (VPC-band cohort)
 typical_wt <- 60   # kg, AHF cohort mean (Table 1)
 
 make_ahf_cohort <- function(n, regimen, id_offset = 0L) {
@@ -219,7 +219,7 @@ Iida 2008 Figure 2 left upper panel shows individual plasma nicorandil
 concentration vs time after IV bolus doses of 4, 8, 12, and 18 mg in AHF
 patients. Concentrations decline rapidly within 1-2 h. Below we replicate
 the 12 mg bolus arm as a population-VPC band (median and 5th-95th
-percentile of the 200-subject virtual cohort) plus the typical-value
+percentile of the 80-subject virtual cohort) plus the typical-value
 trajectory.
 
 ```{r figure-2, fig.width = 7, fig.height = 4}

--- a/vignettes/articles/Karlsson_2009_voriconazole.Rmd
+++ b/vignettes/articles/Karlsson_2009_voriconazole.Rmd
@@ -113,15 +113,15 @@ knitr::kable(distribution_check, digits = 2,
 
 The original observed concentration data are not publicly available. The
 simulations below use a virtual cohort whose covariate distributions approximate
-the Karlsson 2009 study population: 82 subjects, body weight 10.8-54.9 kg
-(distribution skewed toward smaller children), ALT log-normally distributed
-around the published mean, and CYP2C19 metabolizer distribution matched to the
-70.7 / 25.6 / 3.7 percent EM / HEM / PM split.
+the Karlsson 2009 study population (82 patients): a 48-subject virtual cohort
+with body weight 10.8-54.9 kg (distribution skewed toward smaller children),
+ALT log-normally distributed around the published mean, and CYP2C19 metabolizer
+distribution matched to the 70.7 / 25.6 / 3.7 percent EM / HEM / PM split.
 
 ```{r cohort}
 set.seed(20090301)
 
-n_subj <- 82L
+n_subj <- 48L   # virtual cohort (trial enrolled 82); sized for a smooth VPC/NCA-by-stratum
 
 # Weight: log-normal centered at the mean 22.8 kg, range 10.8-54.9 kg.
 wt_log_sd <- 0.45  # picked to span the observed range with 95 percent coverage
@@ -134,8 +134,8 @@ alt_log_sd <- 0.7
 alts <- 26.5 * exp(rnorm(n_subj, mean = 0, sd = alt_log_sd))
 alts <- pmin(pmax(alts, 7), 242)
 
-# CYP2C19 phenotype: 58 EM / 21 HEM / 3 PM.
-cyp_pheno <- sample(rep(c("EM", "HEM", "PM"), c(58L, 21L, 3L)))
+# CYP2C19 phenotype: 34 EM / 12 HEM / 2 PM (matches trial 70.7 / 25.6 / 3.7 percent at n = 48).
+cyp_pheno <- sample(rep(c("EM", "HEM", "PM"), c(34L, 12L, 2L)))
 cyp2c19_im <- as.integer(cyp_pheno == "HEM")
 cyp2c19_pm <- as.integer(cyp_pheno == "PM")
 
@@ -324,7 +324,7 @@ nca_summary <- nca_tbl |>
   dplyr::arrange(PPTESTCD, cyp2c19_pheno)
 
 knitr::kable(nca_summary, digits = 2,
-             caption = "Day-14 steady-state NCA summary by CYP2C19 group for 7 mg/kg BID i.v. (virtual cohort, n=82).")
+             caption = "Day-14 steady-state NCA summary by CYP2C19 group for 7 mg/kg BID i.v. (virtual cohort, n=48).")
 ```
 
 ## Comparison against published expectations

--- a/vignettes/articles/Wu_2014_FEV1_asthma.Rmd
+++ b/vignettes/articles/Wu_2014_FEV1_asthma.Rmd
@@ -114,7 +114,7 @@ reference (`CONMED_BUDESONIDE = 0`).
 ```{r cohort}
 set.seed(20260612)
 
-n_subj <- 400L
+n_subj <- 200L   # virtual subjects for the covariate-distribution summary + height-for-age smoother
 
 cohort <- tibble::tibble(
   id  = seq_len(n_subj),
@@ -258,7 +258,7 @@ envelope at each age is a marginal distribution over IIV draws, matching
 the cohort-aggregate interpretation of Figure 2).
 
 ```{r figure-2-vpc, fig.cap = "Typical-value FEV1 median and 5th / 95th percentile envelope vs age, by treatment arm. Replicates the VPC envelope of Figure 2 of Wu 2014 to first order."}
-n_draws <- 250L
+n_draws <- 100L   # IIV draws per age grid point per arm (VPC envelope)
 
 events_vpc <- tidyr::expand_grid(
   draw = seq_len(n_draws),
@@ -307,7 +307,7 @@ ggplot(envelope, aes(x = time, fill = arm, colour = arm)) +
     colour  = "Treatment arm",
     fill    = "Treatment arm",
     title   = "FEV1 median + 5th / 95th percentile envelope vs age",
-    caption = "Median trajectory + 5th / 95th percentile envelope from n = 250 IIV draws per age and arm."
+    caption = "Median trajectory + 5th / 95th percentile envelope from n = 100 IIV draws per age and arm."
   ) +
   theme_bw()
 ```


### PR DESCRIPTION
The pkgdown site build ([run 27767090009](https://github.com/nlmixr2/nlmixr2lib/actions/runs/27767090009)) renders 883 vignettes. Parsing the per-article timings from the parallel-build log showed one article over the 5-minute target and four sitting just under it. In every case the cost is an oversized **virtual simulation cohort** drawn only to draw VPC bands / NCA summaries — not the model itself. This PR reduces those cohort sizes. No models, parameters, or structural conclusions change.

| Vignette | Knob | Before → After |
|---|---|---|
| `Iida_2008_nicorandil` | `n_ahf` (per regimen arm) | 200 → 80 |
| `Billard_1995_methoxsalen` | `n_per_cohort` (per dose group) | 200 → 80 |
| `Wu_2014_FEV1_asthma` | `n_subj`; `n_draws` (VPC envelope) | 400 → 200; 250 → 100 |
| `Frymoyer_2013_mycophenolic_acid` | `n_per` (per route) | 200 → 80 |
| `Karlsson_2009_voriconazole` | `n_subj` (CYP2C19 counts 34/12/2) | 82 → 48 |

VPC 5–95% bands stay smooth at these sizes. For Karlsson the CYP2C19 proportions (70.7 / 25.6 / 3.7%) are preserved and the published trial N (82) is retained in the prose and the cohort-vs-paper comparison column.

**Verification** — cold old-vs-new local render (each in a fresh subprocess so rxode2 model-compile cost isn't shared), then projected onto the measured CI baselines via `ratio × CI_old` (the ratio cancels machine speed and CI parallel-contention):

| Vignette | local old → new | projected CI |
|---|---|---|
| Iida | 204.4 → 57.1 s | 382 → ~107 s |
| Billard | 169.9 → 70.7 s | 300 → ~125 s |
| Wu | 92.8 → 27.3 s | 291 → ~86 s |
| Frymoyer | 67.9 → 29.7 s | 290 → ~127 s |
| Karlsson | 112.3 → 59.5 s | 289 → ~153 s |

All five now well under 300 s; all figures/tables still render (0 errors). Captions and cohort-description prose updated to match the new sizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)