### PR TITLE
Check that inverse logits are spelled expit(), and fix 13 that were not

### DIFF
--- a/R/checkModelConventions.R
+++ b/R/checkModelConventions.R
@@ -69,7 +69,8 @@ checkModelConventions <- function(model, verbose = TRUE) {
     .checkTimeVaryingClearanceNames(ui, conv),
     .checkCompartmentData(ui, conv),
     .checkFmFamily(ui, conv),
-    .checkLogitBackTransform(ui, conv)
+    .checkLogitBackTransform(ui, conv),
+    .checkHandWrittenInverseLogit(ui, conv)
   )
   issues <- do.call(rbind, checks)
   if (is.null(issues) || nrow(issues) == 0) {
@@ -1753,6 +1754,132 @@ checkModelConventions <- function(model, verbose = TRUE) {
             "`1/(1+exp(x))` is expit(-x). If the source really does use the",
             "negative convention, keep it and make the label state the",
             "proportion that convention produces.")))
+  }
+  issues
+}
+
+# Hand-written inverse logit ------------------------------------------------
+#
+# The library spells every binary inverse logit `expit(x)`. That is not a style
+# preference: `exp(x)/(1+exp(x))` returns NaN for x >= 710 because exp()
+# overflows before the division can cancel it, while expit() returns 1. The
+# whole library was normalised for that reason, and within a day four newly
+# extracted models had reintroduced the hand-written form -- a convention that
+# lives only in prose decays, so this check is what keeps it.
+#
+# The sibling check `.checkLogitBackTransform()` tests the ARITHMETIC of a
+# back-transform against the proportion its label documents. This one tests the
+# SPELLING. They are complementary: arithmetic cannot see a correct-but-
+# overflow-prone form, and spelling cannot see a wrong sign.
+#
+# Matching is done on the parsed expression, not on text, because the whole
+# difficulty is telling a binary inverse logit apart from shapes that look like
+# one and must NOT be rewritten:
+#
+#   * a softmax over 3+ categories -- `exp(x_k)/(1 + exp(x_j) + exp(x_k))` or
+#     `exp(x_k)/tsum`. Its denominator carries extra terms, or its two exp()
+#     arguments differ, so the identical-argument test below excludes it.
+#   * the odds two-step `odds <- exp(x); p <- odds/(1+odds)`, and the
+#     odds-ratio IIV identity `odds_typ*exp(eta)` then `odds/(1+odds)`. The
+#     numerator is a SYMBOL, not an `exp()` call, so neither matches.
+#   * a SCALED logistic, `k/(1 + exp(x))` with k != 1 -- `18/(1 + exp(blc - A))`
+#     in Delor 2013, `9.2/(1 + exp(-das28_logit))` in Wojciechowski 2015. These
+#     are published equations whose scale factor carries meaning; `k * expit(x)`
+#     would be equivalent but reshapes a formula quoted from the source, and
+#     they carry no overflow risk. The numerator-is-1 test excludes them.
+#   * `exp(a)/(1 + exp(b))` with DIFFERENT arguments, which is a typical value
+#     divided by a logistic factor rather than an inverse logit at all --
+#     `SchaedeliStark_2024_balovaptan` divides CL by a logistic age term
+#     exactly this way, and rewriting it would be a bug.
+#
+# Comparison is on the deparsed argument so that `a + b` and `a+b` count as the
+# same expression while `a + b` and `b + a` do not -- the latter would still be
+# an inverse logit, but writing the two halves differently is itself worth a
+# nudge toward expit().
+
+# Strip redundant `(` wrappers, which R keeps in the AST.
+.unparen <- function(e) {
+  while (is.call(e) && length(e) == 2L &&
+         identical(as.character(e[[1]]), "(")) {
+    e <- e[[2]]
+  }
+  e
+}
+
+.isExpCall <- function(e) {
+  e <- .unparen(e)
+  is.call(e) && length(e) == 2L && identical(as.character(e[[1]]), "exp")
+}
+
+.sameArg <- function(a, b) {
+  identical(paste(deparse(.unparen(a)), collapse = " "),
+            paste(deparse(.unparen(b)), collapse = " "))
+}
+
+.isOne <- function(e) {
+  e <- .unparen(e)
+  is.numeric(e) && length(e) == 1L && isTRUE(e == 1)
+}
+
+# `1 + exp(X)` / `exp(X) + 1` -> the X, else NULL.
+.onePlusExpArg <- function(e) {
+  e <- .unparen(e)
+  if (!(is.call(e) && length(e) == 3L && identical(as.character(e[[1]]), "+"))) {
+    return(NULL)
+  }
+  l <- e[[2]]
+  r <- e[[3]]
+  if (.isOne(l) && .isExpCall(r)) return(.unparen(r)[[2]])
+  if (.isOne(r) && .isExpCall(l)) return(.unparen(l)[[2]])
+  NULL
+}
+
+# Does this call spell a binary inverse logit by hand? Returns the deparsed
+# offending expression, or NA.
+.handWrittenInverseLogit <- function(e) {
+  e <- .unparen(e)
+  if (!(is.call(e) && length(e) == 3L && identical(as.character(e[[1]]), "/"))) {
+    return(NA_character_)
+  }
+  num <- e[[2]]
+  den <- .onePlusExpArg(e[[3]])
+  if (is.null(den)) return(NA_character_)
+  # 1 / (1 + exp(X))
+  if (.isOne(num)) return(paste(deparse(e), collapse = " "))
+  # exp(X) / (1 + exp(X)) -- only when the two arguments are the SAME
+  if (.isExpCall(num) && .sameArg(.unparen(num)[[2]], den)) {
+    return(paste(deparse(e), collapse = " "))
+  }
+  NA_character_
+}
+
+.inverseLogitOffenders <- function(e, acc = character(0)) {
+  if (!is.call(e)) return(acc)
+  hit <- .handWrittenInverseLogit(e)
+  if (!is.na(hit)) acc <- c(acc, hit)
+  for (i in seq_along(e)) {
+    part <- tryCatch(e[[i]], error = function(e) NULL)
+    if (is.call(part)) acc <- .inverseLogitOffenders(part, acc)
+  }
+  acc
+}
+
+.checkHandWrittenInverseLogit <- function(ui, conv) {
+  issues <- .emptyIssues()
+  exprs <- tryCatch(ui$lstExpr, error = function(e) NULL)
+  if (!length(exprs)) return(issues)
+  offenders <- character(0)
+  for (e in exprs) offenders <- .inverseLogitOffenders(e, offenders)
+  for (o in unique(offenders)) {
+    issues <- rbind(issues, .issue(
+      "hand_written_inverse_logit", "error", NA_character_,
+      sprintf("`%s` spells an inverse logit by hand.", substr(o, 1, 120)),
+      paste("Use `expit()`. `exp(x)/(1+exp(x))` returns NaN for x >= 710",
+            "because exp() overflows before the division cancels it, and a",
+            "logit-scale parameter with IIV can reach that on an extreme eta",
+            "draw. `expit(x)` is bit-identical to `1/(1+exp(-x))` and within",
+            "2 ulp of `exp(x)/(1+exp(x))`. For the negative convention write",
+            "`expit(-x)`.")))
   }
   issues
 }

--- a/R/checkModelConventions.R
+++ b/R/checkModelConventions.R
@@ -1797,57 +1797,68 @@ checkModelConventions <- function(model, verbose = TRUE) {
 # an inverse logit, but writing the two halves differently is itself worth a
 # nudge toward expit().
 
-# Strip redundant `(` wrappers, which R keeps in the AST.
-.unparen <- function(e) {
+# Recursively drop `(` wrappers, which R keeps as calls in the AST. Removing
+# them does not change meaning -- the tree already encodes precedence -- and it
+# lets one template match `1/(1 + exp(x))`, `1/((1 + exp(x)))` and
+# `(exp(a))/(1 + exp(a))` alike. Applied to the templates too, so both sides are
+# in the same normal form.
+.stripParens <- function(e) {
   while (is.call(e) && length(e) == 2L &&
          identical(as.character(e[[1]]), "(")) {
     e <- e[[2]]
   }
+  if (is.call(e)) {
+    for (i in seq_along(e)) {
+      part <- tryCatch(e[[i]], error = function(e) NULL)
+      if (!is.null(part) && (is.call(part) || is.name(part))) {
+        e[[i]] <- .stripParens(part)
+      }
+    }
+  }
   e
 }
 
-.isExpCall <- function(e) {
-  e <- .unparen(e)
-  is.call(e) && length(e) == 2L && identical(as.character(e[[1]]), "exp")
-}
+# The two `exp()` arguments of a matched `exp(.)/(... exp(.) ...)`, in the two
+# operand orders. Top-level rather than closures inside the template list so the
+# accessor is readable on its own.
+.ilArgsPlusRight <- function(e) list(e[[2]][[2]], e[[3]][[3]][[2]])
+.ilArgsPlusLeft <- function(e) list(e[[2]][[2]], e[[3]][[2]][[2]])
+
+# `rxode2::.matchesLangTemplate()` does the structural matching: `.` in a
+# template matches any sub-expression, and a numeric literal matches by VALUE,
+# so the `1` here also matches a source that writes `1.0`. That last point is
+# not incidental -- the regex sweep that first normalised the library required a
+# literal `1` and therefore missed all eleven `1.0 / (1.0 + exp(...))`
+# occurrences.
+#
+# `sameArg` marks the templates whose two wildcards must denote the SAME
+# expression. The matcher does not tie wildcards together -- `exp(a)/(1+exp(b))`
+# matches `exp(.)/(1+exp(.))` -- and that is exactly the shape that must not be
+# flagged, so the equality is checked separately.
+.inverseLogitTemplates <- list(
+  list(tmpl = .stripParens(str2lang("1/(1 + exp(.))")), args = NULL),
+  list(tmpl = .stripParens(str2lang("1/(exp(.) + 1)")), args = NULL),
+  list(tmpl = .stripParens(str2lang("exp(.)/(1 + exp(.))")),
+       args = .ilArgsPlusRight),
+  list(tmpl = .stripParens(str2lang("exp(.)/(exp(.) + 1)")),
+       args = .ilArgsPlusLeft)
+)
 
 .sameArg <- function(a, b) {
-  identical(paste(deparse(.unparen(a)), collapse = " "),
-            paste(deparse(.unparen(b)), collapse = " "))
+  identical(paste(deparse(a), collapse = " "),
+            paste(deparse(b), collapse = " "))
 }
 
-.isOne <- function(e) {
-  e <- .unparen(e)
-  is.numeric(e) && length(e) == 1L && isTRUE(e == 1)
-}
-
-# `1 + exp(X)` / `exp(X) + 1` -> the X, else NULL.
-.onePlusExpArg <- function(e) {
-  e <- .unparen(e)
-  if (!(is.call(e) && length(e) == 3L && identical(as.character(e[[1]]), "+"))) {
-    return(NULL)
-  }
-  l <- e[[2]]
-  r <- e[[3]]
-  if (.isOne(l) && .isExpCall(r)) return(.unparen(r)[[2]])
-  if (.isOne(r) && .isExpCall(l)) return(.unparen(l)[[2]])
-  NULL
-}
-
-# Does this call spell a binary inverse logit by hand? Returns the deparsed
-# offending expression, or NA.
+# Does this expression spell a binary inverse logit by hand? Returns the
+# deparsed offending expression, or NA.
 .handWrittenInverseLogit <- function(e) {
-  e <- .unparen(e)
-  if (!(is.call(e) && length(e) == 3L && identical(as.character(e[[1]]), "/"))) {
-    return(NA_character_)
-  }
-  num <- e[[2]]
-  den <- .onePlusExpArg(e[[3]])
-  if (is.null(den)) return(NA_character_)
-  # 1 / (1 + exp(X))
-  if (.isOne(num)) return(paste(deparse(e), collapse = " "))
-  # exp(X) / (1 + exp(X)) -- only when the two arguments are the SAME
-  if (.isExpCall(num) && .sameArg(.unparen(num)[[2]], den)) {
+  e <- .stripParens(e)
+  for (spec in .inverseLogitTemplates) {
+    if (!rxode2::.matchesLangTemplate(e, spec$tmpl)) next
+    if (!is.null(spec$args)) {
+      ab <- tryCatch(spec$args(e), error = function(e) NULL)
+      if (is.null(ab) || !.sameArg(ab[[1]], ab[[2]])) next
+    }
     return(paste(deparse(e), collapse = " "))
   }
   NA_character_

--- a/inst/modeldb/endogenous/Duong_2016_WHIG_T2DM.R
+++ b/inst/modeldb/endogenous/Duong_2016_WHIG_T2DM.R
@@ -234,7 +234,7 @@ Duong_2016_WHIG_T2DM <- function() {
     # Table 4 'Insulin sensitivity' block).
     # -------------------------------------------------------------------
     lscale_efs  <- log(0.0458)       ; label("ScaleEFS scaling factor for weight change on IS (per kg; log-normal IIV per paper)")                     # Duong 2017 Table 4: Scale EFS = 0.0458 (RSE 9 pct)
-    s0          <- 0.963             ; label("Baseline insulin-sensitivity logit s0; IS_0 = 1 / (1 + exp(s0))")                                        # Duong 2017 Table 4: s0 = 0.963 (RSE 5 pct)
+    s0          <- 0.963             ; label("Baseline insulin-sensitivity logit s0; IS_0 = expit(-s0)")                                        # Duong 2017 Table 4: s0 = 0.963 (RSE 5 pct)
 
     # Duong 2017 Table 4 also reports a Box-Cox shape parameter
     # theta_shape = -0.476 (RSE 15 pct) on the etas0 IIV distribution
@@ -365,13 +365,13 @@ Duong_2016_WHIG_T2DM <- function() {
     # -------------------------------------------------------------------
     dwgt         <- weight - wgt_baseline
     efs          <- 1.0 + scale_efs_i * dwgt
-    is_0         <- 1.0 / (1.0 + exp(s0_i))
+    is_0         <- expit(-s0_i)
 
     # -------------------------------------------------------------------
     # 5. b-cell function (Duong 2017 Eqs 5-7). rB is a rate per year;
     # divide by 365 for a per-day time base.
     # -------------------------------------------------------------------
-    bf           <- 1.0 / (1.0 + exp(b0_i + rb_i * t / 365.0))
+    bf           <- expit(-(b0_i + rb_i * t / 365.0))
     efb          <- 1.0 + efbt_i * oc1
     bfunc        <- bf * efb
 
@@ -415,7 +415,7 @@ Duong_2016_WHIG_T2DM <- function() {
     # equal at t = 0 (efs = 1, efb = 1, bf = BF0). aa_ss, cc_ss,
     # disc_ss are the t = 0 values of aa, cc, disc for the
     # closed-form FSI / FPG at baseline.
-    bf_ss     <- 1.0 / (1.0 + exp(b0_i))
+    bf_ss     <- expit(-b0_i)
     aa_ss     <- bf_ss * 7.8
     cc_ss     <- is_0
     disc_ss   <- (3.5 * aa_ss * cc_ss) * (3.5 * aa_ss * cc_ss) + 4.0 * cc_ss * 35.1 * aa_ss

--- a/inst/modeldb/specificDrugs/Crass_2024_pegcetacoplan_ldh.R
+++ b/inst/modeldb/specificDrugs/Crass_2024_pegcetacoplan_ldh.R
@@ -239,8 +239,7 @@ Crass_2024_pegcetacoplan_ldh <- function() {
         (logitemax_ecu_bl + e_conmed_eculizumab_emax * CONMED_ECULIZUMAB)
 
     rbase <- exp(lrbase_typ + etalrbase)
-    emax <- exp(logitemax_typ + etalogitemax) /
-      (exp(logitemax_typ + etalogitemax) + 1)
+    emax <- expit(logitemax_typ + etalogitemax)
     ec50 <- exp(lec50 + etalec50)
     hill <- exp(lhill)
 

--- a/inst/modeldb/specificDrugs/Friberg_2012_voriconazole.R
+++ b/inst/modeldb/specificDrugs/Friberg_2012_voriconazole.R
@@ -194,7 +194,7 @@ Friberg_2012_voriconazole <- function() {
 
     # ---- 2. Vmax,inh (typical and HEM/PM-adult override) ----
     lgt_vmax_inh_i    <- lgt_vmax_inh + e_age_lt12_lgt_vmax_inh * is_child
-    vmax_inh_typical  <- 1.0 / (1.0 + exp(-lgt_vmax_inh_i))
+    vmax_inh_typical  <- expit(lgt_vmax_inh_i)
     vmax_inh          <- vmax_inh_typical * (1.0 - is_hem_or_pm_adult) + 1.0 * is_hem_or_pm_adult
 
     # ---- 3. T50 and time-dependent Vmax driver ----
@@ -232,7 +232,7 @@ Friberg_2012_voriconazole <- function() {
     eta_f1_raw <- etalgtf1_adult * is_stdy5_adult + etalgtf1_other * is_not_stdy5
     eta_f1_bc  <- (exp(bc_f1 * eta_f1_raw) - 1.0) / bc_f1
     lgt_f1_i   <- lgt_f1 + eta_f1_bc
-    f1         <- 1.0 / (1.0 + exp(-lgt_f1_i))
+    f1         <- expit(lgt_f1_i)
 
     # ka: population-specific typical value plus a non-adult log-normal IIV.
     ka_typical_ped  <- exp(lka_ped)

--- a/inst/modeldb/specificDrugs/Li_2018_PF04236921.R
+++ b/inst/modeldb/specificDrugs/Li_2018_PF04236921.R
@@ -338,8 +338,7 @@ Li_2018_PF04236921 <- function() {
     # =====================================================================
     base <- exp(lbase_cohort + etalbase) * (alb_gdL / 4.0)^e_alb_base
     logitimax_prime <- logitimax_cohort * (alb_gdL / 4.0)^e_alb_logitimax
-    imax <- exp(logitimax_prime + etalogitimax) /
-            (1 + exp(logitimax_prime + etalogitimax))
+    imax <- expit(logitimax_prime + etalogitimax)
     ic50 <- exp(lic50_cohort + etalic50)
     gamma <- exp(lgamma_cohort)
     kout <- exp(lkout)

--- a/inst/modeldb/specificDrugs/Lindauer_2017_lacosamide_dropout.R
+++ b/inst/modeldb/specificDrugs/Lindauer_2017_lacosamide_dropout.R
@@ -123,10 +123,10 @@ Lindauer_2017_lacosamide_dropout <- function() {
     # reduces to k_j on the j-th interval (a Riemann-sum expression of the
     # piecewise-constant hazard reported by Table 2).
     gam <- 50
-    s1 <- 1.0 / (1.0 + exp(-gam * (t - bp1)))
-    s2 <- 1.0 / (1.0 + exp(-gam * (t - bp2)))
-    s3 <- 1.0 / (1.0 + exp(-gam * (t - bp3)))
-    s4 <- 1.0 / (1.0 + exp(-gam * (t - bp4)))
+    s1 <- expit(gam * (t - bp1))
+    s2 <- expit(gam * (t - bp2))
+    s3 <- expit(gam * (t - bp3))
+    s4 <- expit(gam * (t - bp4))
     h0_drop <- k1 + (k2 - k1) * s1 + (k3 - k2) * s2 + (k4 - k3) * s3 + (k5 - k4) * s4
 
     # Multiplicative covariate effects (log-linear on hazard).

--- a/inst/modeldb/specificDrugs/Savic_2010_warfarin.R
+++ b/inst/modeldb/specificDrugs/Savic_2010_warfarin.R
@@ -184,8 +184,8 @@ Savic_2010_warfarin <- function() {
     Cc <- central / vc
     Ce <- effect  / vc
 
-    P_ge2 <- 1.0 / (1.0 + exp(-(alpha1_ind + beta * Ce)))
-    P_ge1 <- 1.0 / (1.0 + exp(-(alpha1_ind + alpha2 + beta * Ce)))
+    P_ge2 <- expit(alpha1_ind + beta * Ce)
+    P_ge1 <- expit(alpha1_ind + alpha2 + beta * Ce)
     P_eq0 <- 1.0 - P_ge1
     P_eq1 <- P_ge1 - P_ge2
     P_eq2 <- P_ge2

--- a/tests/testthat/test-checkModelConventions.R
+++ b/tests/testthat/test-checkModelConventions.R
@@ -2090,4 +2090,154 @@ test_that("no shipped model disagrees with its own logit back-transform", {
   }
   expect_equal(offenders, character(0))
 })
+
+# Hand-written inverse logit -------------------------------------------------
+#
+# The point of this block is the NEGATIVE cases. A rule that only flags
+# `exp(x)/(1+exp(x))` is easy; one that leaves a softmax, an odds two-step and a
+# logistic divisor alone is what makes it safe to run over the whole library.
+
+test_that("the four hand-written inverse-logit spellings are detected", {
+  f <- nlmixr2lib:::.handWrittenInverseLogit
+  for (txt in c("1/(1 + exp(-x))", "1/(1 + exp(x))",
+                "exp(x)/(1 + exp(x))", "exp(x)/(exp(x) + 1)",
+                "exp(a + b)/(1 + exp(a + b))")) {
+    expect_false(is.na(f(str2lang(txt))), info = txt)
+  }
+})
+
+test_that("shapes that merely resemble an inverse logit are NOT detected", {
+  f <- nlmixr2lib:::.handWrittenInverseLogit
+  cases <- c(
+    # Ibrahim's two-step and Chan's odds-ratio IIV: numerator is a symbol
+    "odds/(1 + odds)",
+    # vandenBerg / Pejcic softmax: denominator carries extra terms
+    "exp(k)/(1 + exp(j) + exp(k))",
+    "exp(x)/tsum",
+    # a typical value over a logistic factor -- SchaedeliStark 2024 balovaptan
+    # divides CL exactly this way; the exp() arguments differ
+    "exp(a)/(1 + exp(b))",
+    "exp(lcl + etalcl)/(1 + exp(e_age_cl * (age50_cl - AGE)))",
+    # ordinary division
+    "exp(x)/vc",
+    "central/vc"
+  )
+  for (txt in cases) expect_true(is.na(f(str2lang(txt))), info = txt)
+})
+
+test_that("a model using expit() raises no issue", {
+  ok <- function() {
+    description <- "A"
+    reference <- "R"
+    units <- list(time = "day", dosing = "mg", concentration = "mg/L")
+    ini({
+      logitfdepot <- 1.5613; label("Bioavailability on the logit scale")
+      lcl <- 1;   label("Clearance (CL, L/day)")
+      lvc <- 1;   label("Central volume (Vc, L)")
+      propSd <- 0.1; label("Proportional residual error (fraction)")
+    })
+    model({
+      fdepot <- expit(logitfdepot)
+      cl <- exp(lcl)
+      vc <- exp(lvc)
+      d/dt(central) <- -cl / vc * central * fdepot
+      Cc <- central / vc
+      Cc ~ prop(propSd)
+    })
+  }
+  res <- suppressWarnings(checkModelConventions(ok, verbose = FALSE))
+  expect_equal(nrow(res[res$category == "hand_written_inverse_logit", ]), 0L)
+})
+
+test_that("a model spelling the inverse logit by hand is an error", {
+  bad <- function() {
+    description <- "A"
+    reference <- "R"
+    units <- list(time = "day", dosing = "mg", concentration = "mg/L")
+    ini({
+      logitfdepot <- 1.5613; label("Bioavailability on the logit scale")
+      lcl <- 1;   label("Clearance (CL, L/day)")
+      lvc <- 1;   label("Central volume (Vc, L)")
+      propSd <- 0.1; label("Proportional residual error (fraction)")
+    })
+    model({
+      fdepot <- exp(logitfdepot) / (1 + exp(logitfdepot))
+      cl <- exp(lcl)
+      vc <- exp(lvc)
+      d/dt(central) <- -cl / vc * central * fdepot
+      Cc <- central / vc
+      Cc ~ prop(propSd)
+    })
+  }
+  res <- suppressWarnings(checkModelConventions(bad, verbose = FALSE))
+  hit <- res[res$category == "hand_written_inverse_logit", ]
+  expect_equal(nrow(hit), 1L)
+  expect_equal(hit$severity[[1]], "error")
+  expect_true(grepl("expit", hit$suggestion[[1]], fixed = TRUE))
+})
+
+test_that("a logistic DIVISOR is left alone even though it looks similar", {
+  # SchaedeliStark 2024 balovaptan: CL/F divided by a logistic age factor. The
+  # two exp() arguments differ, so this is not an inverse logit and rewriting
+  # it to expit() would be a bug.
+  divisor <- function() {
+    description <- "A"
+    reference <- "R"
+    units <- list(time = "day", dosing = "mg", concentration = "mg/L")
+    ini({
+      lcl <- 1;   label("Clearance (CL, L/day)")
+      lvc <- 1;   label("Central volume (Vc, L)")
+      e_age_cl <- 0.1; label("Logistic age slope on CL (per year)")
+      age50_cl <- 40;  label("Age at half the CL effect (year)")
+      propSd <- 0.1; label("Proportional residual error (fraction)")
+    })
+    model({
+      cl <- exp(lcl) / (1 + exp(e_age_cl * (age50_cl - AGE)))
+      vc <- exp(lvc)
+      d/dt(central) <- -cl / vc * central
+      Cc <- central / vc
+      Cc ~ prop(propSd)
+    })
+  }
+  res <- suppressWarnings(checkModelConventions(divisor, verbose = FALSE))
+  expect_equal(nrow(res[res$category == "hand_written_inverse_logit", ]), 0L)
+})
+
+test_that("no shipped model spells an inverse logit by hand", {
+  # Enumerating over the source text, like the sibling register sweeps: parse
+  # each model({}) block and walk it, which is seconds rather than the quarter
+  # hour instantiating ~2500 models would cost. Deliberately no skip_on_cran():
+  # a check that silently skips reports green over an unexamined library.
+  root <- system.file("modeldb", package = "nlmixr2lib")
+  skip_if(!nzchar(root) || !dir.exists(root), "modeldb sources not installed")
+  files <- list.files(root, pattern = "[.]R$", recursive = TRUE, full.names = TRUE)
+  expect_gt(length(files), 100L)
+  offenders <- character(0)
+  for (f in files) {
+    txt <- paste(readLines(f, warn = FALSE), collapse = "\n")
+    m <- regexpr("model\\s*\\(\\s*\\{", txt)
+    if (m < 0) next
+    open <- m + attr(m, "match.length") - 1L
+    chars <- strsplit(substring(txt, open), "")[[1]]
+    depth <- 0L
+    close <- NA_integer_
+    for (i in seq_along(chars)) {
+      if (chars[[i]] == "{") depth <- depth + 1L
+      if (chars[[i]] == "}") {
+        depth <- depth - 1L
+        if (depth == 0L) { close <- i; break }
+      }
+    }
+    if (is.na(close)) next
+    body <- substring(txt, open, open + close - 1L)
+    e <- tryCatch(str2lang(body), error = function(e) NULL)
+    if (is.null(e)) next
+    hits <- nlmixr2lib:::.inverseLogitOffenders(e)
+    if (length(hits)) {
+      offenders <- c(offenders, paste0(basename(f), ": ", unique(hits)))
+    }
+  }
+  expect_equal(offenders, character(0))
+})
+
 # nolint end


### PR DESCRIPTION
#503 normalized the library to `expit()` because `exp(x)/(1+exp(x))` returns `NaN` for x ≥ 710 — `exp()` overflows before the division cancels it. Within a day, four newly extracted models had reintroduced the hand-written form. A convention that lives only in prose decays; this is the check that keeps it.

It is the **spelling** half of a pair. `.checkLogitBackTransform()` (#504) tests the **arithmetic** of a back-transform against the proportion its label documents. Neither subsumes the other: arithmetic can't see a correct-but-overflow-prone form, and spelling can't see a wrong sign.

## Matching is on the parsed expression, not on text

That's the whole difficulty — telling a binary inverse logit apart from shapes that look like one and must **not** be rewritten. All of these stay silent:

* **softmax** over 3+ categories — `exp(x_k)/(1 + exp(x_j) + exp(x_k))`, `exp(x_k)/tsum` (vandenBerg uprifosbuvir, Pejcic clopidogrel)
* the **odds two-step** `odds <- exp(x); p <- odds/(1+odds)` (Ibrahim ×3) and Chan 2008's odds-ratio IIV identity — numerator is a symbol
* `exp(a)/(1 + exp(b))` with **different** arguments — a typical value over a logistic factor, not an inverse logit. `SchaedeliStark_2024_balovaptan` divides CL exactly this way and rewriting it would be a bug.
* a **scaled** logistic `k/(1 + exp(x))`, k ≠ 1 — `18/(1 + exp(blc - A))` (Delor 2013), `9.2/(1 + exp(-das28_logit))` (Wojciechowski 2015). Published equations whose scale factor carries meaning, and no overflow risk.

## It immediately found 13 still on main

| cause | count | models |
|---|---|---|
| written `1.0 / (1.0 + exp(...))` — #503's regex required a literal `1` | 11 | Duong 2016 WHIG ×3, Friberg 2012 voriconazole ×2, Lindauer 2017 lacosamide dropout ×4, Savic 2010 warfarin ×2 |
| expression spans two lines — #503's own line-count guard skipped them | 2 | Crass 2024 pegcetacoplan LDH, Li 2018 PF-04236921 |

The AST test is numeric, so `1.0` counts. Ten are bit-identical rewrites; the two multi-line ones are the ≤2 ulp form. Duong's labels were brought into step with its code, as the Choy 2016 sibling already is.

## Tests

They lead with the **negative** cases — seven shapes that must stay silent — because a rule that flags those is unsafe to run over the whole library. Two fixtures prove it goes red. The enumerating test parses every shipped model's `model({})` block and finds zero; no `skip_on_cran()`, since a check that silently skips reports green over an unexamined library.

**Gates:** testthat 314 passed / 0 failed / 0 skipped; lintr 0; all six affected vignettes render green on the CI stack (rxode2 5.1.6 / nlmixr2est 7.0.2) with zero out-of-bounds warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)