### PR TITLE
Stop the ini() quoted-comment defect at extraction time

### DIFF
--- a/.claude/skills/extract-literature-model/SKILL.md
+++ b/.claude/skills/extract-literature-model/SKILL.md
@@ -201,8 +201,39 @@ Use `references/model-file-template.md` as the starting skeleton and the two bes
 The file body has this shape:
 
 1. `description`, `reference`, `vignette`, `units`, `covariateData`, `population` — metadata before `ini()`. `vignette` is the basename of the validation vignette in `vignettes/articles/` (e.g., `"Clegg_2024_nirsevimab"`, no path, no extension); `buildModelDb()` extracts it so the list-of-models table can link to the rendered vignette on the pkgdown site.
-2. `ini()` — parameters with `label()` and a trailing **in-file comment pointing to the source location** for every value. **Wrap fixed parameters in `fixed()`** — see the "Fixed parameters" subsection below.
+2. `ini()` — parameters with `label()` and a trailing **in-file comment pointing to the source location** for every value. **Wrap fixed parameters in `fixed()`** — see the "Fixed parameters" subsection below. **Quote source-table text in those comments with SINGLE quotes** — see "Quoting inside `ini()` comments" below.
 3. `model()` — derived terms → individual parameters → micro-constants → ODEs → bioavailability → observation and error.
+
+### Quoting inside `ini()` comments
+
+**Never put a double quote in a trailing comment inside `ini()`. Use single quotes.**
+
+```r
+# WRONG - the model will not re-parse
+etalcl ~ 0.186   # Table 2, row "eta CL variance" = 0.186 (43.1% CV)
+
+# RIGHT
+etalcl ~ 0.186   # Table 2, row 'eta CL variance' = 0.186 (43.1% CV)
+```
+
+rxode2 promotes a trailing comment on an `ini()` line that has no `label()`
+into `label("<comment>")`. An embedded double quote terminates that generated
+string early, and the re-parse fails inside `.rxReplaceCommentWithLabel()` —
+so the model errors at load and its vignette dies at render, not at write time.
+
+This bites **eta / omega lines specifically**, because those conventionally
+carry no `label()` and are exactly where an author wants to quote a source
+table's row name (`$OMEGA`, "eta CL variance", "POPIIV KA 34.6%"). Lines that
+do carry a `label()` are unaffected — rxode2 does not promote a comment when a
+label is already present.
+
+The enumerating test `no ini() line carries a quoted trailing comment rxode2
+would promote into a broken label` in `tests/testthat/test-checkModelConventions.R`
+catches this, but only once the file is written and the suite is run. It has
+been reintroduced by independent extractions in two consecutive consolidation
+merges (15 lines across the Nakashima valproic-acid models on 2026-09-05;
+18 lines across seven models on 2026-09-09), which is why the rule is here
+rather than only in the test.
 
 ### Fixed parameters in `ini()`
 

--- a/.claude/skills/extract-literature-model/references/model-file-template.md
+++ b/.claude/skills/extract-literature-model/references/model-file-template.md
@@ -114,6 +114,10 @@ Related references:
 
     # IIV — eta + transformed parameter name. Use a block for correlated IIV.
     # Use ~ fixed(<var>) for IIVs the paper held constant from a prior publication.
+    # SINGLE-quote any source-table text in these comments: rxode2 promotes a
+    # trailing comment on a line with no label() into label("<comment>"), and an
+    # embedded double quote terminates that string early so the model will not
+    # re-parse. Eta lines carry no label(), so this is where it bites.
     # Use fixed(0) inside a c(...) block for off-diagonals NONMEM fixed to zero.
     etalcl + etalvc ~ c(<var_cl>, <cov_cl_vc>, <var_vc>)  # <source location>
     etalka          ~ <var_ka>                              # <source location>

--- a/.claude/skills/extract-literature-model/scripts/lint-conventions.R
+++ b/.claude/skills/extract-literature-model/scripts/lint-conventions.R
@@ -67,6 +67,72 @@ formatRow <- function(row) {
   paste(bits, collapse = "\n")
 }
 
+# Double quotes in a trailing `ini()` comment. checkModelConventions() cannot
+# see this: it is a property of the FILE TEXT, not of the parsed model object.
+# rxode2 promotes a trailing comment on an ini() line that carries no label()
+# into `label("<comment>")`, and an embedded double quote terminates that
+# generated string early, so the model fails to re-parse and its vignette dies
+# at render.
+#
+# The package already has an enumerating test for this
+# (tests/testthat/test-checkModelConventions.R, "no ini() line carries a quoted
+# trailing comment rxode2 would promote into a broken label"), but it only runs
+# over the whole library once the file is written and the suite is run. Two
+# consecutive consolidation merges had to repair the defect after the fact
+# (2026-09-05, 15 lines; 2026-09-09, 18 lines), so the same check runs here,
+# on the one file the extraction just wrote.
+.lintIniQuotes <- function(path) {
+  if (is.null(path) || !file.exists(path)) {
+    return(character())
+  }
+  lines <- readLines(path, warn = FALSE)
+  inIni <- FALSE
+  bad <- character()
+  for (i in seq_along(lines)) {
+    ln <- lines[[i]]
+    if (grepl("^\\s*ini\\(\\{", ln)) {
+      inIni <- TRUE
+      next
+    }
+    if (grepl("^\\s*model\\(\\{", ln)) inIni <- FALSE
+    if (!inIni) next
+    # A standalone comment is not attached to a parameter; a line that already
+    # calls label() is not promoted.
+    if (grepl("^\\s*#", ln)) next
+    if (grepl("label(", ln, fixed = TRUE)) next
+    # First `#` that is not itself inside a string literal.
+    chars <- strsplit(ln, "", fixed = TRUE)[[1]]
+    nq <- 0L
+    hash <- 0L
+    for (k in seq_along(chars)) {
+      if (chars[[k]] == '"') {
+        nq <- nq + 1L
+      } else if (chars[[k]] == "#" && nq %% 2L == 0L) {
+        hash <- k
+        break
+      }
+    }
+    if (hash == 0L) next
+    if (grepl('"', substring(ln, hash), fixed = TRUE)) {
+      bad <- c(bad, sprintf("%s:%d: %s", basename(path), i, trimws(ln)))
+    }
+  }
+  bad
+}
+
+.modelFilePath <- function(model) {
+  db <- tryCatch(nlmixr2lib::modeldb, error = function(e) NULL)
+  if (is.null(db) || !("filename" %in% names(db))) return(NULL)
+  row <- db[db$name == model, , drop = FALSE]
+  if (nrow(row) != 1L) return(NULL)
+  for (root in c(file.path(getwd(), "inst", "modeldb"),
+                 system.file("modeldb", package = "nlmixr2lib"))) {
+    p <- file.path(root, row$filename[[1]])
+    if (nzchar(root) && file.exists(p)) return(p)
+  }
+  NULL
+}
+
 lintOne <- function(model) {
   res <- tryCatch(
     suppressWarnings(checkModelConventions(model, verbose = FALSE)),
@@ -77,15 +143,28 @@ lintOne <- function(model) {
     }
   )
   if (is.null(res)) return(2L)
-  if (nrow(res) == 0L) {
+  quoted <- .lintIniQuotes(.modelFilePath(model))
+  if (length(quoted)) {
+    cat(sprintf("\n=== %s — %d ini() comment(s) with a double quote ===\n",
+                model, length(quoted)))
+    for (q in quoted) {
+      cat(sprintf("  [error] %s\n", q))
+    }
+    cat(paste0("        rxode2 promotes a trailing comment on an ini() line ",
+               "with no label() into\n        label(\"<comment>\"); an embedded ",
+               "double quote terminates that string early\n        and the model ",
+               "will not re-parse. Use single quotes.\n\n"))
+  }
+  if (nrow(res) == 0L && length(quoted) == 0L) {
     cat(sprintf("OK: %s — no convention issues.\n", model))
     return(0L)
   }
+  if (nrow(res) == 0L) return(2L)
   cat(sprintf("\n=== %s — %d issue(s) ===\n", model, nrow(res)))
   for (i in seq_len(nrow(res))) {
     cat(formatRow(res[i, ]), "\n\n", sep = "")
   }
-  if (any(res$severity == "error")) {
+  if (length(quoted) || any(res$severity == "error")) {
     2L
   } else if (any(res$severity == "warning")) {
     1L


### PR DESCRIPTION
rxode2 promotes a trailing comment on an `ini()` line that carries no `label()` into `label("<comment>")`. An embedded double quote terminates that generated string early, so the model fails to re-parse and its vignette dies at render.

The package already has an enumerating test for this, but it only runs over the whole library once files are written and the suite is run. Two consecutive consolidation merges therefore had to repair the defect after the fact — 15 lines across the Nakashima valproic-acid models on 2026-09-05, and 18 lines across seven unrelated models on 2026-09-09, written by independent extractions that had never seen each other. A defect that recurs from independent sources is a gap in what the skill says and checks, not an author mistake.

## Changes

1. **`SKILL.md`** gains a "Quoting inside `ini()` comments" section: the rule, a wrong/right pair, the mechanism, and why it lands on **eta / omega lines specifically** — those conventionally carry no `label()`, and they are exactly where an author wants to quote a source table's row name (`"eta CL variance"`, `"POPIIV KA 34.6%"`). Lines that *do* carry a `label()` are unaffected, since rxode2 doesn't promote a comment when a label is present.

2. **The `ini()` bullet in the file-shape list** — the instruction that tells authors to write a source-location comment in the first place — now carries the single-quote requirement at the point of instruction.

3. **`references/model-file-template.md`** gains the note at the IIV lines, the only lines in the template with the vulnerable shape.

4. **`scripts/lint-conventions.R`**, which the skill already runs at Phase 6 step 3, now performs the same file-text scan on the model just written and exits non-zero on a hit. `checkModelConventions()` cannot see this defect — it's a property of the file text, not the parsed model object — so the wrapper had to grow the check rather than delegate it.

## Verification

| fixture | findings |
| --- | ---: |
| the 7 models as they stood *before* the 2026-09-09 repair | **18** |
| the same 7 models after | 0 |
| dirty fixture (eta line with `"…"`) | 1 |
| …its `label()`-carrying line | exempt |
| …a quoted comment outside `ini()` | ignored |
| clean fixture | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)