### PR TITLE
Ignore the stray Rplots.pdf that R writes for base graphics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,10 @@ post_merge_advance.sh
 # Vignette-gate render artifacts (verify_vignettes_parallel.R)
 *.knit.md
 vignettes/articles/*.html
+
+# R writes Rplots.pdf automatically whenever base graphics are drawn in a
+# non-interactive session (Rscript, devtools::check, a vignette render). It is
+# a stray artifact, never content -- but because it is untracked it trips the
+# task runner's "uncommitted work left" gate, which failed oare_PMC13176099 on
+# three consecutive full-effort dispatches before this was noticed.
+Rplots.pdf


### PR DESCRIPTION
R writes Rplots.pdf into the working directory whenever base graphics are drawn in a non-interactive session -- Rscript, devtools::check(), or a vignette render. It is never content.

Because it was untracked and unignored, it read as uncommitted work to the task runner's output-evidence gate, which then failed the run. That is not theoretical: oare_PMC13176099 burned three consecutive full-effort opus dispatches, each ending in "run ended with 1 uncommitted path(s) in the worktree", and each retry reproduced the same stray file and failed the same way. The task's real work -- one commit making two Ding 2026 vancomycin event-table assertions falsifiable -- was already pushed.

Ignoring it breaks that loop and prevents the class, since any task whose vignette or check draws a base plot can produce one.