### PR TITLE
Use expit() for every inverse logit, removing an overflow cliff

### DIFF
--- a/inst/modeldb/ddmore/Bizzotto_2016_glucose.R
+++ b/inst/modeldb/ddmore/Bizzotto_2016_glucose.R
@@ -139,10 +139,10 @@ Bizzotto_2016_glucose <- function() {
     # detection happy for the etas on flambda3 and w1.
     lflambda3i <- lflambda3 + etalflambda3
     lw1i       <- lw1       + etalw1
-    flambda3 <- 1 / (1 + exp(-lflambda3i))
-    flambda2 <- 1 / (1 + exp(-lflambda2))                      # var_flambda2 fixed at 0 -> no eta
-    w1       <- 1 / (1 + exp(-lw1i))
-    fw2      <- 1 / (1 + exp(-lfw2))                           # var_fw2    fixed at 0  -> no eta
+    flambda3 <- expit(lflambda3i)
+    flambda2 <- expit(lflambda2)                      # var_flambda2 fixed at 0 -> no eta
+    w1       <- expit(lw1i)
+    fw2      <- expit(lfw2)                           # var_fw2    fixed at 0  -> no eta
     pflow    <- exp(lpflow)                                    # var_F      fixed at 0  -> no eta
 
     # Derived periphery-block rate constants - .mdl MODEL_PREDICTION lines 177-183.

--- a/inst/modeldb/ddmore/Henin_2009_capecitabine.R
+++ b/inst/modeldb/ddmore/Henin_2009_capecitabine.R
@@ -137,20 +137,20 @@ Henin_2009_capecitabine <- function() {
     # 7. Cumulative probabilities and per-grade probabilities, exposed per Markov state
     #    (consumer simulates the categorical draw and feeds the realized grade as the
     #    next Markov state). Naming: P<grade>_s<previous>.
-    pc0_s0 <- exp(a0_s0) / (1 + exp(a0_s0))
-    pc1_s0 <- exp(a1_s0) / (1 + exp(a1_s0))
+    pc0_s0 <- expit(a0_s0)
+    pc1_s0 <- expit(a1_s0)
     P0_s0 <- pc0_s0
     P1_s0 <- pc1_s0 - pc0_s0
     P2_s0 <- 1 - pc1_s0
 
-    pc0_s1 <- exp(a0_s1) / (1 + exp(a0_s1))
-    pc1_s1 <- exp(a1_s1) / (1 + exp(a1_s1))
+    pc0_s1 <- expit(a0_s1)
+    pc1_s1 <- expit(a1_s1)
     P0_s1 <- pc0_s1
     P1_s1 <- pc1_s1 - pc0_s1
     P2_s1 <- 1 - pc1_s1
 
-    pc0_s2 <- exp(a0_s2) / (1 + exp(a0_s2))
-    pc1_s2 <- exp(a1_s2) / (1 + exp(a1_s2))
+    pc0_s2 <- expit(a0_s2)
+    pc1_s2 <- expit(a1_s2)
     P0_s2 <- pc0_s2
     P1_s2 <- pc1_s2 - pc0_s2
     P2_s2 <- 1 - pc1_s2

--- a/inst/modeldb/ddmore/NA_NA_paracetamol.R
+++ b/inst/modeldb/ddmore/NA_NA_paracetamol.R
@@ -392,7 +392,7 @@ NA_NA_paracetamol <- function() {
     ks       <- kw * (1 - gluinhi)
     ks       <- ks * (ks >= 0)
 
-    lag      <- 1 / (1 + exp(-10 * (t - t50)))
+    lag      <- expit(10 * (t - t50))
     fpl      <- vmax * intestine_apap / (km_apap + intestine_apap)
 
     # -------------------------------------------------------------------

--- a/inst/modeldb/ddmore/Novakovic_2017_cladribine.R
+++ b/inst/modeldb/ddmore/Novakovic_2017_cladribine.R
@@ -258,11 +258,11 @@ Novakovic_2017_cladribine <- function() {
     pyr_cum3  <- pyr_cum2 + b_pyr_3
     pyr_cum4  <- pyr_cum3 + b_pyr_4
     pyr_cum5  <- pyr_cum4 + b_pyr_5
-    pge_pyr_1 <- 1 / (1 + exp(-a_pyr * (pd - pyr_cum1)))
-    pge_pyr_2 <- 1 / (1 + exp(-a_pyr * (pd - pyr_cum2)))
-    pge_pyr_3 <- 1 / (1 + exp(-a_pyr * (pd - pyr_cum3)))
-    pge_pyr_4 <- 1 / (1 + exp(-a_pyr * (pd - pyr_cum4)))
-    pge_pyr_5 <- 1 / (1 + exp(-a_pyr * (pd - pyr_cum5)))
+    pge_pyr_1 <- expit(a_pyr * (pd - pyr_cum1))
+    pge_pyr_2 <- expit(a_pyr * (pd - pyr_cum2))
+    pge_pyr_3 <- expit(a_pyr * (pd - pyr_cum3))
+    pge_pyr_4 <- expit(a_pyr * (pd - pyr_cum4))
+    pge_pyr_5 <- expit(a_pyr * (pd - pyr_cum5))
     pyramidal <- pge_pyr_1 + pge_pyr_2 + pge_pyr_3 + pge_pyr_4 + pge_pyr_5
 
     # Item 2: Cerebellar (0-5)
@@ -271,11 +271,11 @@ Novakovic_2017_cladribine <- function() {
     cer_cum3  <- cer_cum2 + b_cer_3
     cer_cum4  <- cer_cum3 + b_cer_4
     cer_cum5  <- cer_cum4 + b_cer_5
-    pge_cer_1 <- 1 / (1 + exp(-a_cer * (pd - cer_cum1)))
-    pge_cer_2 <- 1 / (1 + exp(-a_cer * (pd - cer_cum2)))
-    pge_cer_3 <- 1 / (1 + exp(-a_cer * (pd - cer_cum3)))
-    pge_cer_4 <- 1 / (1 + exp(-a_cer * (pd - cer_cum4)))
-    pge_cer_5 <- 1 / (1 + exp(-a_cer * (pd - cer_cum5)))
+    pge_cer_1 <- expit(a_cer * (pd - cer_cum1))
+    pge_cer_2 <- expit(a_cer * (pd - cer_cum2))
+    pge_cer_3 <- expit(a_cer * (pd - cer_cum3))
+    pge_cer_4 <- expit(a_cer * (pd - cer_cum4))
+    pge_cer_5 <- expit(a_cer * (pd - cer_cum5))
     cerebellar <- pge_cer_1 + pge_cer_2 + pge_cer_3 + pge_cer_4 + pge_cer_5
 
     # Item 3: Brainstem (0-4)
@@ -283,10 +283,10 @@ Novakovic_2017_cladribine <- function() {
     bs_cum2  <- bs_cum1 + b_bs_2
     bs_cum3  <- bs_cum2 + b_bs_3
     bs_cum4  <- bs_cum3 + b_bs_4
-    pge_bs_1 <- 1 / (1 + exp(-a_bs * (pd - bs_cum1)))
-    pge_bs_2 <- 1 / (1 + exp(-a_bs * (pd - bs_cum2)))
-    pge_bs_3 <- 1 / (1 + exp(-a_bs * (pd - bs_cum3)))
-    pge_bs_4 <- 1 / (1 + exp(-a_bs * (pd - bs_cum4)))
+    pge_bs_1 <- expit(a_bs * (pd - bs_cum1))
+    pge_bs_2 <- expit(a_bs * (pd - bs_cum2))
+    pge_bs_3 <- expit(a_bs * (pd - bs_cum3))
+    pge_bs_4 <- expit(a_bs * (pd - bs_cum4))
     brainstem <- pge_bs_1 + pge_bs_2 + pge_bs_3 + pge_bs_4
 
     # Item 4: Sensory (0-6)
@@ -296,12 +296,12 @@ Novakovic_2017_cladribine <- function() {
     sen_cum4  <- sen_cum3 + b_sen_4
     sen_cum5  <- sen_cum4 + b_sen_5
     sen_cum6  <- sen_cum5 + b_sen_6
-    pge_sen_1 <- 1 / (1 + exp(-a_sen * (pd - sen_cum1)))
-    pge_sen_2 <- 1 / (1 + exp(-a_sen * (pd - sen_cum2)))
-    pge_sen_3 <- 1 / (1 + exp(-a_sen * (pd - sen_cum3)))
-    pge_sen_4 <- 1 / (1 + exp(-a_sen * (pd - sen_cum4)))
-    pge_sen_5 <- 1 / (1 + exp(-a_sen * (pd - sen_cum5)))
-    pge_sen_6 <- 1 / (1 + exp(-a_sen * (pd - sen_cum6)))
+    pge_sen_1 <- expit(a_sen * (pd - sen_cum1))
+    pge_sen_2 <- expit(a_sen * (pd - sen_cum2))
+    pge_sen_3 <- expit(a_sen * (pd - sen_cum3))
+    pge_sen_4 <- expit(a_sen * (pd - sen_cum4))
+    pge_sen_5 <- expit(a_sen * (pd - sen_cum5))
+    pge_sen_6 <- expit(a_sen * (pd - sen_cum6))
     sensory <- pge_sen_1 + pge_sen_2 + pge_sen_3 + pge_sen_4 + pge_sen_5 + pge_sen_6
 
     # Item 5: Bowel/Bladder (0-5)
@@ -310,11 +310,11 @@ Novakovic_2017_cladribine <- function() {
     bb_cum3  <- bb_cum2 + b_bb_3
     bb_cum4  <- bb_cum3 + b_bb_4
     bb_cum5  <- bb_cum4 + b_bb_5
-    pge_bb_1 <- 1 / (1 + exp(-a_bb * (pd - bb_cum1)))
-    pge_bb_2 <- 1 / (1 + exp(-a_bb * (pd - bb_cum2)))
-    pge_bb_3 <- 1 / (1 + exp(-a_bb * (pd - bb_cum3)))
-    pge_bb_4 <- 1 / (1 + exp(-a_bb * (pd - bb_cum4)))
-    pge_bb_5 <- 1 / (1 + exp(-a_bb * (pd - bb_cum5)))
+    pge_bb_1 <- expit(a_bb * (pd - bb_cum1))
+    pge_bb_2 <- expit(a_bb * (pd - bb_cum2))
+    pge_bb_3 <- expit(a_bb * (pd - bb_cum3))
+    pge_bb_4 <- expit(a_bb * (pd - bb_cum4))
+    pge_bb_5 <- expit(a_bb * (pd - bb_cum5))
     bowel_bladder <- pge_bb_1 + pge_bb_2 + pge_bb_3 + pge_bb_4 + pge_bb_5
 
     # Item 6: Visual (0-6)
@@ -324,12 +324,12 @@ Novakovic_2017_cladribine <- function() {
     vis_cum4  <- vis_cum3 + b_vis_4
     vis_cum5  <- vis_cum4 + b_vis_5
     vis_cum6  <- vis_cum5 + b_vis_6
-    pge_vis_1 <- 1 / (1 + exp(-a_vis * (pd - vis_cum1)))
-    pge_vis_2 <- 1 / (1 + exp(-a_vis * (pd - vis_cum2)))
-    pge_vis_3 <- 1 / (1 + exp(-a_vis * (pd - vis_cum3)))
-    pge_vis_4 <- 1 / (1 + exp(-a_vis * (pd - vis_cum4)))
-    pge_vis_5 <- 1 / (1 + exp(-a_vis * (pd - vis_cum5)))
-    pge_vis_6 <- 1 / (1 + exp(-a_vis * (pd - vis_cum6)))
+    pge_vis_1 <- expit(a_vis * (pd - vis_cum1))
+    pge_vis_2 <- expit(a_vis * (pd - vis_cum2))
+    pge_vis_3 <- expit(a_vis * (pd - vis_cum3))
+    pge_vis_4 <- expit(a_vis * (pd - vis_cum4))
+    pge_vis_5 <- expit(a_vis * (pd - vis_cum5))
+    pge_vis_6 <- expit(a_vis * (pd - vis_cum6))
     visual <- pge_vis_1 + pge_vis_2 + pge_vis_3 + pge_vis_4 + pge_vis_5 + pge_vis_6
 
     # Item 7: Mental (0-4)
@@ -337,10 +337,10 @@ Novakovic_2017_cladribine <- function() {
     men_cum2  <- men_cum1 + b_men_2
     men_cum3  <- men_cum2 + b_men_3
     men_cum4  <- men_cum3 + b_men_4
-    pge_men_1 <- 1 / (1 + exp(-a_men * (pd - men_cum1)))
-    pge_men_2 <- 1 / (1 + exp(-a_men * (pd - men_cum2)))
-    pge_men_3 <- 1 / (1 + exp(-a_men * (pd - men_cum3)))
-    pge_men_4 <- 1 / (1 + exp(-a_men * (pd - men_cum4)))
+    pge_men_1 <- expit(a_men * (pd - men_cum1))
+    pge_men_2 <- expit(a_men * (pd - men_cum2))
+    pge_men_3 <- expit(a_men * (pd - men_cum3))
+    pge_men_4 <- expit(a_men * (pd - men_cum4))
     mental <- pge_men_1 + pge_men_2 + pge_men_3 + pge_men_4
 
     # Item 8: Ambulation (0-9)
@@ -353,15 +353,15 @@ Novakovic_2017_cladribine <- function() {
     amb_cum7  <- amb_cum6 + b_amb_7
     amb_cum8  <- amb_cum7 + b_amb_8
     amb_cum9  <- amb_cum8 + b_amb_9
-    pge_amb_1 <- 1 / (1 + exp(-a_amb * (pd - amb_cum1)))
-    pge_amb_2 <- 1 / (1 + exp(-a_amb * (pd - amb_cum2)))
-    pge_amb_3 <- 1 / (1 + exp(-a_amb * (pd - amb_cum3)))
-    pge_amb_4 <- 1 / (1 + exp(-a_amb * (pd - amb_cum4)))
-    pge_amb_5 <- 1 / (1 + exp(-a_amb * (pd - amb_cum5)))
-    pge_amb_6 <- 1 / (1 + exp(-a_amb * (pd - amb_cum6)))
-    pge_amb_7 <- 1 / (1 + exp(-a_amb * (pd - amb_cum7)))
-    pge_amb_8 <- 1 / (1 + exp(-a_amb * (pd - amb_cum8)))
-    pge_amb_9 <- 1 / (1 + exp(-a_amb * (pd - amb_cum9)))
+    pge_amb_1 <- expit(a_amb * (pd - amb_cum1))
+    pge_amb_2 <- expit(a_amb * (pd - amb_cum2))
+    pge_amb_3 <- expit(a_amb * (pd - amb_cum3))
+    pge_amb_4 <- expit(a_amb * (pd - amb_cum4))
+    pge_amb_5 <- expit(a_amb * (pd - amb_cum5))
+    pge_amb_6 <- expit(a_amb * (pd - amb_cum6))
+    pge_amb_7 <- expit(a_amb * (pd - amb_cum7))
+    pge_amb_8 <- expit(a_amb * (pd - amb_cum8))
+    pge_amb_9 <- expit(a_amb * (pd - amb_cum9))
     ambulation <- pge_amb_1 + pge_amb_2 + pge_amb_3 + pge_amb_4 + pge_amb_5 + pge_amb_6 + pge_amb_7 + pge_amb_8 + pge_amb_9
 
     # 4. FREM continuous-covariate observations. Each is the typical-population mean shifted by

--- a/inst/modeldb/ddmore/Plan_2012_pain.R
+++ b/inst/modeldb/ddmore/Plan_2012_pain.R
@@ -140,7 +140,7 @@ Plan_2012_pain <- function() {
     # Mean count lambda on 0-10 scale, with the paracetamol additive logit shift.
     tvlam <- bas * plc / 10
     phl   <- log(tvlam / (1 - tvlam)) + e_conmed_para * CONMED_PARA
-    lam   <- 10 * exp(phl) / (1 + exp(phl))
+    lam   <- 10 * expit(phl)
 
     # Time-varying Markov drift (TE * days; TEF in source).
     te  <- exp(lte0 + etalte0)

--- a/inst/modeldb/ddmore/Schoemaker_2018_levetiracetam.R
+++ b/inst/modeldb/ddmore/Schoemaker_2018_levetiracetam.R
@@ -213,7 +213,7 @@ Schoemaker_2018_levetiracetam <- function() {
     # the FIXED-0 peds offset can be freed by a re-fitter without
     # restructuring the model.
     p_responder_subject <-
-      1 / (1 + exp(-(log(p_responder / (1 - p_responder)) + CHILD * p_responder_ped)))
+      expit(log(p_responder / (1 - p_responder)) + CHILD * p_responder_ped)
 
     # ------------------------------------------------------------------
     # Observation models -- Plan_2012_pain precedent.

--- a/inst/modeldb/ddmore/Svensson_2016_bedaquiline.R
+++ b/inst/modeldb/ddmore/Svensson_2016_bedaquiline.R
@@ -175,7 +175,7 @@ Svensson_2016_bedaquiline <- function() {
     # Absorption derived from MAT (hours) and FR (unitless fraction in (0, 1)).
     # MAT inherits its IIV via etalmat; FR has no IIV in the source model.
     mat <- exp(lmat + etalmat)
-    fr  <- 1 / (1 + exp(-logitfmat))
+    fr  <- expit(logitfmat)
     mtt <- mat * fr
     ka  <- log(2) / (mat * (1 - fr) / 3.3)   # absorption rate (1/h); the 3.3-fold delay-to-absorption-half-life ratio is the paper's parameterization (Svensson 2016 Methods, transit description)
     ktr <- 2 / mtt                            # transit-chain rate (1/h) for two transit compartments

--- a/inst/modeldb/endogenous/Bonner_2015_gastric_emptying.R
+++ b/inst/modeldb/endogenous/Bonner_2015_gastric_emptying.R
@@ -201,7 +201,7 @@ Bonner_2015_gastric_emptying <- function() {
     gamma1_i   <- exp(lgamma1 + etalgamma1)
     gamma2_i   <- exp(lgamma2 + etalgamma2)
     logit_pr_i <- llogit_pr + etallogit_pr
-    pr_frac_i  <- 1 / (1 + exp(-logit_pr_i))
+    pr_frac_i  <- expit(logit_pr_i)
     pr_pct_i   <- 100 * pr_frac_i
 
     # ---------------------------------------------------------------------

--- a/inst/modeldb/specificDrugs/Abduljalil_2009_clarithromycin.R
+++ b/inst/modeldb/specificDrugs/Abduljalil_2009_clarithromycin.R
@@ -160,7 +160,7 @@ Abduljalil_2009_clarithromycin <- function() {
     cl      <- exp(lcl     + etalcl) * (WT / ref_wt)^e_wt_cl
     ki      <- exp(lki)
     ic50    <- exp(lic50)
-    fclp    <- exp(logitfclp) / (1 + exp(logitfclp))
+    fclp    <- expit(logitfclp)
     cl_ohcla <- exp(lcl_ohcla + etalcl_ohcla) * (WT / ref_wt)^e_wt_cl_ohcla
     vc_ohcla <- exp(lvc_ohcla)               * (WT / ref_wt)^e_wt_vc_ohcla
 

--- a/inst/modeldb/specificDrugs/Aguiar_2021_ustekinumab.R
+++ b/inst/modeldb/specificDrugs/Aguiar_2021_ustekinumab.R
@@ -189,7 +189,7 @@ Aguiar_2021_ustekinumab <- function() {
     # Subcutaneous bioavailability on the logit scale; FCGR3A_VV adds a fixed
     # shift relative to the V/F + F/F reference group.
     logit_f <- logitfdepot + etalogitfdepot + e_fcgr3a_vv_fdepot * FCGR3A_VV
-    fdepot  <- 1 / (1 + exp(-logit_f))
+    fdepot  <- expit(logit_f)
 
     # ----- Individual target turnover and binding -----
     # Ksyn carries the CRP linear-deviation effect (footnote d) and a

--- a/inst/modeldb/specificDrugs/AitOudhia_2012_canakinumab.R
+++ b/inst/modeldb/specificDrugs/AitOudhia_2012_canakinumab.R
@@ -287,9 +287,9 @@ AitOudhia_2012_canakinumab <- function() {
     logit_acr50 <- log(0.5 / 0.5) + logit_acrl + acrshift + etaacrshift
     logit_acr70 <- log(0.3 / 0.7) + logit_acrl + acrshift + etaacrshift
 
-    prob_ACR20  <- 1 / (1 + exp(-logit_acr20))
-    prob_ACR50  <- 1 / (1 + exp(-logit_acr50))
-    prob_ACR70  <- 1 / (1 + exp(-logit_acr70))
+    prob_ACR20  <- expit(logit_acr20)
+    prob_ACR50  <- expit(logit_acr50)
+    prob_ACR70  <- expit(logit_acr70)
 
     Cc        ~ prop(propSd)            + add(addSd)
     totalIL1b ~ prop(propSd_totalIL1b) + add(addSd_totalIL1b)

--- a/inst/modeldb/specificDrugs/AitOudhia_2024_sotatercept.R
+++ b/inst/modeldb/specificDrugs/AitOudhia_2024_sotatercept.R
@@ -239,7 +239,7 @@ AitOudhia_2024_sotatercept <- function() {
     # logit-scale sum is kept on its own line so nlmixr2 can mu-reference
     # etalogitfdepot (same idiom as Martinez_2019_alirocumab).
     logit_f <- logitfdepot + etalogitfdepot
-    fdepot  <- 1 / (1 + exp(-logit_f))
+    fdepot  <- expit(logit_f)
 
     # ---- 2. Micro-constants (Methods 'Clinical relevance of covariates') ----
     kel <- cl / vc

--- a/inst/modeldb/specificDrugs/AlfoseaCuadrado_2024_reserpine_rat.R
+++ b/inst/modeldb/specificDrugs/AlfoseaCuadrado_2024_reserpine_rat.R
@@ -213,7 +213,7 @@ AlfoseaCuadrado_2024_reserpine_rat <- function() {
     # 1. Individual parameters
     ka     <- exp(lka + etalka)
     d1     <- exp(ld1 + etald1)
-    fdepot <- exp(logitfdepot + etalogitfdepot) / (1 + exp(logitfdepot + etalogitfdepot))
+    fdepot <- expit(logitfdepot + etalogitfdepot)
     vc     <- exp(lvc + etalvc)
     cl     <- exp(lcl + etalcl)
 

--- a/inst/modeldb/specificDrugs/Assmus_2025_benznidazole_mouse.R
+++ b/inst/modeldb/specificDrugs/Assmus_2025_benznidazole_mouse.R
@@ -256,8 +256,8 @@ Assmus_2025_benznidazole_mouse <- function() {
 
     # 7. Exposure-response (Equation 1). Two parallel univariate logistic
     #    models for the probability of sterile parasitological cure.
-    pcure_auc  <- 1 / (1 + exp(-(logite0_cure_auc  + e_auc_cure  * auc_total)))
-    pcure_tmic <- 1 / (1 + exp(-(logite0_cure_tmic + e_tmic_cure * t_above_mic)))
+    pcure_auc  <- expit(logite0_cure_auc  + e_auc_cure  * auc_total)
+    pcure_tmic <- expit(logite0_cure_tmic + e_tmic_cure * t_above_mic)
 
     # 8. Residual error: additive on the natural-log concentration scale.
     Cc ~ lnorm(expSd)

--- a/inst/modeldb/specificDrugs/Baverel_2015_tralokinumab.R
+++ b/inst/modeldb/specificDrugs/Baverel_2015_tralokinumab.R
@@ -143,7 +143,7 @@ Baverel_2015_tralokinumab <- function() {
     d0     <- exp(ld0)
     tlag   <- exp(ltlag)
     fdepot <- exp(lfdepot)
-    fr     <- exp(logitffo + etalogitffo) / (1 + exp(logitffo + etalogitffo))
+    fr     <- expit(logitffo + etalogitffo)
 
     # Two-compartment disposition micro-constants.
     kel <- cl / vc

--- a/inst/modeldb/specificDrugs/Bhagunde_2026_lecanemab_gfap.R
+++ b/inst/modeldb/specificDrugs/Bhagunde_2026_lecanemab_gfap.R
@@ -334,7 +334,7 @@ Bhagunde_2026_lecanemab_gfap <- function() {
     # --- Layer 2: brain amyloid plaque turnover
     # BSL = 250 * exp(phi) / (1 + exp(phi)); phi = TVphi * COV
     phi_plaque   <- logitrbase_plaque * e_apoe4_carrier_logitrbase_plaque^APOE4_CARRIER
-    rbase_plaque <- plaque_max * exp(phi_plaque) / (1 + exp(phi_plaque))
+    rbase_plaque <- plaque_max * expit(phi_plaque)
     kout_plaque  <- exp(lkout_plaque) / hrs_per_year
     slope_plaque <- exp(lslope_plaque) * (AGE / age_ref)^e_age_slope_plaque
     kin_plaque   <- rbase_plaque * kout_plaque   # kin = BSL * kout
@@ -355,7 +355,7 @@ Bhagunde_2026_lecanemab_gfap <- function() {
     kout <- kin / rbase   # Bhagunde 2026: "KinG = BGFAP * KoutG (at baseline)"
     # Kept on its own line so rxode2 recognises the mu-referenced expression
     logit_slp <- logitslope_gfap + etalogitslope_gfap
-    slp  <- 1 / (1 + exp(-logit_slp))
+    slp  <- expit(logit_slp)
     prog <- exp(lprog) / hrs_per_year
 
     # dGFAP/dt = KinG * (1 - SLP * relative plaque reduction + DP * TIME) - KoutG * GFAP

--- a/inst/modeldb/specificDrugs/Bian_2024_lefamulin_higher_ppb.R
+++ b/inst/modeldb/specificDrugs/Bian_2024_lefamulin_higher_ppb.R
@@ -329,12 +329,11 @@ Bian_2024_lefamulin_higher_ppb <- function() {
     ka2  <- exp(lka2 + etalka2) * (1 - FED + e_fed_ka2 * FED)
     tlag <- exp(ltlag)
 
-    fdepot_typ <- exp(logitfdepot) / (1 + exp(logitfdepot))
+    fdepot_typ <- expit(logitfdepot)
     bio        <- fdepot_typ * (1 - FED + e_fed_fdepot * FED)
     fpo        <- log(bio / (1 - bio))
-    fdepot     <- exp(fpo + etalogitfdepot) / (1 + exp(fpo + etalogitfdepot))
-    frac       <- exp(logitfrac + etalogitfrac) /
-                  (1 + exp(logitfrac + etalogitfrac))
+    fdepot     <- expit(fpo + etalogitfdepot)
+    frac       <- expit(logitfrac + etalogitfrac)
 
     penratio_elf <- exp(lpenratio_elf)
 

--- a/inst/modeldb/specificDrugs/Bian_2024_lefamulin_original_ppb.R
+++ b/inst/modeldb/specificDrugs/Bian_2024_lefamulin_original_ppb.R
@@ -378,12 +378,11 @@ Bian_2024_lefamulin_original_ppb <- function() {
     # result and adds eta9 on the logit scale. Equations 11-12 do the
     # same for the delayed-route fraction, whose typical value is
     # already carried on the logit scale in ini().
-    fdepot_typ <- exp(logitfdepot) / (1 + exp(logitfdepot))
+    fdepot_typ <- expit(logitfdepot)
     bio        <- fdepot_typ * (1 - FED + e_fed_fdepot * FED)
     fpo        <- log(bio / (1 - bio))
-    fdepot     <- exp(fpo + etalogitfdepot) / (1 + exp(fpo + etalogitfdepot))
-    frac       <- exp(logitfrac + etalogitfrac) /
-                  (1 + exp(logitfrac + etalogitfrac))
+    fdepot     <- expit(fpo + etalogitfdepot)
+    frac       <- expit(logitfrac + etalogitfrac)
 
     # ELF micro-constants.
     kin_elf  <- exp(lkin_elf)

--- a/inst/modeldb/specificDrugs/Bjornsson_2023_buprenorphine.R
+++ b/inst/modeldb/specificDrugs/Bjornsson_2023_buprenorphine.R
@@ -442,13 +442,13 @@ Bjornsson_2023_buprenorphine <- function() {
     # (etalogitfdepot_sl cannot be mu-referenced because the dose-dependent
     # typical value is not a bare theta; rxode2 emits a non-mu-reference note
     # for it, which affects estimation efficiency only, not simulation.)
-    fdepot_sl_tv <- (1 / (1 + exp(-logitfdepot_sl))) *
+    fdepot_sl_tv <- (expit(logitfdepot_sl)) *
       (DOSE_BPN_SL_MG / dose_sl_ref)^e_dose_fdepot_sl
     lgt_sl       <- log(fdepot_sl_tv / (1 - fdepot_sl_tv)) + etalogitfdepot_sl
-    fdepot_sl    <- 1 / (1 + exp(-lgt_sl))
+    fdepot_sl    <- expit(lgt_sl)
 
     lgt_sl1    <- logitfdepot_sl1 + etalogitfdepot_sl1
-    fdepot_sl1 <- 1 / (1 + exp(-lgt_sl1))
+    fdepot_sl1 <- expit(lgt_sl1)
 
     tlag_sl1 <- exp(ltlag_sl1)
     d1_sl1   <- exp(ld1_sl1)
@@ -473,7 +473,7 @@ Bjornsson_2023_buprenorphine <- function() {
 
     # ------------------ CAM2038 Q4W absorption parameters -----------------
     lgt_q4w1    <- logitfdepot_q4w1 + etalogitfdepot_q4w1
-    fdepot_q4w1 <- 1 / (1 + exp(-lgt_q4w1))
+    fdepot_q4w1 <- expit(lgt_q4w1)
     ka_q4w1     <- exp(lka_q4w1)
     ka_q4w2     <- exp(lka_q4w2 + etalka_q4w2)
 

--- a/inst/modeldb/specificDrugs/Borghardt_2016_olodaterol.R
+++ b/inst/modeldb/specificDrugs/Borghardt_2016_olodaterol.R
@@ -240,9 +240,9 @@ Borghardt_2016_olodaterol <- function() {
     logit_pbio_i <- logitpbio + etalogitpbio
     logit_ff1_i  <- logitff1  + etalogitff1
     logit_ff2_i  <- logitff2  + etalogitff2
-    pbio <- 1 / (1 + exp(-logit_pbio_i))
-    ff1  <- 1 / (1 + exp(-logit_ff1_i))
-    ff2  <- 1 / (1 + exp(-logit_ff2_i))
+    pbio <- expit(logit_pbio_i)
+    ff1  <- expit(logit_ff1_i)
+    ff2  <- expit(logit_ff2_i)
 
     # Per-depot fractions of the pulmonary bioavailable dose.
     frac_slow <- ff1

--- a/inst/modeldb/specificDrugs/Bosch_2024_cotadutide_qsp.R
+++ b/inst/modeldb/specificDrugs/Bosch_2024_cotadutide_qsp.R
@@ -351,7 +351,7 @@ Bosch_2024_cotadutide_qsp <- function() {
     keglc  <- exp(lkeglc)
     kelglc <- exp(lkelglc)
     kaglc  <- exp(lkaglc)
-    fglc   <- 1 / (1 + exp(-logitfglc))
+    fglc   <- expit(logitfglc)
 
     clins  <- exp(lclins)
     vcins  <- exp(lvcins)

--- a/inst/modeldb/specificDrugs/Chakraborty_2012_canakinumab.R
+++ b/inst/modeldb/specificDrugs/Chakraborty_2012_canakinumab.R
@@ -157,7 +157,7 @@ Chakraborty_2012_canakinumab <- function() {
     kd    <- exp(lkd  + etalkd)
     psl   <- exp(lpsl + etalpsl)
     cl_x  <- cl                    # Complex clearance assumed equal to free-drug clearance (Chakraborty 2012 page e7)
-    fdepot <- 1 / (1 + exp(-lfdepot))
+    fdepot <- expit(lfdepot)
 
     # ------------------------------------------------------------------
     # 2. Quasi-steady-state binding (Chakraborty 2012 equation 7):

--- a/inst/modeldb/specificDrugs/Chua_2025_mirikizumab.R
+++ b/inst/modeldb/specificDrugs/Chua_2025_mirikizumab.R
@@ -132,7 +132,7 @@ Chua_2025_mirikizumab <- function() {
 
     # Bioavailability on logit scale with linear BMI effect.
     logit_f <- logitfdepot + etalogitfdepot + e_bmi_fdepot * (BMI - 24.75)
-    fdepot  <- 1 / (1 + exp(-logit_f))
+    fdepot  <- expit(logit_f)
 
     # Two-compartment model with first-order SC absorption.
     kel <- cl / vc

--- a/inst/modeldb/specificDrugs/Courlet_2023_cabamiquine.R
+++ b/inst/modeldb/specificDrugs/Courlet_2023_cabamiquine.R
@@ -382,7 +382,7 @@ Courlet_2023_cabamiquine <- function() {
     #    the exponent is clamped to a range that is still far beyond
     #    saturation (exp(500) ~ 1e217, i.e. tr_lb ~ 1e-217 versus 0).
     z_lb  <- max(min((t - t50) / sigma_lb, 500), -500)
-    tr_lb <- 1 / (1 + exp(-z_lb))
+    tr_lb <- expit(z_lb)
 
     d/dt(parasite_liver) <- kgrow_liver * parasite_liver -
                               klb * tr_lb * parasite_liver -

--- a/inst/modeldb/specificDrugs/FiedlerKelly_2020_fremanezumab_cm.R
+++ b/inst/modeldb/specificDrugs/FiedlerKelly_2020_fremanezumab_cm.R
@@ -100,7 +100,7 @@ FiedlerKelly_2020_fremanezumab_cm <- function() {
     BL_i      <- bl_cm + slope_AM * max(0, ACUTE_MED_DAYS - 5) + etabl_cm
     maxPLC_i  <- maxPLC_cm + etamaxPLC_cm
     hill_i    <- exp(lhill_PLC + etalhill_PLC)
-    drugInt_i <- 1 / (1 + exp(-(logitDrugInt + etalogitDrugInt)))
+    drugInt_i <- expit(logitDrugInt + etalogitDrugInt)
     drugExp_i <- exp(ldrugExp + etaldrugExp)
 
     # Placebo Hill function in time (Fiedler-Kelly 2020 Figure 2B form):

--- a/inst/modeldb/specificDrugs/FiedlerKelly_2020_fremanezumab_em.R
+++ b/inst/modeldb/specificDrugs/FiedlerKelly_2020_fremanezumab_em.R
@@ -89,7 +89,7 @@ FiedlerKelly_2020_fremanezumab_em <- function() {
     exp_i <- exp_PLC + etaexp_PLC
 
     # Individual maximum fractional Cav response (logit-normal IIV).
-    Emax_i <- 1 / (1 + exp(-(logitEmax + etalogitEmax)))
+    Emax_i <- expit(logitEmax + etalogitEmax)
 
     # Placebo time-course (Fiedler-Kelly 2020 Figure 2A form): predicted
     # reduction from baseline = exp(exponent * month). At month 0 the

--- a/inst/modeldb/specificDrugs/Fung_2008_butanediol_rat.R
+++ b/inst/modeldb/specificDrugs/Fung_2008_butanediol_rat.R
@@ -269,7 +269,7 @@ Fung_2008_butanediol_rat <- function() {
 
     ka    <- exp(lka)
     tlag  <- exp(ltlag + etaltlag)
-    fr_bd <- 1 / (1 + exp(-logitfr_bd))
+    fr_bd <- expit(logitfr_bd)
 
     # ============================================================
     # 2. Concentrations (molar; mmol/L)

--- a/inst/modeldb/specificDrugs/Gandhi_2021_abatacept.R
+++ b/inst/modeldb/specificDrugs/Gandhi_2021_abatacept.R
@@ -175,7 +175,7 @@ Gandhi_2021_abatacept <- function() {
                DIS_PJIA * e_jia_f +
                e_wt_f  * log(WT  / 68) +
                e_age_f * log(AGE / 49)
-    fdepot  <- 1 / (1 + exp(-logit_f))
+    fdepot  <- expit(logit_f)
 
     # Two-compartment PK; IV doses go directly to central, SC doses to depot
     # with bioavailability fdepot.

--- a/inst/modeldb/specificDrugs/Germovsek_2018_meropenem.R
+++ b/inst/modeldb/specificDrugs/Germovsek_2018_meropenem.R
@@ -163,7 +163,7 @@ Germovsek_2018_meropenem <- function() {
     # from the 1.2 g/L reference modulates this logit. p = 1 - barrier
     # is the steady-state CSF / plasma concentration ratio.
     logit_barr <- logituptake + e_csftpro_uptake * (CSF_TPRO - 1.2)
-    barrier    <- 1 / (1 + exp(-logit_barr))
+    barrier    <- expit(logit_barr)
     penetration <- 1 - barrier
 
     # Plasma + CSF ODE system. CL_CSF * Cc enters the CSF compartment;

--- a/inst/modeldb/specificDrugs/Hanan_2026_peginterferon_alfa_24wk_mbma.R
+++ b/inst/modeldb/specificDrugs/Hanan_2026_peginterferon_alfa_24wk_mbma.R
@@ -493,7 +493,7 @@ Hanan_2026_peginterferon_alfa_24wk_mbma <- function() {
                eta_study
 
     # -------- Study-arm HBsAg-loss probability ----------------------
-    p_hbsag_loss <- exp(logit_p) / (1 + exp(logit_p))
+    p_hbsag_loss <- expit(logit_p)
 
     # -------- Binomial sampling-error weight (Section 2.3.1) --------
     # The paper's variance function is w_isa = sqrt(p*(1-p)/N_isa).

--- a/inst/modeldb/specificDrugs/Hanan_2026_peginterferon_alfa_eot_mbma.R
+++ b/inst/modeldb/specificDrugs/Hanan_2026_peginterferon_alfa_eot_mbma.R
@@ -455,7 +455,7 @@ Hanan_2026_peginterferon_alfa_eot_mbma <- function() {
                eta_study
 
     # -------- Study-arm HBsAg-loss probability ----------------------
-    p_hbsag_loss <- exp(logit_p) / (1 + exp(logit_p))
+    p_hbsag_loss <- expit(logit_p)
 
     # -------- Binomial sampling-error weight (Section 2.3.1) --------
     # The paper's variance function is w_isa = sqrt(p*(1-p)/N_isa).

--- a/inst/modeldb/specificDrugs/Hanberg_2018_meropenem.R
+++ b/inst/modeldb/specificDrugs/Hanberg_2018_meropenem.R
@@ -197,7 +197,7 @@ Hanberg_2018_meropenem <- function() {
 
     # Back-transform fraction unbound in SCT from logit scale (bounds 0-1
     # respected without explicit constraint at simulation time).
-    fu_sct <- 1 / (1 + exp(-logitfu_sct))
+    fu_sct <- expit(logitfu_sct)
 
     kel <- cl / vc
     k12 <- q  / vc

--- a/inst/modeldb/specificDrugs/Henin_2012_diclofenac.R
+++ b/inst/modeldb/specificDrugs/Henin_2012_diclofenac.R
@@ -161,7 +161,7 @@ Henin_2012_diclofenac <- function() {
     ka_col      <- exp(lka_col)
 
     logitfa_i   <- logitfa + etalogitfa
-    fa          <- 1 / (1 + exp(-logitfa_i))
+    fa          <- expit(logitfa_i)
 
     # Allometric scaling to 70 kg reference.
     cl          <- exp(lcl + etalcl) * (WT / 70)^e_wt_cl
@@ -177,9 +177,9 @@ Henin_2012_diclofenac <- function() {
     # transit is a single event (IP_APSI); IP_FA is not used because
     # no drug is released in the stomach.
     # ------------------------------------------------------------------
-    s_apsi      <- 1 / (1 + exp(-sig * (t - IP_APSI)))
-    s_psidsi    <- 1 / (1 + exp(-sig * (t - IP_PSI_DSI)))
-    s_dsic      <- 1 / (1 + exp(-sig * (t - IP_DSI_C)))
+    s_apsi      <- expit(sig * (t - IP_APSI))
+    s_psidsi    <- expit(sig * (t - IP_PSI_DSI))
+    s_dsic      <- expit(sig * (t - IP_DSI_C))
 
     pos_stomach <- 1 - s_apsi
     pos_psi     <- s_apsi - s_psidsi

--- a/inst/modeldb/specificDrugs/Henin_2012_felodipine.R
+++ b/inst/modeldb/specificDrugs/Henin_2012_felodipine.R
@@ -235,11 +235,11 @@ Henin_2012_felodipine <- function() {
     logitfa_fasted_i <- logitfa_fasted + etalogitfa_fasted
     logitfa_fed_i    <- logitfa_fed    + etalogitfa_fed
     logitfa_i        <- logitfa_fasted_i * (1 - FED) + logitfa_fed_i * FED
-    fa               <- 1 / (1 + exp(-logitfa_i))
+    fa               <- expit(logitfa_i)
 
     # Hepatic extraction ratio via logit-scale IIV.
     logiteh_i      <- logiteh + etalogiteh
-    eh             <- 1 / (1 + exp(-logiteh_i))
+    eh             <- expit(logiteh_i)
 
     # Semi-physiological liver: allometric flow, per-kg volume.
     qh             <- qh_per_kg075 * WT^0.75
@@ -258,10 +258,10 @@ Henin_2012_felodipine <- function() {
     # No-return-to-fundus subpopulation only: fundus -> antrum -> PSI
     # -> DSI -> colon in monotonic order (see description).
     # ------------------------------------------------------------------
-    s_fa           <- 1 / (1 + exp(-sig * (t - IP_FA)))
-    s_apsi         <- 1 / (1 + exp(-sig * (t - IP_APSI)))
-    s_psidsi       <- 1 / (1 + exp(-sig * (t - IP_PSI_DSI)))
-    s_dsic         <- 1 / (1 + exp(-sig * (t - IP_DSI_C)))
+    s_fa           <- expit(sig * (t - IP_FA))
+    s_apsi         <- expit(sig * (t - IP_APSI))
+    s_psidsi       <- expit(sig * (t - IP_PSI_DSI))
+    s_dsic         <- expit(sig * (t - IP_DSI_C))
 
     pos_fundus     <- 1 - s_fa
     pos_antrum     <- s_fa - s_apsi
@@ -281,7 +281,7 @@ Henin_2012_felodipine <- function() {
     # over a ~0.1 mg window. Preserves the paper's zero-order-until-
     # exhausted release intent without introducing an if / else branch.
     # ------------------------------------------------------------------
-    depot_active   <- 1 / (1 + exp(-50 * (depot - 0.1)))
+    depot_active   <- expit(50 * (depot - 0.1))
     release_fundus <- d_fundus     * pos_fundus * depot_active
     release_antrum <- d_antrum_psi * pos_antrum * depot_active
     release_psi    <- d_antrum_psi * pos_psi    * depot_active

--- a/inst/modeldb/specificDrugs/Hennig_2015_phenytoin.R
+++ b/inst/modeldb/specificDrugs/Hennig_2015_phenytoin.R
@@ -103,7 +103,7 @@ Hennig_2015_phenytoin <- function() {
     # Split the mu-reference onto its own line so nlmixr2 recognises etalogitfdepot
     # as mu-referenced.
     phi_fdepot <- logitfdepot + etalogitfdepot
-    fdepot <- 1 / (1 + exp(-phi_fdepot))
+    fdepot <- expit(phi_fdepot)
 
     # Micro-constants
     kel <- cl / vc

--- a/inst/modeldb/specificDrugs/Jensen_2023_lngIus52mg.R
+++ b/inst/modeldb/specificDrugs/Jensen_2023_lngIus52mg.R
@@ -227,7 +227,7 @@ Jensen_2023_lngIus52mg <- function() {
     kin_shbg  <- rbase_shbg * kout_shbg
 
     # Bioavailability of the LNG reservoir into the depot compartment.
-    fdepot <- exp(logitfdepot) / (1 + exp(logitfdepot))
+    fdepot <- expit(logitfdepot)
 
     # ------------------------------------------------------------------
     # Free fraction of LNG (closed-form solution to reversible binding).

--- a/inst/modeldb/specificDrugs/Jeon_2013_interferonAlfa2a.R
+++ b/inst/modeldb/specificDrugs/Jeon_2013_interferonAlfa2a.R
@@ -165,7 +165,7 @@ Jeon_2013_interferonAlfa2a <- function() {
     rf   <- exp(lrf   + etalrf)
     # Fz: zero-order absorbed fraction via logit transform of RF
     # (Jeon 2013 Table 4 footnote b: Fz = e^RF / (1 + e^RF)).
-    fz   <- exp(rf) / (1 + exp(rf))
+    fz   <- expit(rf)
 
     kel <- cl / vc
 

--- a/inst/modeldb/specificDrugs/Jia_2025_tak_071.R
+++ b/inst/modeldb/specificDrugs/Jia_2025_tak_071.R
@@ -173,7 +173,7 @@ Jia_2025_tak_071 <- function() {
     # off for the sparsely-sampled subset (control stream:
     # IF(SAMPLING == 2) FRAC_ = TVFRAC_).
     logitfslowTv <- logitfslow * ((1 - FORM_TABLET) + e_form_tablet_fslow * FORM_TABLET)
-    fslow        <- 1 / (1 + exp(-(logitfslowTv + etalogitfslow * SAMPLE_INTENSIVE)))
+    fslow        <- expit(logitfslowTv + etalogitfslow * SAMPLE_INTENSIVE)
 
     # Parallel absorption rates. Both carry the dose power effect and the
     # tablet ratio, and both share the single random effect on the slow rate,

--- a/inst/modeldb/specificDrugs/Jung_2024_clopidogrel.R
+++ b/inst/modeldb/specificDrugs/Jung_2024_clopidogrel.R
@@ -401,8 +401,8 @@ Jung_2024_clopidogrel <- function() {
                     e_cyp2c19_pm_logitfm1 * CYP2C19_PM + etalogitfm1
     logitfm2_ind <- logitfm2 + e_cyp2c19_im_logitfm2 * CYP2C19_IM +
                     e_cyp2c19_pm_logitfm2 * CYP2C19_PM + etalogitfm2
-    fm1 <- 1 / (1 + exp(-logitfm1_ind))
-    fm2 <- 1 / (1 + exp(-logitfm2_ind))
+    fm1 <- expit(logitfm1_ind)
+    fm2 <- expit(logitfm2_ind)
 
     # ------------------------------------------------------------------
     # Metabolite PK parameters

--- a/inst/modeldb/specificDrugs/Karakitsios_2025_bedaquiline_human_pbpk.R
+++ b/inst/modeldb/specificDrugs/Karakitsios_2025_bedaquiline_human_pbpk.R
@@ -269,7 +269,7 @@ Karakitsios_2025_bedaquiline_human_pbpk <- function() {
     # 2. Individual plasma parameters.
     # -------------------------------------------------------------------
     mat <- exp(lmat + etalmat)
-    fr  <- 1 / (1 + exp(-logitfmat))
+    fr  <- expit(logitfmat)
     mtt <- mat * fr
     ka  <- log(2) / (mat * (1 - fr) / 3.3)
     ktr <- 2 / mtt

--- a/inst/modeldb/specificDrugs/Keunecke_2020_regorafenib_phase1.R
+++ b/inst/modeldb/specificDrugs/Keunecke_2020_regorafenib_phase1.R
@@ -166,8 +166,8 @@ Keunecke_2020_regorafenib_phase1 <- function() {
     # because fm_m2 rescales them (step 2).
     logitfm_m2_ind <- logitfm_m2 + etalogitfm_m2
     logitfm_m5_ind <- logitfm_m5 + etalogitfm_m5
-    fm_m2 <- 1 / (1 + exp(-logitfm_m2_ind))
-    fm_m5 <- 1 / (1 + exp(-logitfm_m5_ind))
+    fm_m2 <- expit(logitfm_m2_ind)
+    fm_m5 <- expit(logitfm_m5_ind)
 
     # 2. Individual parameters. The parent rows of Table 2 are tabulated as the
     #    composites CL_P/(1-FRM2), VC_P/(1-FRM2), Q_P/(1-FRM2) and

--- a/inst/modeldb/specificDrugs/Keunecke_2020_regorafenib_phase3.R
+++ b/inst/modeldb/specificDrugs/Keunecke_2020_regorafenib_phase3.R
@@ -266,8 +266,8 @@ Keunecke_2020_regorafenib_phase3 <- function() {
     #    rescales them (step 3).
     logitfm_m2_ind <- logitfm_m2 + etalogitfm_m2
     logitfm_m5_ind <- logitfm_m5 + etalogitfm_m5
-    fm_m2 <- 1 / (1 + exp(-logitfm_m2_ind))
-    fm_m5 <- 1 / (1 + exp(-logitfm_m5_ind))
+    fm_m2 <- expit(logitfm_m2_ind)
+    fm_m5 <- expit(logitfm_m5_ind)
 
     # 3. Individual parameters. The parent rows of Table 3 are tabulated as the
     #    composites CL_P/(1-FRM2), VC_P/(1-FRM2), Q_P/(1-FRM2) and

--- a/inst/modeldb/specificDrugs/Kong_2025_piperacillin_tazobactam.R
+++ b/inst/modeldb/specificDrugs/Kong_2025_piperacillin_tazobactam.R
@@ -582,8 +582,8 @@ Kong_2025_piperacillin_tazobactam <- function() {
       (logitedia_taz_avf1n - logitedia_taz) * VASCACC_AVF1N +
       (logitedia_taz_avf2n - logitedia_taz) * VASCACC_AVF2N
 
-    edia     <- exp(logitedia)       / (1 + exp(logitedia))
-    edia_taz <- exp(logitedia_taz_i) / (1 + exp(logitedia_taz_i))
+    edia     <- expit(logitedia)
+    edia_taz <- expit(logitedia_taz_i)
 
     bfr_lph <- BFR * 60 / 1000  # ESM $PK 'FLOW = IFLOW*60/1000' -- mL/min to L/h
 

--- a/inst/modeldb/specificDrugs/Kurup_2024_DZIF10c.R
+++ b/inst/modeldb/specificDrugs/Kurup_2024_DZIF10c.R
@@ -204,7 +204,7 @@ Kurup_2024_DZIF10c <- function() {
     phih <- logitfdepot + etalogitfdepot
     phim <- logitfdepot_macaque + etalogitfdepot_macaque
     logitfinh <- phih * (1 - SPECIES_MACAQUE) + phim * SPECIES_MACAQUE
-    finh <- exp(logitfinh) / (1 + exp(logitfinh))
+    finh <- expit(logitfinh)
 
     # Individual parameters. Every clearance carries the 0.85 exponent and
     # every volume the 1.0 exponent, both on WT/70, for humans and macaques

--- a/inst/modeldb/specificDrugs/Lallemand_2023_benzylpenicillin_horse.R
+++ b/inst/modeldb/specificDrugs/Lallemand_2023_benzylpenicillin_horse.R
@@ -386,15 +386,15 @@ Lallemand_2023_benzylpenicillin_horse <- function() {
       e_study_sweden_im_fdepot_proc * STUDY_SWEDEN_IM +
         e_study_usa1_fdepot_proc * STUDY_USA1 +
         e_study_japan_fdepot_proc * STUDY_JAPAN) + etalogitfdepot_proc
-    f_proc <- 1 / (1 + exp(-logit_f_proc))
+    f_proc <- expit(logit_f_proc)
 
     # Depots 3 and 4, Duplocilline: two parallel prodrug fractions
     ka_duplo_pro <- exp(lka_duplo_pro + etalka_duplo_pro)
     ka_duplo_benza <- exp(lka_duplo_benza + etalka_duplo_benza)
     logit_f_duplo_pro <- logitfdepot_duplo_pro + etalogitfdepot_duplo_pro
     logit_f_duplo_benza <- logitfdepot_duplo_benza + etalogitfdepot_duplo_benza
-    f_duplo_pro <- 1 / (1 + exp(-logit_f_duplo_pro))
-    f_duplo_benza <- 1 / (1 + exp(-logit_f_duplo_benza))
+    f_duplo_pro <- expit(logit_f_duplo_pro)
+    f_duplo_benza <- expit(logit_f_duplo_benza)
 
     # Depots 5-7, penethamate: one sequential Ka pair per injection site
     ka_peneth1 <- exp(lka_peneth1 + etalka_peneth1)
@@ -407,7 +407,7 @@ Lallemand_2023_benzylpenicillin_horse <- function() {
     ka2_peneth3 <- exp(lka2_peneth3 + etalka2_peneth3)
     tlag_peneth3 <- exp(ltlag_peneth3)
     logit_f_peneth <- logitfdepot_peneth + etalogitfdepot_peneth
-    f_peneth <- 1 / (1 + exp(-logit_f_peneth))
+    f_peneth <- expit(logit_f_peneth)
 
     # -------------------------------------------------------------------
     # Sequential-absorption switches. tad(<depot>) is the time since that

--- a/inst/modeldb/specificDrugs/Li_2019_abatacept.R
+++ b/inst/modeldb/specificDrugs/Li_2019_abatacept.R
@@ -169,7 +169,7 @@ Li_2019_abatacept <- function() {
     # formulation indicator is additive on the logit scale. F_abs is bounded
     # in (0, 1) via the inverse logit.
     logit_f <- logitfdepot + etalogitfdepot + FORM_ABA_PHASE2 * e_form_f
-    fdepot  <- 1 / (1 + exp(-logit_f))
+    fdepot  <- expit(logit_f)
 
     # Two-compartment PK; IV doses go directly to central, SC doses to depot
     # with bioavailability fdepot.

--- a/inst/modeldb/specificDrugs/Lim_2026_leuprolide.R
+++ b/inst/modeldb/specificDrugs/Lim_2026_leuprolide.R
@@ -278,7 +278,7 @@ Lim_2026_leuprolide <- function() {
     ntr <- exp(lntr)
 
     # FRAC on the natural scale; F2 = 1 - FRAC is the delayed fraction.
-    ffo <- 1 / (1 + exp(-logitffo))
+    ffo <- expit(logitffo)
 
     # ---------------- Micro-constants ---------------------------------------
     kel <- cl / vc # Results: K30_i = CL_i / V_i

--- a/inst/modeldb/specificDrugs/Ma_2020_sarilumab_das28crp.R
+++ b/inst/modeldb/specificDrugs/Ma_2020_sarilumab_das28crp.R
@@ -191,7 +191,7 @@ Ma_2020_sarilumab_das28crp <- function() {
             (BLHAQ    / 1.75)^e_blhaq_base    *
             (WT       / 72.8)^e_wt_base
     lemax_i <- lemax + etalemax + e_crp_lemax * log(CRP / 15.7)
-    emax    <- 1 / (1 + exp(-lemax_i))
+    emax    <- expit(lemax_i)
     ic50    <- exp(lic50 + etalic50)
     kout    <- exp(lkout + etalkout) * e_pricort_kout^PRICORT
     PLB     <- exp(lPLB  + etalPLB)

--- a/inst/modeldb/specificDrugs/Mann_2022_carfentanil_iv.R
+++ b/inst/modeldb/specificDrugs/Mann_2022_carfentanil_iv.R
@@ -187,7 +187,9 @@ Mann_2022_carfentanil_iv <- function() {
     # See Q_TOTAL_LPM covariate documentation; standalone use leaves
     # q_scale ~ 1, composed use lets it saturate toward 2 during
     # carfentanil-induced hyperperfusion.
-    q_scale_raw <- 1 + 1 / (1 + exp((1.6 - Q_TOTAL_LPM / 4.87) / 0.05))
+    # expit(-x) is identical to the 1/(1+exp(x)) form the `reference`
+    # string quotes verbatim from the paper; the quote is left as printed.
+    q_scale_raw <- 1 + expit(-((1.6 - Q_TOTAL_LPM / 4.87) / 0.05))
     q_scale <- (q_scale_raw < 1) * 1 + (q_scale_raw > 2) * 2 +
                (q_scale_raw >= 1) * (q_scale_raw <= 2) * q_scale_raw
     vc_eff <- vc / q_scale

--- a/inst/modeldb/specificDrugs/Mann_2022_fentanyl_iv.R
+++ b/inst/modeldb/specificDrugs/Mann_2022_fentanyl_iv.R
@@ -190,7 +190,9 @@ Mann_2022_fentanyl_iv <- function() {
     # the hyperperfusion-driven Q rises above baseline during overdose,
     # q_scale saturates toward 2, vc_eff = vc / q_scale halves, and the
     # effect-site concentration doubles.
-    q_scale_raw <- 1 + 1 / (1 + exp((1.6 - Q_TOTAL_LPM / 4.87) / 0.05))
+    # expit(-x) is identical to the 1/(1+exp(x)) form the `reference`
+    # string quotes verbatim from the paper; the quote is left as printed.
+    q_scale_raw <- 1 + expit(-((1.6 - Q_TOTAL_LPM / 4.87) / 0.05))
     q_scale <- (q_scale_raw < 1) * 1 + (q_scale_raw > 2) * 2 +
                (q_scale_raw >= 1) * (q_scale_raw <= 2) * q_scale_raw
     vc_eff <- vc / q_scale

--- a/inst/modeldb/specificDrugs/Martinez_2019_alirocumab.R
+++ b/inst/modeldb/specificDrugs/Martinez_2019_alirocumab.R
@@ -126,7 +126,7 @@ Martinez_2019_alirocumab <- function() {
 
     # Bioavailability on logit scale with IIV (logit-space).
     logit_f <- logitfdepot + etalogitfdepot
-    fdepot  <- 1 / (1 + exp(-logit_f))
+    fdepot  <- expit(logit_f)
 
     # Absorption lag time (no IIV).
     lag <- exp(ltlag)

--- a/inst/modeldb/specificDrugs/Mercier_2014_tramadol_tapentadol_mbma.R
+++ b/inst/modeldb/specificDrugs/Mercier_2014_tramadol_tapentadol_mbma.R
@@ -175,7 +175,7 @@ Mercier_2014_tramadol_tapentadol_mbma <- function() {
 
     # 5. Observed pain intensity on the 0-10 scale (paper Eq. 1).
     latent  <- base_arm + r_arm * (1 - exp(-kel * time))
-    score   <- 10 * exp(latent) / (1 + exp(latent))
+    score   <- 10 * expit(latent)
 
     # 6. Additive residual on the observed 0-10 scale. Per-arm
     # sample-size weighting (SD -> addSd / sqrt(N)) is applied

--- a/inst/modeldb/specificDrugs/Mitra_2026_ziftomenib.R
+++ b/inst/modeldb/specificDrugs/Mitra_2026_ziftomenib.R
@@ -195,7 +195,7 @@ Mitra_2026_ziftomenib <- function() {
     logitfdepot_i <- logitfdepot +
                e_fed_logitfdepot        * FED +
                e_conmed_ppi_logitfdepot * CONMED_PPI
-    fd      <- 1 / (1 + exp(-logitfdepot_i))
+    fd      <- expit(logitfdepot_i)
 
     # Metabolites (KO-739 and KO-516).
     q_ko739  <- exp(lq_ko739  + etalq_ko739)
@@ -218,7 +218,7 @@ Mitra_2026_ziftomenib <- function() {
     # relative abundance (Kura Oncology Inc., data on file per Table 1
     # footnote d); no covariate and no IIV.
     logitfm_ind   <- logitfm + e_dis_healthy_logitfm * DIS_HEALTHY + etalogitfm
-    fm            <- 1 / (1 + exp(-logitfm_ind))
+    fm            <- expit(logitfm_ind)
     fm_ko516_frac <- 0.5
 
     # ==================== Micro-rate constants ====================

--- a/inst/modeldb/specificDrugs/Na_2025_hosu53_dog.R
+++ b/inst/modeldb/specificDrugs/Na_2025_hosu53_dog.R
@@ -172,7 +172,7 @@ Na_2025_hosu53_dog <- function() {
     # F is logit-normal (Section 2.5); the remaining parameters are
     # log-normal. CL carries the IIV that was fixed from the IV-only fit.
     logit_f <- logitfdepot + etalogitfdepot
-    fdepot  <- 1 / (1 + exp(-logit_f))
+    fdepot  <- expit(logit_f)
     ka     <- exp(lka + etalka)
     cl     <- exp(lcl + etalcl)
     vc     <- exp(lvc)

--- a/inst/modeldb/specificDrugs/Na_2025_hosu53_mouse.R
+++ b/inst/modeldb/specificDrugs/Na_2025_hosu53_mouse.R
@@ -160,7 +160,7 @@ Na_2025_hosu53_mouse <- function() {
     # --- Individual PK parameters -------------------------------------
     # F is logit-normal (Section 2.5) but carries no IIV in the mouse fit;
     # the remaining parameters are log-normal.
-    fdepot <- 1 / (1 + exp(-logitfdepot))
+    fdepot <- expit(logitfdepot)
     ka     <- exp(lka)
     cl     <- exp(lcl + etalcl)
     vc     <- exp(lvc + etalvc)

--- a/inst/modeldb/specificDrugs/Nagy_2017_obiltoxaximab_survival.R
+++ b/inst/modeldb/specificDrugs/Nagy_2017_obiltoxaximab_survival.R
@@ -137,7 +137,7 @@ Nagy_2017_obiltoxaximab_survival <- function() {
     doseTerm <- emax * DOSE_OBILTOXAXIMAB_MGKG / (ed50 + DOSE_OBILTOXAXIMAB_MGKG)
 
     logitPsurv <- theta0 - bactTerm + doseTerm
-    psurv <- 1 / (1 + exp(-logitPsurv))
+    psurv <- expit(logitPsurv)
 
     # ------------------------------------------------------------------
     # 2. Weibull death rate for the non-cured fraction.

--- a/inst/modeldb/specificDrugs/Park_2025_efineptakin_alfa.R
+++ b/inst/modeldb/specificDrugs/Park_2025_efineptakin_alfa.R
@@ -312,7 +312,7 @@ Park_2025_efineptakin_alfa <- function() {
     # Both depots must be dosed with the FULL amount; the f() values do the
     # splitting. The lag applies to depot 2 only, which is what separates the
     # two absorption peaks.
-    fr1        <- exp(logitfdepot) / (1 + exp(logitfdepot))
+    fr1        <- expit(logitfdepot)
     f(depot)   <- bioa * fr1
     f(depot2)  <- bioa * (1 - fr1)
     alag(depot2) <- tlag

--- a/inst/modeldb/specificDrugs/Patel_2015_oseltamivir.R
+++ b/inst/modeldb/specificDrugs/Patel_2015_oseltamivir.R
@@ -241,7 +241,7 @@ Patel_2015_oseltamivir <- function() {
     #    from the logit scale so it is bounded in (0, 1) for every subject.
     # ------------------------------------------------------------------
     logitfm_ind <- logitfm + etalogitfm
-    fm          <- 1 / (1 + exp(-logitfm_ind))
+    fm          <- expit(logitfm_ind)
 
     # ------------------------------------------------------------------
     # 2. Individual parameters. Clearances scale as (WT/70)^0.75 and volumes

--- a/inst/modeldb/specificDrugs/Paule_2011_hydroxyurea.R
+++ b/inst/modeldb/specificDrugs/Paule_2011_hydroxyurea.R
@@ -172,7 +172,7 @@ Paule_2011_hydroxyurea <- function() {
     kin_hbf       <- exp(lkin_hbf  + etalkin_hbf)
     kout_hbf      <- exp(lkout_hbf + etalkout_hbf)
     logit_imax    <- logitimax_hbf + etalogitimax_hbf
-    imax_hbf      <- 1 / (1 + exp(-logit_imax))
+    imax_hbf      <- expit(logit_imax)
     inhib_hbf     <- imax_hbf * Cc / (Cc + 0.005)
 
     # Off-drug steady state: effect1(SS) = kin_hbf / kout_hbf (matches the

--- a/inst/modeldb/specificDrugs/PerezRuixo_2020_esketamine.R
+++ b/inst/modeldb/specificDrugs/PerezRuixo_2020_esketamine.R
@@ -244,7 +244,7 @@ PerezRuixo_2020_esketamine <- function() {
     # externally for 56-/84-/112-mg doses by averaging across sprays:
     #   FRn_effective = FRn * (1 + (N_sprays - 1) * dose_FRn_effect) / N_sprays
     FRn_logit <- logitFRn + etalogitFRn
-    FRn_per_spray <- 1 / (1 + exp(-FRn_logit))
+    FRn_per_spray <- expit(FRn_logit)
     FRn <- FRn_per_spray * (e_japanese_FRn ^ RACE_JAPANESE)
     dose_FRn_effect_export <- dose_FRn_effect  # documented in ini(); not applied dynamically
 
@@ -254,7 +254,7 @@ PerezRuixo_2020_esketamine <- function() {
     ka_sw  <- exp(lka_sw  + etalka_sw)
     Dpo    <- exp(lDpo)
     ka_po  <- exp(lka_po  + etalka_po)
-    Fgut   <- 1 / (1 + exp(-lFgut))
+    Fgut   <- expit(lFgut)
     Vc     <- exp(lvc     + etalvc)
     Q1     <- exp(lq1)
     Vp     <- exp(lvp     + etalvp)

--- a/inst/modeldb/specificDrugs/Perlstein_2026_olanzapine_lai.R
+++ b/inst/modeldb/specificDrugs/Perlstein_2026_olanzapine_lai.R
@@ -225,7 +225,7 @@ Perlstein_2026_olanzapine_lai <- function() {
     # etalogitfrel defaulted to non-mu-referenced); same shape as the
     # logitfm_ind idiom registered in parameter-names.md.
     logitfrel_ind <- logitfrel + etalogitfrel
-    frel <- 1 / (1 + exp(-logitfrel_ind))
+    frel <- expit(logitfrel_ind)
 
     # 2. Individual disposition parameters, allometrically scaled to the
     #    70 kg reference weight.

--- a/inst/modeldb/specificDrugs/Reinecke_2018_levonorgestrel_implant.R
+++ b/inst/modeldb/specificDrugs/Reinecke_2018_levonorgestrel_implant.R
@@ -180,7 +180,7 @@ Reinecke_2018_levonorgestrel_implant <- function() {
     kout_shbg  <- exp(lkout_shbg)
     kin_shbg   <- rbase_shbg * kout_shbg
 
-    fdepot <- exp(logitfdepot) / (1 + exp(logitfdepot))
+    fdepot <- expit(logitfdepot)
 
     A3nM  <- (central / vc) * (1e6 / MWLNG) + 1e-6
     temp1 <- KALB * KDS + shbg - A3nM

--- a/inst/modeldb/specificDrugs/Reinecke_2018_levonorgestrel_lngIus12.R
+++ b/inst/modeldb/specificDrugs/Reinecke_2018_levonorgestrel_lngIus12.R
@@ -184,7 +184,7 @@ Reinecke_2018_levonorgestrel_lngIus12 <- function() {
     kout_shbg  <- exp(lkout_shbg)
     kin_shbg   <- rbase_shbg * kout_shbg
 
-    fdepot <- exp(logitfdepot) / (1 + exp(logitfdepot))
+    fdepot <- expit(logitfdepot)
 
     A3nM  <- (central / vc) * (1e6 / MWLNG) + 1e-6
     temp1 <- KALB * KDS + shbg - A3nM

--- a/inst/modeldb/specificDrugs/Reinecke_2018_levonorgestrel_lngIus20.R
+++ b/inst/modeldb/specificDrugs/Reinecke_2018_levonorgestrel_lngIus20.R
@@ -219,7 +219,7 @@ Reinecke_2018_levonorgestrel_lngIus20 <- function() {
     kin_shbg   <- rbase_shbg * kout_shbg
 
     # Absolute bioavailability of the reservoir (logit scale).
-    fdepot <- exp(logitfdepot) / (1 + exp(logitfdepot))
+    fdepot <- expit(logitfdepot)
 
     # Free fraction of levonorgestrel; see the ivOral model file for the
     # unit derivation of A3nM.

--- a/inst/modeldb/specificDrugs/Reinecke_2018_levonorgestrel_lngIus8.R
+++ b/inst/modeldb/specificDrugs/Reinecke_2018_levonorgestrel_lngIus8.R
@@ -181,7 +181,7 @@ Reinecke_2018_levonorgestrel_lngIus8 <- function() {
     kout_shbg  <- exp(lkout_shbg)
     kin_shbg   <- rbase_shbg * kout_shbg
 
-    fdepot <- exp(logitfdepot) / (1 + exp(logitfdepot))
+    fdepot <- expit(logitfdepot)
 
     A3nM  <- (central / vc) * (1e6 / MWLNG) + 1e-6
     temp1 <- KALB * KDS + shbg - A3nM

--- a/inst/modeldb/specificDrugs/Robarge_2017_efavirenz.R
+++ b/inst/modeldb/specificDrugs/Robarge_2017_efavirenz.R
@@ -245,7 +245,7 @@ Robarge_2017_efavirenz <- function() {
     # Robarge 2017 final-model equations (Table 2 footnote a):
     #   CL/F = CL_TV * (FFM/56)^(3/4) * factor_CYP2B6  for normal metabolizer factor = 1
     #   V_p/F = V_p,TV * (FM/19)^1
-    f1     <- 1 / (1 + exp(-logitfdepot))           # F1 ~= 0.414 (fixed)
+    f1     <- expit(logitfdepot)           # F1 ~= 0.414 (fixed)
     ka     <- exp(lka     + etalka)
     tlag1  <- exp(ltlag1  + etaltlag1)
     tlag2  <- exp(ltlag2  + etaltlag2)

--- a/inst/modeldb/specificDrugs/Roepcke_2018_tak_079.R
+++ b/inst/modeldb/specificDrugs/Roepcke_2018_tak_079.R
@@ -220,7 +220,7 @@ Roepcke_2018_tak_079 <- function() {
     # =========================================================================
 
     # Bioavailability (logit -> fraction). Only applies to depot dosing (SC).
-    fdepot <- exp(logitfdepot) / (1 + exp(logitfdepot))
+    fdepot <- expit(logitfdepot)
 
     # Individual PK parameters. Route effect: SC reduces Vc to ~30% of the IV
     # typical value; IV is the reference (ROUTE_IV = 1).

--- a/inst/modeldb/specificDrugs/Savic_2017_cladribine.R
+++ b/inst/modeldb/specificDrugs/Savic_2017_cladribine.R
@@ -140,7 +140,7 @@ Savic_2017_cladribine <- function() {
     # Individual absorption parameters
     ka          <- exp(lka + e_fed_ka * FED + etalka)
     logitf_ind  <- logitf + e_fed_logitf * FED + etalogitf
-    f_oral      <- 1 / (1 + exp(-logitf_ind))
+    f_oral      <- expit(logitf_ind)
     tlag_depot  <- exp(lmtt_fed) * FED
 
     # Individual clearances

--- a/inst/modeldb/specificDrugs/Schmidt_2009_linezolid.R
+++ b/inst/modeldb/specificDrugs/Schmidt_2009_linezolid.R
@@ -172,7 +172,7 @@ Schmidt_2009_linezolid <- function() {
     dks   <- exp(ldks  + etaldks)
     ksp   <- exp(lksp)
     kd    <- exp(lkd)
-    fsusc <- exp(logitf) / (1 + exp(logitf))   # back-transform logit -> initial susceptible fraction
+    fsusc <- expit(logitf)   # back-transform logit -> initial susceptible fraction
     ninit <- exp(lninit)
 
     # ---- Time-varying turn-on terms for growth and killing ----

--- a/inst/modeldb/specificDrugs/Schmidt_2009_rwj416457.R
+++ b/inst/modeldb/specificDrugs/Schmidt_2009_rwj416457.R
@@ -170,7 +170,7 @@ Schmidt_2009_rwj416457 <- function() {
     dks   <- exp(ldks  + etaldks)
     ksp   <- exp(lksp)
     kd    <- exp(lkd)
-    fsusc <- exp(logitf) / (1 + exp(logitf))   # back-transform logit -> initial susceptible fraction
+    fsusc <- expit(logitf)   # back-transform logit -> initial susceptible fraction
     ninit <- exp(lninit)
 
     # ---- Time-varying turn-on terms for growth and killing ----

--- a/inst/modeldb/specificDrugs/Sheng_2016_quinine_rat.R
+++ b/inst/modeldb/specificDrugs/Sheng_2016_quinine_rat.R
@@ -176,7 +176,7 @@ Sheng_2016_quinine_rat <- function() {
     # ------------------------------------------------------------------
     drugEmax <- emax_i * (conc^c_i) / (RIC50_i^c_i + conc^c_i)
     E        <- e0_i + drugEmax + etae
-    p_low    <- exp(E) / (1 + exp(E))
+    p_low    <- expit(E)
     p_high   <- 1 - p_low
 
     # ------------------------------------------------------------------

--- a/inst/modeldb/specificDrugs/Shoji_2017_fosdagrocorat_p1np.R
+++ b/inst/modeldb/specificDrugs/Shoji_2017_fosdagrocorat_p1np.R
@@ -135,7 +135,7 @@ Shoji_2017_fosdagrocorat_p1np <- function() {
 
     # ---- Individual parameters ----
     kel   <- exp(lkel_active + etalkel)
-    imax  <- 1 / (1 + exp(-logitimax_active))
+    imax  <- expit(logitimax_active)
     edk50 <- exp(ledk50_active + etaledk50)
     kd    <- exp(lkd)
     rbase    <- exp(lrbase + etalrbase)

--- a/inst/modeldb/specificDrugs/Siccardi_2012_efavirenz.R
+++ b/inst/modeldb/specificDrugs/Siccardi_2012_efavirenz.R
@@ -295,8 +295,8 @@ Siccardi_2012_efavirenz <- function() {
     # 7. Exposure-response (Siccardi 2012 Equation 1). Two independent
     #    binary logistic regressions on log10(C8-16h).
     lc816 <- log10(max(c816, 1e-12))
-    psupp <- 1 / (1 + exp(-(logite0_supp + e_c816_supp * lc816)))
-    pcns  <- 1 / (1 + exp(-(logite0_cns  + e_c816_cns  * lc816)))
+    psupp <- expit(logite0_supp + e_c816_supp * lc816)
+    pcns  <- expit(logite0_cns  + e_c816_cns  * lc816)
 
     # 8. Residual error: proportional structure, magnitude unpublished.
     Cc ~ prop(propSd)

--- a/inst/modeldb/specificDrugs/Suleiman_2019_risankizumab.R
+++ b/inst/modeldb/specificDrugs/Suleiman_2019_risankizumab.R
@@ -162,7 +162,7 @@ Suleiman_2019_risankizumab <- function() {
     # (Suleiman 2019 Eq. 2). The default logitfdepot uses the phase III
     # drug-supply value (logit 2.09, F = 0.890).
     logit_f  <- logitfdepot + etalogitfdepot
-    fdepot   <- exp(logit_f) / (1 + exp(logit_f))
+    fdepot   <- expit(logit_f)
     f(depot) <- fdepot
 
     # Concentration: dose in mg, volume in L -> mg/L = ug/mL.

--- a/inst/modeldb/specificDrugs/Tang_2026_vixarelimab.R
+++ b/inst/modeldb/specificDrugs/Tang_2026_vixarelimab.R
@@ -192,7 +192,7 @@ Tang_2026_vixarelimab <- function() {
     # Logit-scale bioavailability; the fixed effect and eta are collected on their
     # own line so the term stays in a mu-referenced position.
     logitfdepot_ind <- logitfdepot + etalogitfdepot
-    fdepot <- exp(logitfdepot_ind) / (1 + exp(logitfdepot_ind))
+    fdepot <- expit(logitfdepot_ind)
 
     # ---- Micro-constants (Section 2.4 definitions) ----
     kel  <- cl / vc   # elimination rate constant from the central compartment

--- a/inst/modeldb/specificDrugs/Thakkar_2017_amifampridine.R
+++ b/inst/modeldb/specificDrugs/Thakkar_2017_amifampridine.R
@@ -213,7 +213,7 @@ Thakkar_2017_amifampridine <- function() {
     # population logit plus a normal-distributed individual deviation.
     # ------------------------------------------------------------
     logit_emax_i <- logitemax + etalogitemax
-    emax <- exp(logit_emax_i) / (1 + exp(logit_emax_i))
+    emax <- expit(logit_emax_i)
     ec50 <- exp(lec50 + etalec50)
     e0   <- exp(le0   + etale0)
     tug3 <- e0 * (1 - emax * Cc / (ec50 + Cc))

--- a/inst/modeldb/specificDrugs/Tiraboschi_2025_amlitelimab.R
+++ b/inst/modeldb/specificDrugs/Tiraboschi_2025_amlitelimab.R
@@ -102,10 +102,10 @@ Tiraboschi_2025_amlitelimab <- function() {
     # Fsc: population on logit scale -> invert to linear, add additive albumin term, re-logit, then apply the logit-scale eta
     # (Tiraboschi 2025 Table S2 footnote f: Fsc = TVFsc + 0.598 * ((BALB/47) - 1); the source NONMEM code then uses
     # F1 = exp(PHI + ETAF1) / (1 + exp(PHI + ETAF1)) with PHI = log(Fsc / (1 - Fsc)).)
-    f1_typ_lin <- exp(logitfdepot) / (1 + exp(logitfdepot))
+    f1_typ_lin <- expit(logitfdepot)
     f1_cov_lin <- f1_typ_lin + e_alb_f1 * ((ALB / 47) - 1)
     phi_f1     <- log(f1_cov_lin / (1 - f1_cov_lin))
-    f1         <- exp(phi_f1 + etalogitfdepot) / (1 + exp(phi_f1 + etalogitfdepot))
+    f1         <- expit(phi_f1 + etalogitfdepot)
 
     # Micro-constants
     kel <- cl / vc

--- a/inst/modeldb/specificDrugs/Tsuji_2017_linezolid.R
+++ b/inst/modeldb/specificDrugs/Tsuji_2017_linezolid.R
@@ -246,8 +246,8 @@ Tsuji_2017_linezolid <- function() {
 
     tabs <- exp(ltabs)
     ka   <- log(2) / tabs                        # ka = ln(2) / Tabs per Tsuji 2017 Methods
-    fdepot <- 1 / (1 + exp(-logitfdepot))        # back-transform bioavailability
-    fu     <- 1 / (1 + exp(-logitfu))            # back-transform fraction unbound
+    fdepot <- expit(logitfdepot)        # back-transform bioavailability
+    fu     <- expit(logitfu)            # back-transform fraction unbound
 
     kel <- cl / vc
     k12 <- q  / vc

--- a/inst/modeldb/specificDrugs/Wagh_2021_spectinamide_1810_mouse.R
+++ b/inst/modeldb/specificDrugs/Wagh_2021_spectinamide_1810_mouse.R
@@ -256,7 +256,7 @@ Wagh_2021_spectinamide_1810_mouse <- function() {
     #    drug at the aerosol infection time.
     # -----------------------------------------------------------------------
     k_load_pae <- 100
-    weight_up  <- 1 / (1 + exp(-50 * (Cc - effect)))
+    weight_up  <- expit(50 * (Cc - effect))
     d/dt(effect) <- k_load_pae * weight_up * (Cc - effect) - kpae * effect
     Cpae <- effect
 

--- a/inst/modeldb/specificDrugs/Wattanakul_2024_primaquine.R
+++ b/inst/modeldb/specificDrugs/Wattanakul_2024_primaquine.R
@@ -219,7 +219,7 @@ Wattanakul_2024_primaquine <- function() {
     q_milk  <- exp(lq_milk + etalq_milk)
 
     # Inverse-logit back-transform of the first-pass metabolised fraction.
-    fm <- exp(logitfm + etalogitfm) / (1 + exp(logitfm + etalogitfm))
+    fm <- expit(logitfm + etalogitfm)
 
     # Transit-chain rate constant. NN = 4 transit compartments and ka is
     # set equal to ktr, so KTR = (NN + 1) / MTT = 5 / MTT.

--- a/inst/modeldb/specificDrugs/Wattanakul_2024_primaquine_motherinfant.R
+++ b/inst/modeldb/specificDrugs/Wattanakul_2024_primaquine_motherinfant.R
@@ -204,7 +204,7 @@ Wattanakul_2024_primaquine_motherinfant <- function() {
     vc_cpq  <- exp(lvc_cpq + etalvc_cpq) * (WT / 51)^e_wt_vc
     mtt     <- exp(lmtt    + etalmtt + iov_mtt)
     q_milk  <- exp(lq_milk + etalq_milk)
-    fm      <- exp(logitfm + etalogitfm) / (1 + exp(logitfm + etalogitfm))
+    fm      <- expit(logitfm + etalogitfm)
     ktr     <- 5 / mtt
     vmilk   <- (milk_intake * WT_INFANT) / feed_n
 

--- a/inst/modeldb/specificDrugs/Weber_2015_fluticasone_inhaled.R
+++ b/inst/modeldb/specificDrugs/Weber_2015_fluticasone_inhaled.R
@@ -143,8 +143,8 @@ Weber_2015_fluticasone_inhaled <- function() {
     # recognises the eta as mu-referenced (Aguiar 2021 ustekinumab pattern).
     logit_flung_i <- logitflung + etalogitflung
     logit_fc_i    <- logitfc    + etalogitfc
-    flung <- 1 / (1 + exp(-logit_flung_i))
-    fc    <- 1 / (1 + exp(-logit_fc_i))
+    flung <- expit(logit_flung_i)
+    fc    <- expit(logit_fc_i)
     kdiss <- exp(lkdiss + etalkdiss)
     kmuc  <- exp(lkmuc  + etalkmuc)
     kpulc <- exp(lkpulc + etalkpulc)

--- a/inst/modeldb/specificDrugs/Xie_2019_agomelatine.R
+++ b/inst/modeldb/specificDrugs/Xie_2019_agomelatine.R
@@ -159,7 +159,7 @@ Xie_2019_agomelatine <- function () {
     alag2 <- exp(ltvalag2 + etaltvalag2 + iov_alag2)
 
     expp <- log(fpop/(1 - fpop)) + etafpop
-    fDepot <- exp(expp + iov_fpop)/(1 + exp(expp + iov_fpop))
+    fDepot <- expit(expp + iov_fpop)
     fDepot2 <- 1 - fDepot
     lv <- 0.05012 * WT^0.78
     v3 <- lv

--- a/inst/modeldb/specificDrugs/Yoshida_2024_fazpilodemab.R
+++ b/inst/modeldb/specificDrugs/Yoshida_2024_fazpilodemab.R
@@ -195,8 +195,8 @@ Yoshida_2024_fazpilodemab <- function() {
     lgt1     <- b1_dtmm + slp_ae * Cc
     lgt2     <- b2_dtmm + slp_ae * Cc
 
-    pge1 <- exp(lgt1) / (1 + exp(lgt1))  # Pr(next grade >= 1 | PREV_AE_SCORE, Cc)
-    pge2 <- exp(lgt2) / (1 + exp(lgt2))  # Pr(next grade >= 2 | PREV_AE_SCORE, Cc)
+    pge1 <- expit(lgt1)  # Pr(next grade >= 1 | PREV_AE_SCORE, Cc)
+    pge2 <- expit(lgt2)  # Pr(next grade >= 2 | PREV_AE_SCORE, Cc)
     p_ae_g0   <- 1    - pge1             # Pr(next grade = 0)
     p_ae_g1   <- pge1 - pge2             # Pr(next grade = 1)
     p_ae_g23  <- pge2                    # Pr(next grade in {2, 3})
@@ -210,7 +210,7 @@ Yoshida_2024_fazpilodemab <- function() {
     b_dc <- (PREV_AE_SCORE == 0) * b_dc_g0 +
             (PREV_AE_SCORE == 1) * b_dc_g1 +
             (PREV_AE_SCORE == 2) * b_dc_g2
-    p_dc <- exp(b_dc) / (1 + exp(b_dc))
+    p_dc <- expit(b_dc)
 
     # ---------- Observation and residual error ----------
     # Observation is free fazpilodemab concentration in central (ug/mL).

--- a/inst/modeldb/specificDrugs/Yoshioka_2018_FXa_inhibitors_mbma.R
+++ b/inst/modeldb/specificDrugs/Yoshioka_2018_FXa_inhibitors_mbma.R
@@ -84,8 +84,8 @@ Yoshioka_2018_FXa_inhibitors_mbma <- function() {
     logit_p_mb    <- plc_mb + theta3 * log(PTR)
 
     # Event probabilities on the [0, 1] scale
-    p_isse <- 1 / (1 + exp(-logit_p_isse))
-    p_mb   <- 1 / (1 + exp(-logit_p_mb))
+    p_isse <- expit(logit_p_isse)
+    p_mb   <- expit(logit_p_mb)
 
     # Derived mortality probabilities per Yoshioka 2018 Eq. 3:
     # P_death = w_isse * P_ISSE + w_mb * P_MB

--- a/inst/modeldb/specificDrugs/Yu_2022_ofatumumab.R
+++ b/inst/modeldb/specificDrugs/Yu_2022_ofatumumab.R
@@ -230,7 +230,7 @@ Yu_2022_ofatumumab <- function() {
     # reference; categorical covariates enter as exp(beta * [indicator]).
     ka       <- exp(lka       + etalka)       * (WT / 70)^e_wt_ka
     logit_f  <- logitfdepot + etalogitfdepot
-    fdepot   <- 1 / (1 + exp(-logit_f))
+    fdepot   <- expit(logit_f)
     vc       <- exp(lvc       + etalvc)       * (WT / 70)^e_wt_vc
     kep      <- exp(lkep      + etalkep)      * exp(e_ai_kep      * DEVICE_AI)
     cl       <- exp(lcl       + etalcl)       * (WT / 70)^e_wt_cl    * exp(e_iv_cl       * ROUTE_IV)

--- a/inst/modeldb/specificDrugs/Zhong_2026_abatacept.R
+++ b/inst/modeldb/specificDrugs/Zhong_2026_abatacept.R
@@ -186,7 +186,7 @@ Zhong_2026_abatacept <- function() {
                DIS_PJIA * e_jia_f +
                e_wt_f  * log(WT  / 67.9) +
                e_age_f * log(AGE / 49)
-    fdepot  <- 1 / (1 + exp(-logit_f))
+    fdepot  <- expit(logit_f)
 
     # Two-compartment PK; IV doses go directly to central, SC doses to depot
     # with bioavailability fdepot.

--- a/inst/modeldb/specificDrugs/vandenBerg_2021_uprifosbuvir_pbpk.R
+++ b/inst/modeldb/specificDrugs/vandenBerg_2021_uprifosbuvir_pbpk.R
@@ -300,7 +300,7 @@ vandenBerg_2021_uprifosbuvir_pbpk <- function() {
     # Absorption fast fraction (F1) via logit; F1 baseline = expit(fdos1_logit).
     # Capsule multiplies the pre-logit scalar by e_capsule_fdos1.
     fdos_scaled <- fdos1_logit * (1 + FORM_CAPSULE * (e_capsule_fdos1 - 1))
-    f1_oral     <- exp(fdos_scaled) / (1 + exp(fdos_scaled))
+    f1_oral     <- expit(fdos_scaled)
     f2_oral     <- 1 - f1_oral
 
     # Itraconazole shifts absorption entirely to the slow route (per NONMEM:

--- a/inst/modeldb/specificDrugs/vanderWalt_2013_dapagliflozin.R
+++ b/inst/modeldb/specificDrugs/vanderWalt_2013_dapagliflozin.R
@@ -438,7 +438,7 @@ vanderWalt_2013_dapagliflozin <- function() {
     # logit back-transform; nlmixr2 otherwise warns that the eta is
     # non-mu-referenced because the eta sits inside exp(-...).
     logit_fdepot_i <- logitfdepot + etalogitfdepot
-    fdepot <- 1 / (1 + exp(-logit_fdepot_i))
+    fdepot <- expit(logit_fdepot_i)
 
     # ka collapses the rxode2 transit() output into central without
     # introducing an extra first-order absorption phase that the

--- a/inst/modeldb/therapeuticArea/Choy_2016_T2DM_WHIG.R
+++ b/inst/modeldb/therapeuticArea/Choy_2016_T2DM_WHIG.R
@@ -95,11 +95,11 @@ Choy_2016_T2DM_WHIG <- function() {
     lblwt      <- log(104) ; label("Typical baseline weight (kg)")               # Choy 2016 Table 1
 
     # ----- Insulin sensitivity (Choy 2016 Eq. 5-6) -----
-    is0         <- 1.1         ; label("Baseline insulin sensitivity, logit scale (unitless); IS_baseline = 1/(1+exp(is0))")  # Choy 2016 Table 1; 1.1 -> 25% of normal
+    is0         <- 1.1         ; label("Baseline insulin sensitivity, logit scale (unitless); IS_baseline = expit(-is0)")  # Choy 2016 Table 1; 1.1 -> 25% of normal
     lscaleefs   <- log(0.0514) ; label("Log scaling factor of change in weight on insulin sensitivity (1/kg)")                # Choy 2016 Table 1
 
     # ----- beta-cell function and natural disease progression (Choy 2016 Eq. 7) -----
-    b0 <- -0.446 ; label("Baseline beta-cell function, logit scale (unitless); B_baseline = 1/(1+exp(b0))")  # Choy 2016 Table 1; -0.446 -> 61% of normal
+    b0 <- -0.446 ; label("Baseline beta-cell function, logit scale (unitless); B_baseline = expit(-b0)")  # Choy 2016 Table 1; -0.446 -> 61% of normal
     rb <-  0.209 ; label("Rate of baseline beta-cell function decrease (logits per year)")                   # Choy 2016 Table 1
 
     # ----- Treatment effect on beta-cell function (Choy 2016 Eq. 8-9) -----
@@ -199,16 +199,16 @@ Choy_2016_T2DM_WHIG <- function() {
     # EFS = 1 - scaleefs * dwgt: weight loss (dwgt < 0) raises IS.
     EFS <- 1 - scaleefs_i * dwgt
     # IS_baseline uses the "inverse logit" convention of Choy 2016 (Methods,
-    # FSI-FPG homeostatic feedback model): IS = 1/(1+exp(is0)).
+    # FSI-FPG homeostatic feedback model): IS = expit(-is0).
     # At is0 = 1.1 this gives 0.25 = 25% of normal, matching paper Results.
-    IS_baseline <- 1 / (1 + exp(is0_i))
+    IS_baseline <- expit(-is0_i)
     IS          <- IS_baseline * EFS
 
     # ===== beta-cell function and disease progression (Eq. 7) =====
     # Natural logistic decline of beta-cell function: with rb > 0 the logit
     # grows over time and B decreases.
     B_logit <- b0_i + rb_i * (t / 365)
-    B       <- 1 / (1 + exp(B_logit))
+    B       <- expit(-B_logit)
 
     # ===== Treatment effect on beta-cell function (Eq. 8-9) =====
     # EFB = 1 + efbmax * EFBI(t) * EFBD(t).
@@ -216,8 +216,8 @@ Choy_2016_T2DM_WHIG <- function() {
     # t crosses tTRT; sefbi is negative so the sigmoid is increasing in t).
     # EFBD: logistic decrease centred at t = efb50 (falls from ~1 to ~0 as
     # t crosses efb50; sefbd is positive so the sigmoid is decreasing in t).
-    EFBI <- 1 / (1 + exp(sefbi * (t - tTRT)))
-    EFBD <- 1 / (1 + exp(sefbd * (t - efb50_i)))
+    EFBI <- expit(-(sefbi * (t - tTRT)))
+    EFBD <- expit(-(sefbd * (t - efb50_i)))
     EFB  <- 1 + efbmax_i * EFBI * EFBD
 
     # Combined beta-cell scaling for FSI production.
@@ -249,7 +249,7 @@ Choy_2016_T2DM_WHIG <- function() {
     # Steady-state initial conditions evaluated at t = 0 with the t = 0
     # baseline FPG and the unscaled PPG (the run-in is short relative to
     # MTT ~ 39 d, so the chain starts at its pre-study steady state).
-    B_baseline_init  <- 1 / (1 + exp(b0_i))
+    B_baseline_init  <- expit(-b0_i)
     BLFPG_K          <- IS_baseline * B_baseline_init
     BLFPG_qC         <- KinKoutFPG / (KinKoutFSI * BLFPG_K)
     BLFPG            <- (FPG_floor + sqrt(FPG_floor * FPG_floor + 4 * BLFPG_qC)) / 2

--- a/inst/modeldb/therapeuticArea/Delor_2013_alzheimer.R
+++ b/inst/modeldb/therapeuticArea/Delor_2013_alzheimer.R
@@ -229,7 +229,7 @@ Delor_2013_alzheimer <- function() {
                           e_cdr_sob_slow * (SCORE_CDR_SOB - 1) +
                           e_faq_slow     * (SCORE_FAQ     - 1) +
                           e_rhpnm_slow   * (SCORE_RHPNM   - 1)
-    p_slow_indiv <- 1 / (1 + exp(-logit_p_slow_indiv))
+    p_slow_indiv <- expit(logit_p_slow_indiv)
     p_fast_indiv <- 1 - p_slow_indiv
 
     # 3. Smooth-step disease-activation function. The exponent 30 follows the

--- a/inst/modeldb/therapeuticArea/Goteti_2024_SLE_mbma.R
+++ b/inst/modeldb/therapeuticArea/Goteti_2024_SLE_mbma.R
@@ -670,11 +670,11 @@ Goteti_2024_SLE_mbma <- function() {
 
     # -------- Responder probabilities (supplement Section 1.3) -------
     # SRI: generalized proportional-odds transform with c_0 = 0.
-    p_SRI4 <- exp(theta_SRI_t             ) / (1 + exp(theta_SRI_t             ))
-    p_SRI5 <- exp(theta_SRI_t - c_SRI5    ) / (1 + exp(theta_SRI_t - c_SRI5    ))
-    p_SRI6 <- exp(theta_SRI_t - c_SRI6    ) / (1 + exp(theta_SRI_t - c_SRI6    ))
+    p_SRI4 <- expit(theta_SRI_t)
+    p_SRI5 <- expit(theta_SRI_t - c_SRI5)
+    p_SRI6 <- expit(theta_SRI_t - c_SRI6)
     # BICLA: logistic transform of the latent SLE activity.
-    p_BICLA <- exp(theta_BICLA_t) / (1 + exp(theta_BICLA_t))
+    p_BICLA <- expit(theta_BICLA_t)
 
     # -------- Observation ---------------------------------------------
     # A single Cc endpoint is declared for nlmixr2 compatibility (the

--- a/inst/modeldb/therapeuticArea/Mandema_2011_anticoagulants_mbma.R
+++ b/inst/modeldb/therapeuticArea/Mandema_2011_anticoagulants_mbma.R
@@ -718,12 +718,12 @@ Mandema_2011_anticoagulants_mbma <- function() {
     lor_totalbld <- g_totalbld
 
     # ---- Per-arm event probabilities ---------------------------------------
-    p_pe       <- 1 / (1 + exp(-(e0_pe       + lor_pe)))
-    p_majorvte <- 1 / (1 + exp(-(e0_majorvte + lor_majorvte)))
-    p_totalvte <- 1 / (1 + exp(-(e0_totalvte + lor_totalvte)))
-    p_majorbld <- 1 / (1 + exp(-(e0_majorbld + lor_majorbld)))
-    p_crnmbld  <- 1 / (1 + exp(-(e0_crnmbld  + lor_crnmbld)))
-    p_totalbld <- 1 / (1 + exp(-(e0_totalbld + lor_totalbld)))
+    p_pe       <- expit(e0_pe       + lor_pe)
+    p_majorvte <- expit(e0_majorvte + lor_majorvte)
+    p_totalvte <- expit(e0_totalvte + lor_totalvte)
+    p_majorbld <- expit(e0_majorbld + lor_majorbld)
+    p_crnmbld  <- expit(e0_crnmbld  + lor_crnmbld)
+    p_totalbld <- expit(e0_totalbld + lor_totalbld)
 
     # ---- Derived reporting quantities --------------------------------------
     # The x-axis of the source's Figures 1 and 2: the dose of enoxaparin that

--- a/inst/modeldb/therapeuticArea/Mandema_2011_biologicDMARDs_mbma.R
+++ b/inst/modeldb/therapeuticArea/Mandema_2011_biologicDMARDs_mbma.R
@@ -625,9 +625,9 @@ Mandema_2011_biologicDMARDs_mbma <- function() {
     # (the Table 2 population: placebo means background methotrexate).
     e0_20 <- e0_acr50 + theta_acr20
     e0_70 <- e0_acr50 + theta_acr70
-    p_acr20 <- 1 / (1 + exp(-(e0_20    + g_acr20)))
-    p_acr50 <- 1 / (1 + exp(-(e0_acr50 + g_acr50)))
-    p_acr70 <- 1 / (1 + exp(-(e0_70    + g_acr70)))
+    p_acr20 <- expit(e0_20    + g_acr20)
+    p_acr50 <- expit(e0_acr50 + g_acr50)
+    p_acr70 <- expit(e0_70    + g_acr70)
 
     # ---- Per-arm responder probabilities, methotrexate-naive population -----
     # (the Table 3 and Table 4 population). The treatment effect is the SAME:
@@ -637,9 +637,9 @@ Mandema_2011_biologicDMARDs_mbma <- function() {
     # differs, and it is slightly larger.
     e0_20_naive <- e0_acr50_naive + theta_acr20_naive
     e0_70_naive <- e0_acr50_naive + theta_acr70_naive
-    p_acr20_naive <- 1 / (1 + exp(-(e0_20_naive    + g_acr20)))
-    p_acr50_naive <- 1 / (1 + exp(-(e0_acr50_naive + g_acr50)))
-    p_acr70_naive <- 1 / (1 + exp(-(e0_70_naive    + g_acr70)))
+    p_acr20_naive <- expit(e0_20_naive    + g_acr20)
+    p_acr50_naive <- expit(e0_acr50_naive + g_acr50)
+    p_acr70_naive <- expit(e0_70_naive    + g_acr70)
 
     # ---- Derived reporting quantity ----------------------------------------
     # Multiples of the arm's own ED50: the x-axis on which the source's

--- a/inst/modeldb/therapeuticArea/oncology/Desmee_2015_PSA_mCRPC.R
+++ b/inst/modeldb/therapeuticArea/oncology/Desmee_2015_PSA_mCRPC.R
@@ -124,7 +124,7 @@ Desmee_2015_PSA_mCRPC <- function() {
     r        <- exp(lkg + etalkg)
     psa0     <- exp(lpsa0 + etalpsa0)
     le       <- logiteps + etalogiteps
-    eps      <- exp(le) / (1 + exp(le))                # logit-normal back-transform => (0,1)
+    eps      <- expit(le)                # logit-normal back-transform => (0,1)
     tesc     <- exp(ltesc + etaltesc)
 
     # 2. Fixed mechanistic rate constants

--- a/inst/modeldb/therapeuticArea/oncology/Franzese_2026_pdl1_nsclc_mbma.R
+++ b/inst/modeldb/therapeuticArea/oncology/Franzese_2026_pdl1_nsclc_mbma.R
@@ -543,7 +543,7 @@ Franzese_2026_pdl1_nsclc_mbma <- function() {
                  eta_study_orr
 
     # Predicted per-arm ORR (proportion) via inverse logit.
-    orr_pred <- exp(logit_orr) / (1 + exp(logit_orr))
+    orr_pred <- expit(logit_orr)
 
     # ============ OS MODEL log(HR) ============
     # Per Table 1 OS row: eta_orr_os enters INSIDE each of the four PD-(L)1 or chemotherapy


### PR DESCRIPTION
`exp(x)/(1+exp(x))` returns NaN for x >= 710, because exp() overflows before the division can cancel it. `expit()` and `1/(1+exp(-x))` return 1:

    x=710   expit=1   exp(x)/(1+exp(x))=NaN   1/(1+exp(-x))=1

47 model files carried that cliff. A logit-scale parameter with IIV can reach it on an extreme eta draw, and the result is a silent NaN propagating into a solve -- the same shape as the Yoon 2023 vancomycin failure, which took three rounds to diagnose because a NaN looks like a numeric problem rather than a structural one.

Fixing that is the reason for the change; normalising the remaining spellings is the cheap half that comes with it. 96 files, 202 sites:

  * 143 x `1/(1+exp(-x))`  -> `expit(x)`    BIT-IDENTICAL: verified
    `identical()` TRUE across x in [-709, 709]
  * 7   x `1/(1+exp(x))`   -> `expit(-x)`   bit-identical
  * 52  x `exp(x)/(1+exp(x))` -> `expit(x)` <= 2 ulp (max |diff| 1.1e-16);
    these are the ones that carried the cliff

Deliberately NOT rewritten, because they are not binary inverse logits and rewriting them would be wrong or would move the code away from the source paper's algebra:

  * the softmaxes over 3+ categories -- `exp(x_k)/(1 + sum_j exp(x_j))` in vandenBerg 2021 uprifosbuvir, and Pejcic 2024 clopidogrel's three-way `fr1/(1+fr1+fr2)` normalisation with FP as the reference
  * Chan 2008's odds-ratio IIV identity `odds_typ * exp(eta)` then `odds/(1+odds)`, which IS expit(logit(p)+eta) but states the paper's Eq. 9 directly and would need a logit() call to rewrite
  * Ibrahim's two-step `odds <- exp(x); p <- odds/(1+odds)` (x3), which is already overflow-free at the sizes involved and reads as the paper's own derivation

The transformer matched balanced parentheses and skipped comments, so prose in `description`, `reference` and `notes` is untouched. Two files were left for hand-editing after its own line-count guard refused to splice them (Bian 2024 lefamulin x2, which carry a multi-line `exp(...) /\n (1 + exp(...))`); those three sites per file were done by hand rather than by loosening the guard.

Where prose stated the old form, code and prose were brought back into step: Choy 2016's two labels and one comment now read `expit(-is0)`. Mann 2022's `reference` string quotes the paper's equation verbatim and is left exactly as printed -- the identity is noted at the code site instead.

Verified: vignette gate 1877/1877 on the stack CI installs (rxode2 5.1.6 / nlmixr2est 7.0.2) with zero rxode2 out-of-bounds warnings; testthat 867 passed / 0 failed / 0 skipped; checkNamingRegisters 0; lintr 0. No hand-written inverse logit remains in any model block.