### PR TITLE
extract skill: token-efficient log filter + canonical lookup (Phase 0)

### DIFF
--- a/.claude/skills/extract-literature-model/SKILL.md
+++ b/.claude/skills/extract-literature-model/SKILL.md
@@ -199,7 +199,14 @@ Follow `references/compartment-names.md` and `references/parameter-names.md` str
 - Do NOT pick a "seems obvious" extension silently (e.g., choosing `kel_distinct_<suffix>` when nothing in the registry uses that pattern, or registering `compartment_NN` numbered names instead of role-based names). Even when the new name looks like a natural extension of an existing one, file the sidecar so the operator can decide whether it's actually a new canonical or a synonym of something that already exists.
 - After the operator approves, the new entry is committed alongside the model file in the same PR (same convention as `covariate-columns.md`). Append the new name to the appropriate H2 section in the reference file with a one-paragraph description and a `Founding example: <Author_Year_drug.R>` citation. Do not add a change-log or history section — `git log` is the record.
 
-Covariate columns come from `inst/references/covariate-columns.md`. Before writing any covariate into the file:
+Covariate columns come from `inst/references/covariate-columns.md` (~1.1 MB ≈ 284k tokens — **do NOT `Read` it whole; one whole-file read can exhaust the task's token budget**). To check a canonical name, run the lookup tool, which returns only the matching register entries (a few KB):
+
+```bash
+Rscript --vanilla .claude/skills/extract-literature-model/scripts/lookup-canonical.R WT covariate
+# kinds: covariate | parameter | compartment   (parameter/compartment search their references/*.md)
+```
+
+It prints the matching entry, or a "this is a NEW canonical → stop-and-ask" hint when there is no match. Use it for parameter and compartment names too instead of reading those reference files in full. Before writing any covariate into the file:
 
 - If the canonical name exists, use it and record the source column name in `covariateData[[name]]$source_name`.
 - If the source name is an alias of an existing canonical name (e.g., source uses `SEXM`, canonical is `SEXF`), use the canonical name, note the required value transformation (`SEXF = 1 - SEXM`), and **ask the user to confirm the effect-coefficient sign and reference-category implications** before committing.
@@ -293,7 +300,11 @@ For papers that describe endogenous turnover, steady-state-balance, or mechanist
    HTML="vignettes/articles/${STEM}.html"
    BYTES=$(stat -c%s "$HTML" 2>/dev/null || echo MISSING)
    echo "RENDER_GATE stem=$STEM exit=$RC html_bytes=$BYTES"
+   Rscript --vanilla .claude/skills/extract-literature-model/scripts/filter-r-log.R "$LOG" > "${LOG%.log}.filt.log" 2>/dev/null
+   echo "RENDER_GATE_FILTERED=${LOG%.log}.filt.log"
    ```
+
+   **Read the filtered log (`${LOG%.log}.filt.log`), not the raw `$LOG`.** It compacts the render log to its errors/warnings/traceback (the raw log is often hundreds–thousands of lines that get re-read every turn of the fix loop). Open the raw `$LOG` only if the filtered view is insufficient.
 
    Interpret the printed `RENDER_GATE` line:
 
@@ -333,7 +344,14 @@ For papers that describe endogenous turnover, steady-state-balance, or mechanist
 
    See `references/verification-checklist.md` for the full ASCII substitution table when anything matches.
 
-6. Run `devtools::check()`. Vignettes must build cleanly.
+6. Run `devtools::check()`. Vignettes must build cleanly. Capture the output and read the **filtered** view — a full check log is ~1,000–5,000 lines and gets re-read every turn:
+
+   ```bash
+   Rscript --vanilla -e 'devtools::check(args = "--no-build-vignettes", error_on = "never")' 2>&1 | tee /tmp/check.log
+   Rscript --vanilla .claude/skills/extract-literature-model/scripts/filter-r-log.R /tmp/check.log
+   ```
+
+   Read the filtered errors/warnings/NOTEs; open `/tmp/check.log` only if the summary is insufficient.
 
    A C-level segfault (`*** caught segfault ***`) during `check()` or vignette rendering is a red flag — it indicates a broken R / rxode2 / nlmixr2 install in the environment, not a model-file problem. Stop, sidecar-ask the operator to investigate and fix the environment, and do not work around it with `--no-build-vignettes` or similar flags.
 7. Add a short, single-line `NEWS.md` entry under the current development

--- a/.claude/skills/extract-literature-model/scripts/filter-r-log.R
+++ b/.claude/skills/extract-literature-model/scripts/filter-r-log.R
@@ -1,0 +1,71 @@
+#!/usr/bin/env Rscript
+# filter-r-log.R <logfile>
+#
+# Compact a verbose R log (devtools::check / R CMD check / vignette render)
+# down to the lines that matter: the status summary, ERROR / WARNING / NOTE
+# blocks (with their indented detail), render tracebacks, and the final result
+# line. Drops the hundreds of "* checking ... OK" and pandoc-verbose lines so
+# the agent reads tens of lines instead of thousands.
+#
+# Token economics: a full `devtools::check()` log is commonly 1,000-5,000 lines;
+# the agent re-reads it (cached) every turn of the build-fix loop. Reading the
+# filtered view instead is the single cheapest per-task token win. Open the raw
+# log ONLY if this summary is insufficient.
+#
+# Usage:  Rscript filter-r-log.R /tmp/vignette-render-Foo_2024_drug.log
+
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) < 1L) {
+  cat("usage: filter-r-log.R <logfile>\n"); quit(status = 2L)
+}
+f <- args[[1L]]
+if (!file.exists(f)) {
+  cat(sprintf("filter-r-log: no such file: %s\n", f)); quit(status = 2L)
+}
+
+lines <- readLines(f, warn = FALSE)
+n <- length(lines)
+if (n == 0L) { cat("(empty log)\n"); quit(status = 0L) }
+
+# Lines worth keeping. "* checking ... OK" is pure noise and dropped below.
+keep_re <- paste0(
+  "(ERROR|WARNING|NOTE|Error|Warning|Quitting|Status:|FAIL|failed|Failed|",
+  "cannot|unable|Execution halted|halt|exit=|html_bytes|RENDER_GATE|",
+  "Requesting an AUC|traceback|Backtrace|\\bin chunk\\b|",
+  "\\* checking .*\\.\\.\\. (WARNING|ERROR|NOTE))"
+)
+ok_noise_re <- "^\\* checking .*\\.\\.\\. OK\\s*$"
+
+keep <- logical(n)
+context_after <- 6L  # keep the indented detail block under a status hit
+i <- 1L
+while (i <= n) {
+  ln <- lines[[i]]
+  if (!grepl(ok_noise_re, ln) && grepl(keep_re, ln, perl = TRUE)) {
+    keep[[i]] <- TRUE
+    j <- i + 1L; c <- 0L
+    while (j <= n && c < context_after &&
+           (grepl("^\\s", lines[[j]]) ||
+            nchar(trimws(lines[[j]])) == 0L ||
+            grepl(keep_re, lines[[j]], perl = TRUE))) {
+      keep[[j]] <- TRUE; j <- j + 1L; c <- c + 1L
+    }
+  }
+  i <- i + 1L
+}
+# Always keep the final lines (overall status / pandoc result / RENDER_GATE).
+keep[seq.int(max(1L, n - 7L), n)] <- TRUE
+
+sel <- which(keep)
+out <- lines[sel]
+
+cap <- 250L
+if (length(out) > cap) {
+  out <- c(out[seq_len(cap)],
+           sprintf("...[filtered view truncated at %d of %d kept lines; raw log: %s]",
+                   cap, length(out), f))
+}
+
+cat(sprintf("# filter-r-log: %d raw lines -> %d kept (raw log: %s)\n", n, length(sel), f))
+cat(out, sep = "\n")
+cat("\n")

--- a/.claude/skills/extract-literature-model/scripts/lookup-canonical.R
+++ b/.claude/skills/extract-literature-model/scripts/lookup-canonical.R
@@ -1,0 +1,89 @@
+#!/usr/bin/env Rscript
+# lookup-canonical.R <term> [covariate|parameter|compartment]
+#
+# Return the canonical-register entries matching <term> (matched against the
+# heading name, source aliases, and description) WITHOUT loading the whole
+# register into the agent's context.
+#
+# Token economics: inst/references/covariate-columns.md is ~1.1 MB (~284k
+# tokens). A single accidental whole-file Read blows the per-task budget.
+# This script reads the register on disk and returns only the matching H2/H3
+# entries (a few lines), so the 284k-token file never enters context. Use it
+# for every canonical name check (covariate / parameter / compartment).
+#
+# Run from the repo root (the agent's worktree CWD). Exit 0 = match(es) printed;
+# exit 0 with a "no match" note = likely a NEW canonical (follow the
+# stop-and-ask rule in SKILL.md).
+#
+# Usage:  Rscript .../scripts/lookup-canonical.R WT covariate
+#         Rscript .../scripts/lookup-canonical.R vc parameter
+
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) < 1L) {
+  cat("usage: lookup-canonical.R <term> [covariate|parameter|compartment]\n")
+  quit(status = 2L)
+}
+term <- args[[1L]]
+kind <- if (length(args) >= 2L) tolower(args[[2L]]) else "all"
+
+skill <- ".claude/skills/extract-literature-model"
+cand <- list(
+  covariate   = c("inst/references/covariate-columns.md",
+                  file.path(skill, "references/covariate-columns.md")),
+  parameter   = file.path(skill, "references/parameter-names.md"),
+  compartment = file.path(skill, "references/compartment-names.md")
+)
+if (kind != "all") {
+  if (!kind %in% names(cand)) {
+    cat(sprintf("unknown kind '%s' (use covariate|parameter|compartment)\n", kind))
+    quit(status = 2L)
+  }
+  cand <- cand[kind]
+}
+
+resolve <- function(paths) { for (p in paths) if (file.exists(p)) return(p); NA_character_ }
+# whole-word, case-insensitive match (so "WT" hits "### WT" but not "BWT"/"WTKG").
+# \Q...\E quotes the term literally, so any regex metacharacters are harmless.
+wb <- paste0("\\b\\Q", term, "\\E\\b")
+wmatch <- function(x) grepl(wb, x, ignore.case = TRUE, perl = TRUE)
+
+entries <- list()
+for (k in names(cand)) {
+  f <- resolve(cand[[k]])
+  if (is.na(f)) next
+  lines <- readLines(f, warn = FALSE)
+  head_idx <- grep("^#{2,4}\\s", lines)
+  if (length(head_idx) == 0L) next
+  starts <- head_idx; ends <- c(head_idx[-1L] - 1L, length(lines))
+  for (b in seq_along(starts)) {
+    blk <- lines[starts[[b]]:ends[[b]]]
+    heading <- sub("^#+\\s*", "", lines[[starts[[b]]]])
+    hmatch <- wmatch(heading)
+    bmatch <- any(wmatch(blk))
+    if (hmatch || bmatch)
+      entries[[length(entries) + 1L]] <-
+        list(k = k, f = f, heading = heading, blk = blk, hmatch = hmatch)
+  }
+}
+
+# Heading matches are what "is there a canonical named X?" wants; if any exist,
+# drop body-only (alias/description) mentions. Cap entries + per-entry lines.
+hm <- Filter(function(e) e$hmatch, entries)
+use <- if (length(hm) > 0L) hm else entries
+cap_entries <- 8L
+dropped <- max(0L, length(use) - cap_entries)
+use <- utils::head(use, cap_entries)
+
+if (length(use) == 0L) {
+  cat(sprintf("No %s register entry matches '%s'. If the concept is genuinely absent, this is a NEW canonical -> follow the stop-and-ask rule before adding it.\n",
+              if (kind == "all") "" else kind, term))
+} else {
+  for (e in use) {
+    tag <- if (e$hmatch) "" else " [body/alias match]"
+    cat(sprintf("=== [%s] %s%s  (%s)\n", e$k, e$heading, tag, e$f))
+    blk2 <- if (length(e$blk) > 40L) c(e$blk[seq_len(40L)], "...[entry truncated]") else e$blk
+    cat(blk2, sep = "\n"); cat("\n\n")
+  }
+  if (dropped > 0L)
+    cat(sprintf("...[%d more matching entries omitted; refine the term]\n", dropped))
+}


### PR DESCRIPTION
Per the nlmixr2libingest design (reports/design_nlmixr2libingest_2026-06-22.md in the ingestion queue): measured per-article extraction cost is dominated by cache_read (cached-context-size x agent-turns) + output, NOT the paper (~8.6k tok). Two standalone, quality-neutral wins:

- scripts/lookup-canonical.R <term> [covariate|parameter|compartment]: returns only the matching register entries (a few KB) instead of loading covariate-columns.md (~1.1MB / 284k tokens) into context. Word-boundary, heading-priority match; prints a "NEW canonical -> stop-and-ask" hint on miss.
- scripts/filter-r-log.R <log>: compacts devtools::check / vignette-render logs to errors/warnings/traceback + final status, dropping the hundreds of "* checking ... OK" / pandoc-verbose lines re-read every fix-loop turn.

SKILL.md wired to use both at the three use-points (canonical lookup; vignette render gate; devtools::check). Quality firewall preserved: lookups return register names, not paper source values; the agent still source-traces every ini() value against the paper; raw logs/registers remain available.