### PR TITLE
Put a unit, not a note, in three models' unit slots

### DIFF
--- a/inst/modeldb/specificDrugs/Choi_2025_denosumab.R
+++ b/inst/modeldb/specificDrugs/Choi_2025_denosumab.R
@@ -142,7 +142,7 @@ Choi_2025_denosumab <- function() {
     lka <- log(0.0078)
     label("First-order subcutaneous absorption rate constant in patients (1/h)")  # Table 3, "ka_PMO" = 0.0078 1/h [4.96% RSE]
     e_healthy_ka <- 0.5849336
-    label("Effect of healthy-volunteer status on ka (log-scale)")  # Table 3: ka(HV) 0.014 / ka_PMO 0.0078 = 1.795; Results 3.1 quotes the reciprocal ratio as 0.55
+    label("Effect of healthy-volunteer status on ka, log-scale (unitless)")  # Table 3: ka(HV) 0.014 / ka_PMO 0.0078 = 1.795; Results 3.1 quotes the reciprocal ratio as 0.55
 
     # ---- Distribution (Choi 2025 Table 3) -------------------------------
     lvc <- log(1.58)
@@ -156,7 +156,7 @@ Choi_2025_denosumab <- function() {
     lq <- log(0.20)
     label("Apparent inter-compartmental clearance in patients (L/h)")  # Table 3, "Q/F_PMO" = 0.20 L/h [20.22% RSE]
     e_healthy_q <- 1.731656
-    label("Effect of healthy-volunteer status on Q/F (log-scale)")  # Table 3: Q/F(HV) 1.13 / Q/F_PMO 0.20 = 5.65; Results 3.1 quotes the reciprocal ratio as 0.18
+    label("Effect of healthy-volunteer status on Q/F, log-scale (unitless)")  # Table 3: Q/F(HV) 1.13 / Q/F_PMO 0.20 = 5.65; Results 3.1 quotes the reciprocal ratio as 0.18
 
     # ---- Linear elimination (Choi 2025 Table 3) -------------------------
     lcl <- log(0.006)
@@ -164,17 +164,17 @@ Choi_2025_denosumab <- function() {
     e_wt_cl <- 0.93
     label("Power exponent on (WT/64) for CL/F (unitless)")  # Table 3, "Covariate effect (theta) of body weight on CL/F" = 0.93 [7.98% RSE]
     e_black_cl <- 0.1397619
-    label("Effect of Black race on CL/F (log-scale)")  # Table 3: CL/F Black 0.0069 / Caucasian 0.006 = 1.15; Results 3.1 quotes 1.14
+    label("Effect of Black race on CL/F, log-scale (unitless)")  # Table 3: CL/F Black 0.0069 / Caucasian 0.006 = 1.15; Results 3.1 quotes 1.14
     e_asian_cl <- 0.2097205
-    label("Effect of Asian race on CL/F (log-scale)")  # Table 3: CL/F Asian 0.0074 / Caucasian 0.006 = 1.233; Results 3.1 quotes 1.22
+    label("Effect of Asian race on CL/F, log-scale (unitless)")  # Table 3: CL/F Asian 0.0074 / Caucasian 0.006 = 1.233; Results 3.1 quotes 1.22
     e_sb16_cl <- -0.001801622
-    label("Effect of SB16 biosimilar treatment on CL/F (log-scale)")  # Results 3.3: "implemented CL/F ratio of SB16 to DEN was 0.9982"; log(0.9982)
+    label("Effect of SB16 biosimilar treatment on CL/F, log-scale (unitless)")  # Results 3.3: "implemented CL/F ratio of SB16 to DEN was 0.9982"; log(0.9982)
 
     # ---- Target (RANKL) turnover and QSS binding (Choi 2025 Table 3) ----
     lrbase_target <- log(15.23)
     label("Baseline total target (RANKL) concentration in patients (nmol/L)")  # Table 3, "R0_PMO" = 15.23 nmol/L [12.78% RSE]
     e_healthy_rbase_target <- -2.74347
-    label("Effect of healthy-volunteer status on baseline RANKL (log-scale)")  # Table 3: R0(HV) 0.98 / R0_PMO 15.23 = 0.0644; Results 3.1 quotes the reciprocal ratio as 15.49
+    label("Effect of healthy-volunteer status on baseline RANKL, log-scale (unitless)")  # Table 3: R0(HV) 0.98 / R0_PMO 15.23 = 0.0644; Results 3.1 quotes the reciprocal ratio as 15.49
     lksyn <- log(0.01)
     label("Zero-order target (RANKL) synthesis rate constant (nmol/L/h)")  # Table 3, "ksyn" = 0.01 1/h [2.86% RSE]; see model() for the ksyn/kdeg unit note
     lkint <- log(0.022)

--- a/inst/modeldb/specificDrugs/Jin_2025_benralizumab.R
+++ b/inst/modeldb/specificDrugs/Jin_2025_benralizumab.R
@@ -448,9 +448,9 @@ Jin_2025_benralizumab <- function() {
     # over the same underlying prediction; assign each concentration record to
     # the endpoint matching its study (see covariateData$STUDY_PHASE3).
     # ------------------------------------------------------------------------
-    expSd         <- 0.367;  label("Log-scale additive residual error, phase III studies (log(ng/mL))")                 # Jin 2025 Resource 10, "Error_ADD3, log(ng/mL)" = 0.367 (RSE 0.737%) -- SIROCCO, CALIMA, ZONDA, BISE, MIRACLE
-    expSd_Cc_early   <- 0.175;  label("Log-scale additive residual error, early phase I/II studies (log(ng/mL))")          # Jin 2025 Resource 10, "Error_ADD1, log(ng/mL)" = 0.175 (RSE 1.64%) -- all observations except phase III and MI-CP220
-    expSd_Cc_micp220 <- 0.549;  label("Log-scale additive residual error, study MI-CP220 (log(ng/mL))")                    # Jin 2025 Resource 10, "Error_ADD2, log(ng/mL)" = 0.549 (RSE 2.17%) -- study MI-CP220
+    expSd         <- 0.367;  label("Log-scale additive residual error, phase III studies, log(ng/mL) scale (unitless)")                 # Jin 2025 Resource 10, "Error_ADD3, log(ng/mL)" = 0.367 (RSE 0.737%) -- SIROCCO, CALIMA, ZONDA, BISE, MIRACLE
+    expSd_Cc_early   <- 0.175;  label("Log-scale additive residual error, early phase I/II studies, log(ng/mL) scale (unitless)")          # Jin 2025 Resource 10, "Error_ADD1, log(ng/mL)" = 0.175 (RSE 1.64%) -- all observations except phase III and MI-CP220
+    expSd_Cc_micp220 <- 0.549;  label("Log-scale additive residual error, study MI-CP220, log(ng/mL) scale (unitless)")                    # Jin 2025 Resource 10, "Error_ADD2, log(ng/mL)" = 0.549 (RSE 2.17%) -- study MI-CP220
   })
   model({
     # --- 1. Individual disposition parameters -------------------------------

--- a/inst/modeldb/specificDrugs/Ogasawara_2020_durvalumab.R
+++ b/inst/modeldb/specificDrugs/Ogasawara_2020_durvalumab.R
@@ -113,7 +113,7 @@ Ogasawara_2020_durvalumab <- function() {
 
     # Residual error: log-additive (concentrations were log-transformed;
     # additive error on log scale = proportional-like on original scale)
-    addSd <- 0.198     ; label("Log-additive residual error SD on the log scale (unitless)")
+    expSd <- 0.198     ; label("Log-additive residual error SD on the log scale (unitless)")
   })
   model({
     # Covariate-adjusted PK parameters
@@ -150,6 +150,6 @@ Ogasawara_2020_durvalumab <- function() {
 
     Cc <- central / vc   # mg/L
 
-    Cc ~ lnorm(addSd)
+    Cc ~ lnorm(expSd)
   })
 }


### PR DESCRIPTION
Follow-up to #510, which standardised the unit slot across the library. Three models were missed.

Choi_2025_denosumab wrote six covariate effects as "... on CL/F (log-scale)", with the note occupying the slot.  #510's convention elsewhere keeps the note in the description and a unit in the slot, as in "... versus an ADA titre of 16, log-scale (unitless)", so these follow it.

Jin_2025_benralizumab labelled three residual errors "(log(ng/mL))".  That form appears only here; across the library an expSd slot reads "(unitless)" in 50 models, ahead of "(log units)" at 25 and "(fraction)" at 19.  The scale moves into the description.

Ogasawara_2020_durvalumab declared `Cc ~ lnorm(addSd)`.  lnorm() takes an SD on the log scale, so the quantity is dimensionless and the label saying "(unitless)" was right; the name was not.  168 models spell this parameter expSd and this was the only one calling it addSd, which reads as an additive error on the concentration scale - a consumer mapping it that way takes 0.198 log-units for 0.198 ug/mL, and the number is plausible enough that nothing looks wrong.  Renamed in both ini() and model().

Frey_2013_tocilizumab is deliberately left alone: das28 ~ add(addSd) is a single-output model, so the bare name matches the convention in CLAUDE.md, and the label already states "(DAS28 units)".

All three models load with unchanged theta and eta counts.  buildModelDb() was re-run; data/modeldb.rda is byte-identical because its `parameters` column carries structural parameters only, so no regenerated artifact accompanies this.