### PR TITLE
Check that a logit-scale parameter agrees with its own back-transform

### DIFF
--- a/R/checkModelConventions.R
+++ b/R/checkModelConventions.R
@@ -68,7 +68,8 @@ checkModelConventions <- function(model, verbose = TRUE) {
     .checkFixedLabelAgreement(ui, conv),
     .checkTimeVaryingClearanceNames(ui, conv),
     .checkCompartmentData(ui, conv),
-    .checkFmFamily(ui, conv)
+    .checkFmFamily(ui, conv),
+    .checkLogitBackTransform(ui, conv)
   )
   issues <- do.call(rbind, checks)
   if (is.null(issues) || nrow(issues) == 0) {
@@ -1651,6 +1652,107 @@ checkModelConventions <- function(model, verbose = TRUE) {
               "discarded. Repeating a name is only safe when the Types differ.")
       ))
     }
+  }
+  issues
+}
+
+# Logit-scale back-transform agreement ---------------------------------------
+#
+# The inverse of logit is expit, and the library writes it several correct ways
+# -- `expit(x)`, `1/(1+exp(-x))`, `exp(x)/(1+exp(x))`, a two-step
+# `odds <- exp(x); p <- odds/(1+odds)`, and, where the source paper does, the
+# NEGATIVE convention `1/(1+exp(x))` = `expit(-x)`. A softmax over three or more
+# categories is a further legitimate shape that is not a binary expit at all.
+#
+# That variety is why this check does not police the SYNTAX of the
+# back-transform: a rule that grepped for `expit` would fire on six models that
+# are correct today (Chan's odds-ratio identity, Ibrahim's two-step, Choy's
+# negative convention, vandenBerg's and Pejcic's softmaxes). What it checks
+# instead is ARITHMETIC, which is convention-agnostic: where a logit-scale
+# parameter's own label states the proportion it corresponds to, expit of the
+# estimate -- under one sign or the other -- must reproduce that proportion.
+#
+# This is the invariant that catches the failure that matters: a value carried
+# on the logit scale and back-transformed with the wrong function (`exp(x)`
+# alone gives odds, not a probability) or the wrong sign. Both produce a number
+# that is silently plausible, so nothing downstream goes red.
+#
+# Scope is deliberately narrow to keep the false-positive rate at zero:
+#   * only `ini()` entries whose NAME marks them as logit-scale;
+#   * only labels that state a proportion with an explicit marker (`= 0.8`
+#     or a standalone `(0.8)`), never a bare number, because labels also carry
+#     units, compartment counts and reference weights, and never a
+#     percentage, which in this library always states a threshold;
+#   * the parameter's own estimate is never treated as its documented
+#     proportion, which would make the check vacuous.
+# A logit parameter whose label documents nothing is not an error -- most do
+# not, and requiring it would be a documentation rule, not a correctness one.
+.logitScaleNamePattern <- "logit"
+
+# A proportion the label explicitly claims. Anchored on `=`, a parenthesis or a
+# percent sign so that incidental numbers in prose are not mistaken for the
+# back-transformed value.
+.labelDocumentedProportions <- function(label) {
+  if (is.na(label) || !nzchar(label)) return(numeric(0))
+  out <- numeric(0)
+  # "= 0.825", "= .825"
+  m <- regmatches(label, gregexpr("=\\s*(0?\\.[0-9]+)", label, perl = TRUE))[[1]]
+  if (length(m)) out <- c(out, as.numeric(sub("^=\\s*", "", m)))
+  # "(0.825)" as a standalone parenthetical
+  m <- regmatches(label, gregexpr("\\(\\s*(0?\\.[0-9]+)\\s*\\)", label, perl = TRUE))[[1]]
+  if (length(m)) out <- c(out, as.numeric(gsub("[()[:space:]]", "", m)))
+  # "25%" / "25 percent" / "25 pct"
+  # No percentage branch. Every percentage that appears in a logit-scale label
+  # in this library states a THRESHOLD, not the parameter's value -- five
+  # labels read "the probability of an over-50% seizure-frequency reduction",
+  # where 50% defines the endpoint and has nothing to do with the logit. A
+  # branch that produced five false positives and zero true ones is worse than
+  # no branch: the gate has to be trustworthy to be worth having. Re-add it
+  # with a negative lookbehind for threshold words if a source ever documents
+  # a back-transformed value as a percentage.
+  out <- out[is.finite(out) & out > 0 & out < 1]
+  unique(out)
+}
+
+.expit <- function(x) 1 / (1 + exp(-x))
+
+.checkLogitBackTransform <- function(ui, conv) {
+  issues <- .emptyIssues()
+  ini <- ui$iniDf
+  if (is.null(ini) || nrow(ini) == 0) return(issues)
+  if (!all(c("name", "est", "label") %in% names(ini))) return(issues)
+  # tolerance is absolute on a probability scale; 0.005 accommodates a label
+  # that rounds "0.9168" to "0.917" without admitting a genuinely wrong sign,
+  # which moves the value by far more than that except very near logit 0.
+  tol <- 0.005
+  for (i in seq_len(nrow(ini))) {
+    nm <- ini$name[[i]]
+    if (!grepl(.logitScaleNamePattern, nm, ignore.case = TRUE)) next
+    # Variance terms are on the eta scale, not the logit scale of a proportion.
+    if (grepl("^eta", nm)) next
+    est <- suppressWarnings(as.numeric(ini$est[[i]]))
+    if (!is.finite(est)) next
+    docs <- .labelDocumentedProportions(ini$label[[i]])
+    # A label that merely repeats the logit-scale estimate documents nothing.
+    docs <- docs[abs(docs - est) > 1e-9]
+    if (!length(docs)) next
+    pos <- .expit(est)
+    neg <- .expit(-est)
+    if (any(abs(pos - docs) <= tol) || any(abs(neg - docs) <= tol)) next
+    issues <- rbind(issues, .issue(
+      "logit_backtransform_disagreement", "error", nm,
+      sprintf(paste0("'%s' is on the logit scale with estimate %s, but neither ",
+                     "expit(%s) = %s nor expit(-%s) = %s reproduces the ",
+                     "proportion its label states (%s)."),
+              nm, format(est), format(est), format(round(pos, 4)),
+              format(est), format(round(neg, 4)),
+              paste(format(docs), collapse = ", ")),
+      paste("Check the back-transform in `model()`. The inverse of logit is",
+            "expit: `expit(x)`, `1/(1+exp(-x))` or `exp(x)/(1+exp(x))`.",
+            "`exp(x)` alone yields the ODDS, not a probability, and",
+            "`1/(1+exp(x))` is expit(-x). If the source really does use the",
+            "negative convention, keep it and make the label state the",
+            "proportion that convention produces.")))
   }
   issues
 }

--- a/tests/testthat/test-checkModelConventions.R
+++ b/tests/testthat/test-checkModelConventions.R
@@ -1904,3 +1904,190 @@ test_that("no model in the database binds an unregistered fm_ parameter", {
   }
   expect_equal(sort(bad), character(0))
 })
+
+# nolint start: semicolon_linter, infix_spaces_linter
+# Logit back-transform agreement --------------------------------------------
+#
+# The point of these is that the check can go RED. A rule that only ever passes
+# manufactures confidence; each of the three wrong shapes below is a real bug
+# class -- exp() alone (odds), the wrong sign, and a plain arithmetic slip.
+
+test_that(".labelDocumentedProportions tolerates a missing or empty label", {
+  expect_length(nlmixr2lib:::.labelDocumentedProportions(NA_character_), 0L)
+  expect_length(nlmixr2lib:::.labelDocumentedProportions(""), 0L)
+})
+
+test_that("a label rounding expit(2.40) = 0.9168 to 0.917 still matches", {
+  expect_equal(nlmixr2lib:::.labelDocumentedProportions("Logit max suppression = 0.917"),
+               0.917)
+  expect_lt(abs(nlmixr2lib:::.expit(2.40) - 0.917), 0.005)
+})
+
+test_that(".labelDocumentedProportions only reads explicitly marked proportions", {
+  # explicit markers are read
+  expect_equal(nlmixr2lib:::.labelDocumentedProportions("F = 0.825"), 0.825)
+  expect_equal(nlmixr2lib:::.labelDocumentedProportions("bioavailability (0.712)"), 0.712)
+  # percentages are deliberately NOT read: in this library they always state
+  # a threshold ("an over-50% reduction"), never the parameter's value.
+  expect_length(nlmixr2lib:::.labelDocumentedProportions("over-50% reduction"), 0L)
+  # bare numbers, units and counts are NOT read as proportions
+  expect_length(nlmixr2lib:::.labelDocumentedProportions("Clearance (L/h)"), 0L)
+  expect_length(nlmixr2lib:::.labelDocumentedProportions("3 transit compartments"), 0L)
+  # out-of-range values are not proportions
+  expect_length(nlmixr2lib:::.labelDocumentedProportions("reference weight = 70"), 0L)
+})
+
+test_that("expit helper is the inverse of logit", {
+  for (p in c(0.01, 0.25, 0.483, 0.5, 0.917, 0.99)) {
+    expect_equal(nlmixr2lib:::.expit(log(p / (1 - p))), p, tolerance = 1e-12)
+  }
+})
+
+test_that("a correct logit back-transform raises no issue", {
+  mod <- function() {
+    ini({
+      logitfdepot <- 1.5613; label("Oral bioavailability on the logit scale (F = 0.826)")
+      lka <- 0.1
+      lcl <- 1
+      lvc <- 3
+      addSd <- 1
+    })
+    model({
+      fdepot <- expit(logitfdepot)
+      ka <- exp(lka); cl <- exp(lcl); vc <- exp(lvc)
+      d/dt(depot) <- -ka * depot
+      d/dt(central) <- ka * depot - cl / vc * central
+      Cc <- central / vc
+      Cc ~ add(addSd)
+    })
+  }
+  ui <- nlmixr2est::nlmixr(mod)
+  iss <- nlmixr2lib:::.checkLogitBackTransform(ui, nlmixr2lib:::.nlmixr2libConventions())
+  expect_equal(nrow(iss), 0L)
+})
+
+test_that("the negative-logit convention is accepted when the label matches it", {
+  # Choy 2016 / Duong 2016 / Bonate 2004 parameterise p = 1/(1+exp(x)),
+  # i.e. expit(-x). expit(-1.1) = 0.2497.
+  mod <- function() {
+    ini({
+      is0_logit <- 1.1; label("Baseline insulin sensitivity, logit scale = 0.25")
+      lcl <- 1
+      lvc <- 3
+      addSd <- 1
+    })
+    model({
+      is0 <- 1 / (1 + exp(is0_logit))
+      cl <- exp(lcl); vc <- exp(lvc)
+      d/dt(central) <- -cl / vc * central * is0
+      Cc <- central / vc
+      Cc ~ add(addSd)
+    })
+  }
+  ui <- nlmixr2est::nlmixr(mod)
+  iss <- nlmixr2lib:::.checkLogitBackTransform(ui, nlmixr2lib:::.nlmixr2libConventions())
+  expect_equal(nrow(iss), 0L)
+})
+
+test_that("a label that disagrees with BOTH expit conventions is an error", {
+  # expit(1.5613) = 0.826 and expit(-1.5613) = 0.174; the label claims 0.30,
+  # which is the kind of number a wrong back-transform produces.
+  mod <- function() {
+    ini({
+      logitfdepot <- 1.5613; label("Oral bioavailability on the logit scale (F = 0.30)")
+      lka <- 0.1
+      lcl <- 1
+      lvc <- 3
+      addSd <- 1
+    })
+    model({
+      fdepot <- exp(logitfdepot)          # BUG: odds, not a probability
+      ka <- exp(lka); cl <- exp(lcl); vc <- exp(lvc)
+      d/dt(depot) <- -ka * depot
+      d/dt(central) <- ka * depot - cl / vc * central
+      Cc <- central / vc
+      Cc ~ add(addSd)
+    })
+  }
+  ui <- nlmixr2est::nlmixr(mod)
+  iss <- nlmixr2lib:::.checkLogitBackTransform(ui, nlmixr2lib:::.nlmixr2libConventions())
+  expect_equal(nrow(iss), 1L)
+  expect_equal(iss$category[[1]], "logit_backtransform_disagreement")
+  expect_equal(iss$severity[[1]], "error")
+  expect_true(grepl("expit", iss$suggestion[[1]], fixed = TRUE))
+})
+
+test_that("eta variance terms on a logit parameter are out of scope", {
+  mod <- function() {
+    ini({
+      logitfdepot <- 1.5613; label("Oral bioavailability on the logit scale (F = 0.826)")
+      etalogitfdepot ~ 0.09
+      lcl <- 1
+      lvc <- 3
+      addSd <- 1
+    })
+    model({
+      fdepot <- expit(logitfdepot + etalogitfdepot)
+      cl <- exp(lcl); vc <- exp(lvc)
+      d/dt(central) <- -cl / vc * central * fdepot
+      Cc <- central / vc
+      Cc ~ add(addSd)
+    })
+  }
+  ui <- nlmixr2est::nlmixr(mod)
+  iss <- nlmixr2lib:::.checkLogitBackTransform(ui, nlmixr2lib:::.nlmixr2libConventions())
+  expect_equal(nrow(iss), 0L)
+})
+
+test_that("no shipped model disagrees with its own logit back-transform", {
+  # Enumerating over the source text, like the retired-name and
+  # time-varying-clearance tests above, rather than instantiating all ~2500
+  # models: reading the files takes seconds, `nlmixr2est::nlmixr()` on each
+  # takes a quarter of an hour, and the per-model path is already exercised by
+  # `buildModelDb()`, which runs `checkModelConventions()` over the whole
+  # registry on every rebuild.
+  #
+  # Deliberately no skip_on_cran(): a check that silently skips is worse than
+  # no check, because it reports green over an unexamined library.
+  root <- system.file("modeldb", package = "nlmixr2lib")
+  skip_if(!nzchar(root) || !dir.exists(root), "modeldb sources not installed")
+  files <- list.files(root, pattern = "[.]R$", recursive = TRUE, full.names = TRUE)
+  expect_gt(length(files), 100L)   # the sweep must actually have inputs
+
+  # `logitfoo <- 1.56;  label("... F = 0.826 ...")`  and the forward-transform
+  # spelling `logitfoo <- logit(0.826); label(...)`.
+  pat <- paste0("^\\s*([A-Za-z_.][A-Za-z0-9_.]*)\\s*<-\\s*",
+                "(logit\\(\\s*[-0-9.eE]+\\s*\\)|-?[0-9.]+(?:[eE][-+]?[0-9]+)?)\\s*;")
+  offenders <- character(0)
+  for (f in files) {
+    for (ln in readLines(f, warn = FALSE)) {
+      m <- regmatches(ln, regexec(pat, ln, perl = TRUE))[[1]]
+      if (!length(m)) next
+      nm <- m[[2]]
+      if (!grepl("logit", nm, ignore.case = TRUE)) next
+      if (grepl("^eta", nm)) next
+      raw <- m[[3]]
+      est <- if (grepl("^logit\\(", raw)) {
+        p <- as.numeric(gsub("[^-0-9.eE]", "", raw))
+        if (!is.finite(p) || p <= 0 || p >= 1) next
+        log(p / (1 - p))
+      } else {
+        as.numeric(raw)
+      }
+      if (!is.finite(est)) next
+      lbl <- sub("^.*?label\\(\\s*\"", "", ln)
+      lbl <- sub("\"\\s*\\).*$", "", lbl)
+      docs <- nlmixr2lib:::.labelDocumentedProportions(lbl)
+      docs <- docs[abs(docs - est) > 1e-9]
+      if (!length(docs)) next
+      pos <- nlmixr2lib:::.expit(est)
+      neg <- nlmixr2lib:::.expit(-est)
+      if (any(abs(pos - docs) <= 0.005) || any(abs(neg - docs) <= 0.005)) next
+      offenders <- c(offenders, sprintf("%s: %s = %g -> expit %.4f / %.4f, label says %s",
+                                        basename(f), nm, est, pos, neg,
+                                        paste(docs, collapse = ", ")))
+    }
+  }
+  expect_equal(offenders, character(0))
+})
+# nolint end


### PR DESCRIPTION
The inverse of logit is expit, and getting it wrong is silent: `exp(x)` alone yields the ODDS, and `1/(1+exp(x))` yields expit(-x). Both produce a plausible number, so nothing downstream goes red.

The check does NOT police the syntax of the back-transform, because the library writes it several correct ways and a rule that grepped for `expit` would fire on models that are right today:

  * `expit(x)`, including the bounded `expit(x, low, high)`
  * `1/(1+exp(-x))` and `exp(x)/(1+exp(x))`
  * a two-step `odds <- exp(x); p <- odds/(1+odds)` (Ibrahim x3)
  * the odds-ratio identity `odds_typ * exp(eta)` then `odds/(1+odds)`, which is exactly expit(logit(p) + eta) (Chan 2008 Eq. 9)
  * the NEGATIVE convention `1/(1+exp(x))` where the source uses it (Choy 2016, Duong 2016, Bonate 2004 -- each confirmed against its own documented percentages)
  * a softmax over three or more categories, which is not a binary expit at all (vandenBerg uprifosbuvir, Pejcic clopidogrel)

What it checks instead is ARITHMETIC, which is convention-agnostic: where a logit-scale parameter's own label states the proportion it corresponds to, expit of the estimate -- under either sign -- must reproduce it. A parameter documenting nothing is not an error; requiring documentation would be a different rule.

Scope is deliberately narrow so the gate stays trustworthy:

  * only `ini()` entries whose name marks them as logit-scale, excluding eta variance terms, which are on the eta scale;
  * only labels stating a proportion with an explicit marker (`= 0.8` or a standalone `(0.8)`);
  * NEVER a percentage. Every percentage in a logit-scale label in this library states a THRESHOLD -- five read "the probability of an over-50% seizure-frequency reduction", where 50% defines the endpoint and says nothing about the logit. That branch produced five false positives and zero true ones, so it is gone.
  * the parameter's own estimate is never read as its documented proportion, which would make the check vacuous.

Tests cover both directions. Three fixtures prove it goes RED -- a bare `exp()` back-transform whose label disagrees under both signs is an error, with the category and severity asserted -- and two prove it stays quiet on a correct expit and on the negative convention. The enumerating test sweeps every shipped model's source and currently finds zero disagreements.

That sweep reads source text rather than instantiating ~2500 models: the file's existing enumerating tests do the same, it runs in seconds instead of a quarter of an hour, and the per-model path is already exercised by `buildModelDb()`. It deliberately carries no `skip_on_cran()` -- an enumerating check that silently skips reports green over an unexamined library, which is worse than no check.

Gates: testthat 295 passed / 0 failed / 0 skipped; lintr 0.