### PR TITLE
docs: regenerate with roxygen2 8.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,5 +46,4 @@ Suggests:
     yaml
 Config/testthat/edition: 3
 Config/testthat/parallel: true
-Config/roxygen2/version: 8.0.0
-RoxygenNote: 7.3.3
+Config/roxygen2/version: 8.1.0

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -80,20 +80,22 @@ export(setCombineType)
 export(simMarkov)
 export(snakeCombine)
 export(updateOncologyXenograftSimeoni2004)
-importFrom(rxode2,assertCompartmentExists)
-importFrom(rxode2,assertCompartmentName)
-importFrom(rxode2,assertParameterValue)
-importFrom(rxode2,assertRxUi)
-importFrom(rxode2,assertRxUiEstimatedResiduals)
-importFrom(rxode2,assertRxUiMixedOnly)
-importFrom(rxode2,assertRxUiMuRefOnly)
-importFrom(rxode2,assertRxUiNormal)
-importFrom(rxode2,assertRxUiPopulationOnly)
-importFrom(rxode2,assertRxUiPrediction)
-importFrom(rxode2,assertRxUiRandomOnIdOnly)
-importFrom(rxode2,assertRxUiSingleEndpoint)
-importFrom(rxode2,assertRxUiTransformNormal)
-importFrom(rxode2,assertVariableName)
-importFrom(rxode2,expit)
-importFrom(rxode2,logit)
+importFrom(rxode2,
+  assertCompartmentExists,
+  assertCompartmentName,
+  assertParameterValue,
+  assertRxUi,
+  assertRxUiEstimatedResiduals,
+  assertRxUiMixedOnly,
+  assertRxUiMuRefOnly,
+  assertRxUiNormal,
+  assertRxUiPopulationOnly,
+  assertRxUiPrediction,
+  assertRxUiRandomOnIdOnly,
+  assertRxUiSingleEndpoint,
+  assertRxUiTransformNormal,
+  assertVariableName,
+  expit,
+  logit
+)
 importFrom(stats,setNames)


### PR DESCRIPTION
Regenerated the package documentation with roxygen2 8.1.0 (was 8.0.0/7.3.3).

The NAMESPACE change is formatting only: 8.1.0 writes a multi-symbol importFrom() as one grouped call rather than one call per symbol.  The parsed directive set is unchanged -- 97 directives before, 97 after.

0 files under man/ changed.  No R source and no exported behavior changed.